### PR TITLE
docs(adr): consistency and quality pass on initial ADR set

### DIFF
--- a/docs/adr/0002-agent-hierarchy-model.md
+++ b/docs/adr/0002-agent-hierarchy-model.md
@@ -30,8 +30,9 @@ playful but structurally rigorous).
 
 Four levels: global boundary → node → logical group → individual agent.
 
-* **World**: the global isolation boundary — no cross-World communication without an
-  explicit gateway. Maps to a deployment or tenant.
+* **World**: the hard isolation boundary — no cross-World communication exists, by
+  design. Maps to a deployment or tenant. Worlds on the same infrastructure are
+  completely opaque to each other (see ADR-0003).
 * **City**: a running Elixir/OTP node. Cities join and leave Worlds dynamically.
   Maps directly to a `Node` in Elixir distributed computing.
 * **Department**: a logical group of Lemmings within a City. Defines shared purpose,
@@ -110,4 +111,5 @@ a sub-Department grouping) without redesigning the top-level model.
   `LemmingsOs.Lemming`
 * Database tables: `worlds`, `cities`, `departments`, `lemmings`
 * The hierarchy levels are schema-backed; runtime process names are derived from their DB identities
-* Cross-World communication will require an explicit `LemmingsOs.Gateway` boundary (separate ADR)
+* Cross-World communication does not exist — Worlds are permanently isolated from each other; see ADR-0003
+* The full runtime topology of a City node — services, isolation boundaries, Secret Bank locality, and cross-City routing — is specified in ADR-0017

--- a/docs/adr/0003-world-as-isolation-boundary.md
+++ b/docs/adr/0003-world-as-isolation-boundary.md
@@ -7,30 +7,29 @@
 ## Context
 
 The World is the outermost level of the LemmingsOS hierarchy (see ADR 0002). We need
-to define precisely what "isolation" means at the World level and what constraints apply
-to cross-World communication.
+to define precisely what "isolation" means at the World level.
 
 This decision affects:
 
 * multi-tenant deployments
 * staging vs. production separation
 * air-gapped agent environments
-* the design of any future inter-World bridge or gateway
+* the security model for all agent execution within a deployment
 
 ## Decision Drivers
 
-1. Strong isolation guarantees by default for security and correctness
-2. Explicit, auditable cross-boundary communication
+1. Security over convenience — the isolation boundary must be structural, not configurable away
+2. No accidental data leakage between tenants or environments, ever
 3. Compatibility with single-World deployments (the common case)
 4. Clear failure semantics when boundary rules are violated
 
 ## Considered Options
 
-### Option A — Hard Isolation: No Cross-World Communication Without Explicit Gateway (Chosen)
+### Option A — Hard Isolation: No Cross-World Communication (Chosen)
 
-Worlds are fully isolated by default. No agent in World A can directly send a message
-to, observe, or depend on an agent in World B. Cross-World communication requires an
-explicit `Gateway` abstraction that is separately configured, audited, and monitored.
+Worlds are fully and permanently isolated. No agent in World A can send a message to,
+observe, or depend on an agent in World B. There is no mechanism — configured or
+otherwise — for cross-World communication within the platform.
 
 ### Option B — Soft Isolation: Cross-World Communication Allowed With Permission Flags
 
@@ -51,45 +50,59 @@ infrastructure level (separate deployments, separate databases).
 
 ## Decision
 
-**Worlds are hard isolation boundaries.** No cross-World communication is permitted
-without routing through a named, explicitly configured Gateway.
+**Worlds are hard, permanent isolation boundaries.** There is no cross-World
+communication. No agent, tool, or runtime service may address or observe anything
+outside its own World. This is not a default that can be configured away — it is a
+structural property of the platform.
 
-Specifically:
+The primary driver is security: a misconfigured or compromised agent in one World must
+not be able to affect or observe any other World. This guarantee must hold without
+depending on operator discipline or runtime policy configuration.
 
-* A World has its own:
-  * process namespace (no cross-World process discovery)
-  * database scope (no cross-World schema access)
-  * event bus scope (no cross-World event subscription)
-  * telemetry scope (metrics are tagged by World and do not aggregate cross-World by default)
-* The World identity is propagated as metadata on all logs, telemetry events, and DB rows.
-* A future `LemmingsOs.Gateway` module will mediate cross-World communication with
-  explicit configuration, rate limits, and audit logging.
+A typical deployment runs two or more Worlds on shared infrastructure — for example,
+`world_production` and `world_staging`, or `world_argentina` and `world_brazil` for a
+multi-region company. These Worlds share the same hardware but are completely opaque to
+each other at the platform level.
+
+Specifically, each World has its own:
+
+* process namespace (no cross-World process discovery)
+* database scope (no cross-World schema access)
+* event bus scope (no cross-World event subscription)
+* telemetry scope (metrics are tagged by World and do not aggregate cross-World by default)
+* Secret Bank (credentials are never shared across Worlds)
+
+The World identity is propagated as mandatory metadata on all logs, telemetry events, and DB rows.
 
 ## Rationale
 
-Hard isolation by default:
+Hard, permanent isolation:
 
-* Makes security reasoning simple: the boundary is always enforced unless explicitly bridged.
-* Enables true multi-tenancy without accidental data leakage between tenants.
-* Aligns with the "explicit over implicit" design principle.
+* Makes security reasoning simple: there is no boundary to misconfigure, no flag to set
+  incorrectly, no Gateway to forget to lock down. Isolation is structural.
+* Enables true multi-tenancy without any possibility of accidental data leakage between
+  tenants — a compromised agent in one World cannot reach another World by any path.
 * Gives operators clear operational handles: a World can be suspended, terminated, or
-  migrated independently.
+  migrated without affecting other Worlds on the same infrastructure.
+* Aligns with the principle of security over convenience: teams that need coordination
+  across environments do so through external integrations, not through the platform runtime.
 
-The cost — slightly more configuration for single-World use cases — is acceptable.
-A well-designed default configuration will make single-World deployments transparent.
+The cost — operators who want to share data between Worlds must do so outside the
+platform — is acceptable and intentional. A platform that can be configured to leak
+across tenant boundaries provides weaker guarantees than one that structurally cannot.
 
 ## Consequences
 
 ### Positive
 
-* Strong multi-tenant isolation guarantee
-* Clear security boundary that is easy to audit
+* Strong multi-tenant isolation that does not depend on operator configuration to hold
+* Clear security boundary: no agent action can leak outside its World by any path
 * Enables independent lifecycle management per World (suspend, migrate, terminate)
-* All cross-boundary communication is explicit, logged, and auditable
+* Security reasoning is simple — there is no cross-World communication model to audit
 
 ### Negative / Trade-offs
 
-* Adds indirection for use cases that genuinely need cross-World coordination
+* Teams that need coordination across environments (e.g., syncing data between production and staging) must do so through external integrations outside the platform
 * World identity must be propagated explicitly through all data models and telemetry
 
 ### Mitigations / Follow-ups
@@ -97,7 +110,6 @@ A well-designed default configuration will make single-World deployments transpa
 * Design the default single-World startup to require zero extra configuration
 * Tag all database rows with `world_id`; enforce at the context API level, not just
   at the query level
-* Design the `Gateway` abstraction before exposing any multi-World feature in the UI
 * Document isolation semantics in `docs/architecture.md`
 
 ## Implementation Notes
@@ -108,3 +120,4 @@ A well-designed default configuration will make single-World deployments transpa
 * The World Registry (`LemmingsOs.World.Registry`) is the authoritative source of
   active Worlds on a node.
 * Telemetry metadata: all `telemetry.execute/3` calls must include `%{world_id: id}` in metadata.
+* The runtime execution unit that operates within a World boundary is the Lemming instance (ADR-0004). Configuration inheritance, peer communication policy, and routing scope all start at the World level and flow down through City → Department → Lemming type → instance.

--- a/docs/adr/0004-lemming-execution-model.md
+++ b/docs/adr/0004-lemming-execution-model.md
@@ -1,0 +1,363 @@
+# ADR-0004 — Lemming Execution Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS is an Elixir/OTP-based runtime for autonomous agents organized as:
+
+- World
+- City
+- Department
+- Lemming
+
+A core design principle is that a Lemming is **not** a general-purpose super-agent. Each Lemming is intentionally narrow, specialized, and focused on doing one thing well.
+
+This creates a runtime requirement different from prompt-first agent frameworks:
+
+- Lemmings may run for extended periods.
+- Lemmings may wait on tools, messages, or external events.
+- Lemmings must be restartable after crashes.
+- Lemmings must operate under inherited constraints such as model policy, tool permissions, runtime limits, and cost budgets.
+- Runtime state must remain inspectable and resumable.
+
+We also want to avoid treating each agent as a permanently live process with unbounded in-memory state. Instead, execution should start on demand and remain supervised by OTP.
+
+---
+
+# 2. Decision Drivers
+
+1. **Long-lived execution with blocking waits** — Lemmings spend significant time waiting on model responses, tool calls, peer agents, or external events. The execution model must support resident processes that yield during waits without blocking the scheduler.
+
+2. **OTP supervision must own lifecycle** — On-demand spawning and crash recovery via supervision are first-class requirements. The execution model must be a native OTP citizen, not a wrapper around it.
+
+3. **Inspectable and resumable state** — Instance existence, lifecycle transitions, and execution progress must be observable from outside the process. Crash recovery must be deterministic, not reliant on in-memory reconstruction.
+
+4. **Execution under inherited constraints** — Model policy, tool permissions, cost budgets, and retry limits are resolved from the configuration hierarchy. These constraints must be structurally enforced, not enforced by trust in agent code.
+
+5. **Lightweight process state** — The GenServer must not accumulate heavy concerns such as context storage, model inference, cost accounting, or audit. These must be delegated to dedicated runtime services to keep the instance process simple and restartable.
+
+6. **Configuration snapshot isolation** — Instances must run against a frozen configuration snapshot resolved at spawn time. Mutable live configuration must not affect a running instance mid-execution.
+
+---
+
+# 3. Considered Options
+
+## Option A — Permanently live agent processes
+
+Each Lemming type runs as a permanently alive OTP process. Instances are long-lived singletons.
+
+**Pros:**
+- simple lifecycle; no on-demand spawn logic required
+- always ready to receive work without startup latency
+
+**Cons:**
+- keeps unbounded idle state in memory indefinitely
+- lifecycle management, upgrades, and recovery become harder to reason about
+- does not map naturally to multiple concurrent instances of the same type
+- idle agents consume resources even when no work is scheduled
+
+Rejected. Permanently live processes do not align with the on-demand, multi-instance execution model required.
+
+---
+
+## Option B — Free-form actor loop with mostly in-memory state
+
+Each Lemming runs as a standard GenServer with an unconstrained `handle_info` loop. All execution state lives in the process dictionary or GenServer state with no explicit lifecycle transitions.
+
+**Pros:**
+- straightforward to implement; minimal runtime infrastructure
+- familiar Elixir pattern
+
+**Cons:**
+- in-memory state is lost on crash with no structured recovery path
+- auditability is weakened because no lifecycle transitions are recorded
+- budget and constraint enforcement require external hooks that are easy to bypass
+- large state accumulation in the GenServer makes the process heavyweight and slow to restart
+
+Rejected. In-memory-first execution weakens auditability, restartability, and budget enforcement.
+
+---
+
+## Option C — Workflow engine as the primary runtime abstraction
+
+Lemming execution is modeled as a declarative workflow using a dedicated workflow engine as the core execution substrate.
+
+**Pros:**
+- workflow engines naturally support state persistence, retries, and timeouts
+- visual composition and auditability are built-in
+
+**Cons:**
+- introduces a non-OTP dependency as the core execution substrate
+- LemmingsOS is centered on agent execution and LLM reasoning loops, not on static graph traversal
+- the constraint set (dynamic tool calls, model responses, peer messages) does not fit naturally into rigid workflow steps
+- adds operational complexity for self-hosted deployments
+
+Rejected for the core runtime. Workflow composition may exist as a higher-level abstraction later.
+
+---
+
+## Option D — On-demand supervised OTP process (chosen)
+
+Each Lemming instance runs as a GenServer started under a DynamicSupervisor. Instances are created on demand, persist resumable state externally, and transition through an explicit state machine.
+
+**Pros:**
+- native OTP supervision: restart, crash isolation, and lifecycle are handled by the platform
+- on-demand creation avoids idle resource waste
+- explicit state machine makes execution observable and auditable
+- external persistence enables deterministic crash recovery
+- lightweight GenServer state keeps processes simple and restartable
+
+**Cons:**
+- recovery depends on checkpoint quality and freshness
+- event-driven execution is more complex than a naïve blocking loop
+- requires dedicated external services for context, accounting, and audit
+
+Chosen. The model provides strong alignment with OTP, enforces inspectability, and enables deterministic recovery.
+
+---
+
+# 4. Decision
+
+A runtime execution of a Lemming SHALL be modeled as an **on-demand supervised instance** implemented as an **OTP process**, with the initial implementation using a **GenServer** started under a **DynamicSupervisor**.
+
+Each execution instance:
+
+- is created on demand when work is assigned,
+- owns only the **minimal runtime state** needed to coordinate execution,
+- persists resumable execution state outside the process,
+- can be restarted by supervision and rehydrated from persisted state,
+- operates as a **stateful, event-driven workflow**, rather than as a free-form in-memory loop.
+
+The Lemming definition shown in the control plane represents a **Lemming type** or template. Runtime work is performed by **Lemming instances** spawned from that type.
+
+---
+
+# 5. Runtime Model
+
+## 5.1 Lemming type vs Lemming instance
+
+A **Lemming type** defines the reusable agent template, such as:
+
+- role and purpose
+- system instructions
+- model/provider policy
+- allowed tools
+- allowed communication targets
+- runtime limits
+- retry policy
+
+A **Lemming instance** is a concrete execution of that type for a specific task or request.
+
+The instance is the runtime unit supervised by OTP.
+
+## 5.2 Process model
+
+Each Lemming instance runs as a dedicated GenServer started under a DynamicSupervisor.
+
+The GenServer is responsible for:
+
+- coordinating the current execution step,
+- receiving and reacting to events,
+- delegating specialized concerns to runtime services,
+- checkpointing resumable state,
+- transitioning between execution states.
+
+The GenServer is **not** the source of truth for all execution data.
+
+## 5.3 State model
+
+Each Lemming instance behaves as an explicit stateful execution with states such as:
+
+- created
+- queued
+- running
+- waiting_model
+- waiting_tool
+- waiting_message
+- retry_backoff
+- paused
+- completed
+- failed
+- cancelled
+
+The exact set of states may evolve, but the execution model is explicitly state-based and resumable.
+
+## 5.4 Minimal in-process state
+
+The GenServer should keep only lightweight runtime coordination state, such as:
+
+- instance identifier
+- type identifier
+- current status
+- current step
+- waiting reason
+- timestamps and heartbeat data
+- references to config snapshot, context snapshot, and usage/accounting records
+
+Large or durable concerns must remain outside the process.
+
+## 5.5 Persisted execution state
+
+A Lemming instance must create an initial persisted record at startup so its existence and lifecycle can be traced externally from the beginning of execution.
+
+A Lemming instance must persist the state required for recovery and resumption outside the process.
+
+This persisted state may include:
+
+- instance creation and lifecycle metadata
+- current lifecycle state
+- current step and pending action
+- context references
+- partial outputs
+- retry metadata
+- checkpoint history
+- external wait conditions
+
+If the process crashes and is restarted by supervision, the runtime should be able to rehydrate the instance and continue from the latest valid checkpoint.
+
+## 5.6 Event-driven execution
+
+A Lemming instance does not run as a blocking `while true` loop.
+
+Instead, it progresses by:
+
+- receiving a start signal,
+- executing a step,
+- delegating work to tools or other runtime services,
+- persisting a checkpoint,
+- waiting for the next event, timer, or callback,
+- resuming when conditions are satisfied.
+
+This keeps the execution model OTP-native, observable, and restart-friendly.
+
+---
+
+# 6. Configuration Inheritance
+
+**ADR-0003** establishes World as a hard isolation boundary. That boundary has a direct consequence for execution: a Lemming instance is permanently scoped to the World it was spawned in and cannot address or observe anything outside it. Configuration inheritance follows the same boundary — a Lemming cannot inherit configuration from, or be governed by, a World it does not belong to.
+
+Effective runtime configuration is resolved hierarchically from:
+
+- World
+- City
+- Department
+- Lemming type
+- Instance overrides
+
+More specific configuration takes precedence over less specific configuration.
+
+However, inherited safety restrictions from higher levels must remain enforceable. In particular:
+
+- lower levels must not exceed higher-level deny rules,
+- lower levels must not escape upper budget constraints,
+- effective permissions must remain bounded by platform policy.
+
+The instance should run against a resolved configuration snapshot rather than continuously reading mutable live configuration during execution.
+
+Waiting instances remain resident in memory while idle. They are not unloaded as part of normal waiting behavior. This is expected because Lemmings may spend significant time waiting on model responses, local machine calls, tools, other services, or peer agents. To support crash recovery, the runtime persists execution state at lifecycle boundaries (transition to idle, before termination) as defined in ADR-0008. Active running Lemmings do not checkpoint; their working state lives in ETS and is considered recoverable from the most recent idle snapshot.
+
+---
+
+# 7. Separation of Responsibilities
+
+The Lemming GenServer is only the execution coordinator.
+
+The following concerns are delegated to dedicated runtime services or modules:
+
+- instance tracing and external runtime inspection
+
+- context storage and compaction
+
+- **model inference** — Lemmings never call providers directly. All inference requests
+  are dispatched to the Model Runtime (ADR-0019), which handles provider routing,
+  prompt assembly, retries, token accounting, structured output validation, and
+  streaming. The Lemming transitions to `waiting_model` while inference is in
+  progress. The minimal event set the execution model depends on:
+
+  | event | family | consumed by |
+  |---|---|---|
+  | `model.request_started` | telemetry | observability |
+  | `model.response_received` | telemetry | Lemming resumes execution |
+  | `model.retry` | telemetry | observability |
+  | `model.request_failed` | telemetry | Lemming transitions to failure/backoff |
+  | `model.usage` | telemetry | cost governance (ADR-0015) |
+  | `model.budget_denied` | audit | Lemming receives `{:error, :budget_exhausted}` |
+  | `model.structured_output_invalid` | audit | Lemming receives structured error |
+
+  Full event definitions and payload contracts are in ADR-0019 section 13 and the
+  platform event catalog in ADR-0018.
+
+- token and cost accounting
+- audit/event logging
+- checkpoint persistence
+- large artifact storage
+- tool execution
+
+This prevents the instance process from becoming the single location for all runtime complexity.
+
+---
+
+# 8. Consequences
+
+## Positive
+
+- Waiting instances can resume immediately when external events arrive.
+- External systems can observe that an instance exists and inspect its lifecycle from the beginning of execution.
+- In-memory residency simplifies event delivery and coordination for long-running agents.
+- Periodic idle checkpointing improves crash recovery without requiring full unload/reload semantics.
+- Strong alignment with Elixir/OTP supervision patterns.
+- On-demand execution avoids keeping idle agents permanently alive.
+- Restart and recovery behavior becomes explicit and testable.
+- Runtime state can be inspected, audited, and resumed.
+- The process remains lightweight because heavy concerns are externalized.
+- Specialized Lemming types remain easy to reason about.
+
+## Negative
+
+- Idle instances continue consuming memory while resident; the runtime must tune idle TTL and checkpoint frequency carefully.
+- Recovery requires careful checkpoint design — stale checkpoints mean more repeated work on restart.
+- Persisted state and in-memory state must stay consistent; a divergence between the two produces incorrect rehydration.
+- Event-driven execution is more complex than a naïve in-memory loop.
+- The runtime requires additional services for context, accounting, and audit concerns.
+
+## Mitigations
+
+- Idle memory pressure is mitigated by configurable `idle_ttl` eviction: instances that have been idle beyond the threshold are terminated and their context is compacted into a snapshot (ADR-0008).
+- Checkpoint semantics are defined in ADR-0008: snapshots are written at lifecycle boundaries (idle transition, pre-termination), not continuously. The recovery gap for a running Lemming is bounded by how recently it last transitioned through idle.
+- State consistency is maintained by treating persisted state as the source of truth: on rehydration, the GenServer state is rebuilt entirely from the persisted record rather than patched.
+
+---
+
+# 9. Non-Goals
+
+This ADR intentionally does not define:
+
+- the exact persistence backend (ADR-0008)
+- the context compaction algorithm (ADR-0008)
+- whether future implementations should use `:gen_statem` instead of `GenServer`
+- model inference implementation (ADR-0019)
+- tool execution implementation (ADR-0005 and ADR-0016)
+- routing and addressing details (ADR-0007)
+
+---
+
+# 10. Future Extensions
+
+- Migrating high-complexity instance types from `GenServer` to `:gen_statem` for richer state machine semantics.
+- Streaming checkpoint writes to reduce the latency of idle checkpoints.
+- Structured execution traces that capture every state transition for full replay auditing.
+
+---
+
+# 11. Rationale
+
+Elixir/OTP provides exactly the supervision, lifecycle, and fault-tolerance primitives that a multi-agent runtime requires. Modeling each Lemming instance as a supervised GenServer is the idiomatic choice and provides restartability, crash isolation, and process introspection for free.
+
+The explicit state machine prevents the instance from silently accumulating undefined behavior. Named states like `waiting_model` and `retry_backoff` are observable from outside the process, which makes debugging and monitoring concrete rather than speculative.
+
+The separation of the execution coordinator (GenServer) from its supporting services (context, model, accounting, audit) is a deliberate boundary: each service can evolve, be replaced, or be optimized independently without changing the Lemming's execution contract.

--- a/docs/adr/0005-tool-execution-model.md
+++ b/docs/adr/0005-tool-execution-model.md
@@ -1,0 +1,499 @@
+# ADR-0005 — Tool Execution Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS agents ("Lemmings") must interact with external systems such as:
+
+- local machine capabilities
+- HTTP APIs
+- LLM providers
+- databases
+- other services
+- other external platforms
+
+Allowing agents to execute arbitrary code or unrestricted commands would introduce severe security, reliability, and governance risks.
+
+Therefore, LemmingsOS introduces a **Tool model** as the controlled boundary between agents and external effects.
+
+All interactions with systems outside the Lemming process must go through registered tools managed by the runtime.
+
+The tool system must support:
+
+- security and permission enforcement
+- auditability of external actions
+- runtime policy enforcement
+- rate limits and timeouts
+- cost and token accounting
+- extensibility by third-party developers
+
+The system must also support two main user profiles:
+
+1. **Non-technical users**, who install and enable tools via a simple CLI or UI.
+2. **Technical users**, who may install tools manually or develop custom tools locally.
+
+---
+
+# 2. Decision Drivers
+
+1. **Agents must not execute arbitrary effects** — Unrestricted system calls, shell commands, or direct API access from agent code would make security enforcement impossible and audit trails meaningless. All external effects must be mediated by the runtime.
+
+2. **Tool permissions must be hierarchically governable** — The same tool may have different allowed connections and usage limits in different Departments or Cities. Permission changes must be configuration changes, not code changes.
+
+3. **The extension model must be validated from day one** — First-party tools must ship as separate packages using the same plugin mechanism as community tools. If the core runtime requires modification to add official capabilities, the extension model is broken.
+
+4. **Tool execution must produce an audit trail** — Every external interaction, including failures and policy denials, must produce a traceable event. This is a governance requirement, not an optional observability feature.
+
+5. **Non-technical operators must install tools without touching code** — The CLI-based installation workflow (`lemmings tool install <package>`) is a first-class user experience target, not a convenience.
+
+6. **MCP is an execution backend, not the security boundary** — The Model Context Protocol is a useful adapter for LLM-native tool integrations, but it provides no authorization, audit, or cost governance. LemmingsOS must own those concerns independently of whatever adapter executes the tool.
+
+---
+
+# 3. Considered Options
+
+## Option A — Agents execute external effects directly
+
+Agents call external systems through Elixir function calls, HTTP clients, or shell commands without any runtime intermediary.
+
+**Pros:**
+- simplest implementation; no Tool abstraction layer required
+- no registration or discovery machinery
+
+**Cons:**
+- no mechanism to enforce per-tool or per-department permission policies
+- no audit trail for external interactions
+- a faulty agent can consume unbounded API quota or make destructive external calls
+- tool capabilities cannot be governed without changing agent code
+
+Rejected. Direct execution from agent code makes governance structurally impossible.
+
+---
+
+## Option B — Simple module dispatch without registry or lifecycle
+
+Tools are implemented as plain Elixir modules. The agent calls them directly using a known module name. No registry, no dynamic discovery, no lifecycle state.
+
+**Pros:**
+- low implementation overhead
+- straightforward to test in isolation
+
+**Cons:**
+- no mechanism for runtime enable/disable without a code change
+- policy enforcement requires wrapping every tool call with custom logic, which is error-prone
+- tool inventory is only visible by reading source code, not through a queryable registry
+- third-party tools require changes to the core application
+
+Rejected. The lack of a registry and lifecycle makes operational governance unworkable.
+
+---
+
+## Option C — MCP as the primary tool boundary
+
+All tools are implemented as MCP servers. The Lemming communicates with them through the MCP protocol directly, without a LemmingsOS Tool abstraction.
+
+**Pros:**
+- aligns with emerging LLM ecosystem standards
+- MCP defines a structured schema format for tool inputs and outputs
+
+**Cons:**
+- MCP provides no authorization, policy hierarchy, or cost accounting; those concerns would fall to the agent itself
+- MCP server lifecycle and availability are outside LemmingsOS supervision
+- auditability requires intercepting every MCP call with a governance layer that effectively recreates the Tool Runtime
+- MCP-native tool definitions cannot carry LemmingsOS-specific metadata such as risk level or connection declarations
+
+Rejected. MCP is a useful adapter protocol but cannot serve as the governance boundary.
+
+---
+
+## Option D — Native first-class Tool abstraction with registry, adapter model, and policy enforcement (chosen)
+
+Tools are first-class runtime entities distributed as Hex packages, registered in a Tool Registry, and executed exclusively through the Tool Runtime. The Tool Runtime enforces policy, auditing, and resource limits regardless of the underlying adapter (native Elixir, MCP, HTTP).
+
+**Pros:**
+- all external effects pass through a single governable boundary
+- tools can be enabled, disabled, and governed without agent code changes
+- the extension model is validated by shipping first-party tools as separate packages
+- audit events are produced by the runtime, not by individual tool authors
+- MCP and other adapters work as execution backends under the same governance layer
+
+**Cons:**
+- tool authors must implement the `LemmingsOs.Tool` behaviour contract
+- the adapter layer adds one extra hop per tool invocation
+- dynamic discovery via Hex package scanning requires application restart to register new tools in v1
+
+Chosen. The governance, auditability, and extensibility requirements cannot be satisfied without a managed runtime boundary.
+
+---
+
+# 4. Decision
+
+LemmingsOS defines a **native Tool abstraction** representing controlled capabilities that agents may invoke.
+
+Tools are **first-class runtime entities** registered in the system and governed by runtime policy.
+
+Agents are **not allowed to execute arbitrary code** or perform external actions directly. All external effects must pass through tools.
+
+Tools are:
+
+- distributed as **Hex packages**
+- discovered and registered dynamically by the runtime
+- enabled or disabled through the Tool Registry
+- governed by hierarchical runtime policy
+
+The runtime includes a **Tool Registry** responsible for tracking installed, registered, and enabled tools.
+
+---
+
+# 5. Tool Model
+
+A tool represents a structured capability exposed to agents.
+
+Each tool must define:
+
+- tool identifier
+- human-readable name
+- description
+- input schema
+- output schema
+- execution adapter
+- risk level classification
+- supported connection types, if external credentials or connection metadata are required
+
+Tool schemas allow validation of inputs and outputs and reduce ambiguity when used by agents.
+
+---
+
+# 6. Tool Execution Boundary
+
+Agents never execute external effects directly.
+
+Lemmings invoke tools through a runtime Tool API rather than talking to tool implementations directly. The Tool Runtime is the only supported path for tool execution.
+
+The execution flow is:
+
+```
+Lemming Instance
+   ↓
+Tool Request
+   ↓
+Policy Check
+   ↓
+Tool Adapter Execution
+   ↓
+Result
+   ↓
+Audit/Event Log
+```
+
+This boundary ensures that:
+
+- tool permissions can be enforced
+- connection access can be enforced
+- tool usage can be audited
+- resource limits can be applied
+- failures can be isolated
+
+---
+
+# 7. Runtime Interaction Overview
+
+The following diagram illustrates how a Lemming interacts with tools and external systems through the runtime boundary:
+
+```
+                ┌───────────────────────┐
+                │     Lemming Instance  │
+                └───────────┬───────────┘
+                            │
+                            │ Tool Call (ToolRuntime.call)
+                            ▼
+                ┌───────────┴───────────┐
+                │      Tool Runtime     │
+                │  (policy + auditing)  │
+                └───────────┬───────────┘
+                            │
+                ┌───────────┴───────────┐
+                │  Policy / Permission  │
+                │  Checks               │
+                └───────────┬───────────┘
+                            │
+                            ▼
+                  ┌─────────┴─────────┐
+                  │    Tool Adapter   │
+                  └─────────┬─────────┘
+                            │
+        ┌───────────────────┼───────────────────┐
+        │                   │                   │
+        ▼                   ▼                   ▼
+   Native Tool         MCP Service         HTTP / Worker
+ (Elixir module)        Adapter              Adapter
+        │                   │                   │
+        └───────────────────┴───────────────────┘
+                            │
+                            ▼
+                   External System / API
+```
+
+This architecture ensures that all side effects pass through a controlled runtime boundary where policy, auditing, and resource limits are enforced.
+
+---
+
+# 8. Tool Invocation Model
+
+From the perspective of a Lemming instance, tool execution is always modeled as asynchronous.
+
+A Lemming submits a tool request to the Tool Runtime and later receives completion through a runtime callback event.
+
+This remains true even when the underlying tool implementation may execute quickly or synchronously internally.
+
+This model aligns with OTP-style runtime design and provides a consistent contract for:
+
+- long-running tool calls
+- external callbacks
+- retries and supervision
+- waiting states in agent execution
+- audit and event tracing
+
+The runtime may internally optimize specific tool adapters, but that does not change the external contract seen by the Lemming.
+
+---
+
+# 9. Execution Adapters
+
+Tools may execute through different adapters depending on their implementation.
+
+Examples include:
+
+- native Elixir modules
+- MCP-based integrations
+- HTTP services
+- worker processes
+
+The tool abstraction is independent from the execution adapter.
+
+This allows LemmingsOS to integrate with external ecosystems while maintaining runtime control.
+
+**Isolation semantics by adapter**: not all adapters carry the same isolation
+guarantees. Native Elixir module adapters may execute in-process when the tool
+is classified as trusted first-party; all other adapters execute in external OS
+processes. The trust gradient and process isolation model are defined in
+ADR-0016 section 6. Tool authors must not assume that in-process execution is
+available; it is a platform-side classification decision, not an author-side
+choice.
+
+---
+
+# 10. MCP Integration
+
+Model Context Protocol (MCP) may be used as an adapter for tools.
+
+However, MCP is treated as an **execution backend**, not as the core security boundary.
+
+The LemmingsOS Tool model remains the authoritative control layer for:
+
+- permissions
+- policy enforcement
+- audit logging
+- cost and runtime limits
+
+---
+
+# 11. Tool Registry
+
+The runtime maintains a **Tool Registry** that tracks:
+
+- installed tools
+- discovered tool modules
+- enabled or disabled status
+- tool source (official, community, local)
+- trust level
+- configuration state
+
+Tool lifecycle states include:
+
+- Installed
+- Registered
+- Enabled
+- Policy-allowed
+
+Registration means the runtime has discovered a valid tool module, validated its metadata contract, and made it visible to the control plane and policy system.
+
+Tools may be installed but remain disabled until explicitly enabled by an administrator.
+
+---
+
+# 12. Tool Distribution
+
+Tools are distributed as **Hex packages**.
+
+A package may contain one or more tool modules implemented using the runtime behaviour:
+
+```elixir
+use LemmingsOs.Tool
+```
+
+When installed, the runtime discovers modules that implement the Tool behaviour and registers them automatically.
+
+This allows tools to be added without modifying the core application or its dependency manifest.
+
+---
+
+# 13. Plugin Model
+
+The system supports extensibility through tool packages.
+
+Tools may originate from:
+
+- official packages
+- community packages
+- locally developed packages
+
+Technical users may also install tools dynamically using mechanisms such as `Mix.install` during development.
+
+---
+
+# 14. Official Tools
+
+First-party tools are distributed as **separate packages**, not embedded directly in the runtime core.
+
+For example:
+
+- lemmings_tools_official
+
+This validates the extension model from the beginning and keeps the runtime core minimal.
+
+Product distributions may bundle official tool packages by default for ease of installation.
+
+---
+
+# 15. Installation Flows
+
+### Non-technical users
+
+Tools may be installed through a simple CLI or UI workflow.
+
+Example CLI:
+
+```
+lemmings tool install lemmings_tool_http
+```
+
+The runtime:
+
+1. installs the package
+2. discovers tool modules
+3. registers tools in the registry
+4. allows administrators to enable them
+
+### Technical users
+
+Developers may install tools locally during development.
+
+Example:
+
+```elixir
+Mix.install([
+  {:my_tool, path: "../my_tool"}
+])
+```
+
+The runtime discovery mechanism will detect and register the tools.
+
+---
+
+# 16. Connections and Secret Access
+
+Some tools require access to external systems such as Jira, GitHub, search APIs, databases, or other providers.
+
+Tools do not read secrets directly and agents never receive raw credentials.
+
+Instead:
+
+- a tool declares the connection types it supports
+- runtime policy binds a tool to specific allowed connections
+- secret material is resolved by runtime services at execution time
+- credentials are injected into the tool executor, not exposed to the agent
+
+A tool may support one or more connection types, but it may only use concrete connections explicitly allowed by runtime policy.
+
+The detailed connection, credential, and secret storage model is defined in ADR-0009.
+
+---
+
+# 17. Policy Enforcement
+
+Tool usage is governed by hierarchical configuration:
+
+```
+World → City → Department → Lemming Type → Instance
+```
+
+More specific configuration takes precedence, but lower levels cannot exceed upper-level restrictions.
+
+Policies may control:
+
+- which tools are allowed
+- which concrete connections each tool may use
+- concurrency limits
+- timeouts
+- rate limits
+- budget usage
+
+The full tool policy authorization model is defined in ADR-0012.
+
+---
+
+# 18. Consequences
+
+## Positive
+
+- All external effects pass through a single runtime boundary, making authorization, auditing, and resource enforcement consistent and complete.
+- Tool enable/disable and policy changes are operational decisions; they require no agent code changes.
+- The Hex package distribution model allows community tools to follow exactly the same path as official tools, validating the extension model continuously.
+- MCP and other emerging tool protocols are supported as adapters without ceding governance to those protocols.
+
+## Negative
+
+- Tool authors must implement the `LemmingsOs.Tool` behaviour contract precisely; malformed metadata schemas fail validation at registration time, not at invocation time.
+- The adapter layer adds one serialization hop per tool invocation, which is measurable on high-frequency low-latency tool calls.
+- Dynamic discovery via Hex package scanning requires a controlled application restart to register newly installed tools in v1; hot-loading is not supported.
+
+## Mitigations
+
+- The behaviour contract validation error identifies which field failed and why, giving tool authors actionable feedback during development rather than cryptic runtime failures.
+- High-frequency tool calls that are performance-sensitive can use native Elixir adapter implementations, which avoid external process overhead entirely.
+- The restart requirement for new tool registration is mitigated by the CLI install workflow, which can initiate a controlled restart as its final step.
+
+---
+
+# 19. Non-Goals
+
+This ADR defines the conceptual Tool model and execution boundary. The following concerns are covered by dedicated ADRs:
+
+- tool risk classification (ADR-0013)
+- tool approval workflow (ADR-0014)
+- tool execution isolation and sandboxing (ADR-0016)
+- tool policy authorization model (ADR-0012)
+- secret and connection injection details (ADR-0009)
+
+---
+
+# 20. Future Extensions
+
+- Hot-loading of newly installed tools without full application restart.
+- Signed tool packages with a trust registry for supply chain integrity.
+- Tool marketplace/catalog with community rating and review.
+- Per-tool usage analytics and quota dashboards.
+
+---
+
+# 21. Rationale
+
+The Tool abstraction solves a fundamental tension in agent runtimes: agents must be capable of interacting with the world, but that capability must be governable, auditable, and bounded. Solving this by making Tools first-class runtime entities — rather than library calls or LLM-native primitives — means governance is structural. A tool that is not registered cannot be invoked, regardless of what the model decides. A tool that is not enabled for a Department cannot be invoked by a Lemming in that Department, regardless of what policy inheritance would otherwise allow.
+
+The decision to ship first-party tools as separate Hex packages from day one is a discipline commitment: it prevents the tool system from accumulating a privileged class of "always available" capabilities that bypass the registry and governance mechanisms that community tools must use.

--- a/docs/adr/0006-agent-communication-model.md
+++ b/docs/adr/0006-agent-communication-model.md
@@ -1,0 +1,415 @@
+# ADR-0006 — Agent Communication Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS is built around specialized, narrow agents rather than general-purpose super-agents.
+
+A single user request may require multiple Lemmings to cooperate. For example:
+
+- one agent searches recent news
+- one agent searches a technical knowledge source
+- one agent searches a human-oriented knowledge source
+- one coordinating agent aggregates and synthesizes results
+
+This means LemmingsOS must define a native communication model for cooperation between runtime instances.
+
+Because Lemmings are runtime processes, direct process messaging is technically possible. However, raw process messaging alone is not enough as an architecture model. The runtime must also define:
+
+- what communication patterns are supported
+- who may talk to whom
+- how communication is traced and governed
+- how multi-agent cooperation remains predictable
+
+Communication between Lemmings is an internal runtime concern and must not be modeled as a Tool. Tools are reserved for interaction with external systems.
+
+---
+
+# 2. Decision Drivers
+
+1. **Specialized agents require structured cooperation** — Multi-step tasks decompose across multiple Lemmings. The runtime must define how they coordinate without falling back to super-agents or unstructured messaging.
+
+2. **Direct OTP messaging is insufficient as a governance boundary** — Raw `GenServer.call` / `send` expose PIDs as the caller's concern, provide no policy enforcement, and produce no audit events. A runtime communication API is required.
+
+3. **Communication must be policy-controlled** — Uncontrolled fan-out, cross-department messaging, or unexpected communication graphs must be preventable through configuration, not code changes. Default-deny is the correct starting posture.
+
+4. **Communication must be auditable** — Agent-to-agent interactions are security-relevant and must produce traceable events. A coordinator spawning ten workers without any audit trail is indistinguishable from a runaway loop.
+
+5. **Not every interaction requires a response** — Both fire-and-forget patterns (status notifications, lifecycle signals) and synchronous request/reply patterns are legitimate. The model must support both without forcing async wrappers everywhere.
+
+6. **Communication is an internal runtime concern, not a Tool** — Reusing the Tool execution path for agent messaging would conflate two different governance domains. Communication and external effects have different authorization, audit, and resource accounting requirements.
+
+---
+
+# 3. Considered Options
+
+## Option A — Direct OTP process messaging
+
+Lemmings communicate by calling each other directly using PIDs obtained from the registry. No runtime communication API is involved.
+
+**Pros:**
+- zero additional infrastructure; standard Elixir pattern
+- lowest possible latency
+
+**Cons:**
+- exposes PID-based addressing to callers; PIDs are unstable across restarts
+- no policy enforcement point; any Lemming can message any other Lemming
+- no audit events without wrapping every call site manually
+- callers must handle process liveness themselves
+
+Rejected. Direct OTP messaging does not provide a policy or audit boundary.
+
+---
+
+## Option B — Shared event bus as the primary communication model
+
+Lemmings publish events to a shared bus (Phoenix.PubSub or Erlang `:pg`). Other Lemmings subscribe to topics of interest.
+
+**Pros:**
+- decouples producers from consumers
+- supports broadcast and fan-out naturally
+
+**Cons:**
+- subscription management becomes a new source of complexity
+- topic-based routing does not naturally model directed request/reply
+- a shared bus makes it harder to enforce per-Lemming communication policy
+- audit requires intercepting all publish/subscribe calls, which is more complex than a single API boundary
+
+Rejected. A shared bus is a good fit for observability events but not for governed agent-to-agent work dispatch.
+
+---
+
+## Option C — External message queue (RabbitMQ, Redis Streams)
+
+Agent communication uses an external MQ as the transport layer.
+
+**Pros:**
+- durable message delivery across node restarts
+- standard messaging patterns (work queues, pub/sub) are well understood
+
+**Cons:**
+- requires an external operational dependency on every self-hosted deployment
+- adds significant latency for inter-agent messages that would otherwise be in-process
+- queue management, serialization, and consumer lifecycle are substantial operational surface
+- does not solve the governance and policy enforcement requirement; those still require a runtime layer on top
+
+Rejected. An external MQ is operationally disproportionate for in-runtime agent communication.
+
+---
+
+## Option D — Native runtime communication API with typed patterns and policy enforcement (chosen)
+
+Agent communication goes through a native LemmingsOS communication API. The runtime enforces allowed peers, pattern types, and communication scope. All interactions produce audit events.
+
+**Pros:**
+- single governable boundary for all inter-agent communication
+- policy enforcement is structural, not per-call-site
+- audit events are produced by the runtime, not by individual agents
+- aligns with OTP-style async callback semantics
+
+**Cons:**
+- the runtime must manage routing, tracing, and reply correlation
+- introduces a communication layer between agents that adds a small per-message overhead
+- policy design is important; overly restrictive policies create rigid communication graphs
+
+Chosen. The governance and auditability requirements require a runtime-owned communication boundary.
+
+---
+
+# 4. Decision
+
+LemmingsOS defines agent-to-agent communication as a **native runtime capability**.
+
+Communication is:
+
+- explicit
+- directed
+- policy-controlled
+- auditable
+
+The runtime supports three primary communication patterns:
+
+- request / reply
+- notification
+- delegation with join
+
+These patterns are available as runtime communication primitives. They are not rigid agent role types.
+
+Lemmings are not configured with a single fixed communication type. Instead, runtime policy determines:
+
+- which peer Lemmings a given Lemming may contact
+- which communication patterns it may use
+- whether delegation is allowed
+
+The recommended cooperation model for multi-agent execution is **coordinator → worker(s) → join**, but this is a runtime pattern, not a mandatory topology for all communication.
+
+---
+
+# 5. Addressing Model
+
+Agent communication supports two addressing modes.
+
+## 5.1 Addressing by Lemming type
+
+A Lemming may delegate work to a **Lemming type** rather than an existing instance.
+
+Example:
+
+```
+delegate to: news_researcher
+```
+
+In this case the runtime:
+
+1. resolves the target Lemming type
+2. spawns a new Lemming instance
+3. returns an instance reference to the caller
+
+This allows agents to dynamically create specialized workers when decomposing tasks.
+
+## 5.2 Addressing by Lemming instance
+
+After delegation, subsequent communication targets the specific instance created by the runtime.
+
+Example conceptual flow:
+
+```
+Lemming John
+   ↓ delegate(news_researcher)
+Runtime spawns
+   ↓
+Lemming Sara
+   ↓ instance_ref(sara-123)
+
+John → sara-123 → follow-up request
+```
+
+The caller stores the returned instance reference in its state and continues communicating with that instance rather than spawning a new worker for every follow-up interaction.
+
+This preserves task context and avoids uncontrolled instance creation.
+
+---
+
+# 6. Communication Primitives
+
+## 6.1 Request / reply
+
+A Lemming sends a directed request to another Lemming and expects a response.
+
+Examples:
+
+- ask another agent to summarize a document
+- ask another agent to research a topic
+- ask another agent to classify or evaluate a result
+
+This is the primary pattern for structured cooperation.
+
+## 6.2 Notification
+
+A Lemming sends a directed notification without expecting a reply.
+
+Examples:
+
+- report task completion
+- report a failure
+- signal that intermediate data is available
+
+This pattern is useful for lightweight coordination and lifecycle signaling.
+
+## 6.3 Delegation with join
+
+A coordinating Lemming delegates work to one or more specialized Lemmings and later joins their results.
+
+This enables controlled swarm behavior.
+
+Examples:
+
+- delegate research to several specialists
+- wait for all or some results
+- synthesize the responses into a final output
+
+This is the preferred pattern for multi-agent decomposition.
+
+---
+
+# 7. Runtime Interaction Model
+
+Communication events are traceable as part of runtime observability. The runtime records agent-to-agent interactions so that execution flows can be inspected, audited, and debugged.
+
+Lemmings do not send arbitrary free-form messages to unknown peers.
+
+Instead, communication flows through a native runtime communication boundary.
+
+```
+Lemming A
+   ↓
+Communication Runtime API
+   ↓
+Policy / Routing / Audit
+   ↓
+Lemming B
+   ↓
+Reply / Notification / Completion
+   ↓
+Lemming A
+```
+
+This allows the runtime to enforce:
+
+- peer restrictions
+- communication pattern restrictions
+- tracing and observability
+- resource governance
+
+---
+
+# 8. Coordinator-Worker Pattern
+
+The recommended pattern for collaborative execution is:
+
+```
+                ┌──────────────────────┐
+                │      Coordinator     │
+                └──────────┬───────────┘
+                           │
+          ┌────────────────┼────────────────┐
+          │                │                │
+          ▼                ▼                ▼
+ ┌────────────────┐ ┌────────────────┐ ┌────────────────┐
+ │   Worker A     │ │   Worker B     │ │   Worker C     │
+ │ news research  │ │ tech research  │ │ human research │
+ └────────┬───────┘ └────────┬───────┘ └────────┬───────┘
+          │                  │                  │
+          └──────────────────┴──────────────────┘
+                             │
+                             ▼
+                ┌────────────┴───────────┐
+                │    Join / Synthesis    │
+                └────────────────────────┘
+```
+
+This pattern is encouraged because it preserves specialization while keeping orchestration understandable and auditable.
+
+---
+
+# 9. Policy Model
+
+Agent communication is governed by runtime policy.
+
+Policy defines:
+
+- allowed peer targets
+- allowed communication patterns
+- whether delegation is permitted
+- limits on fan-out or concurrency
+- limits on communication scope across runtime boundaries
+
+A Lemming may only communicate with peers explicitly allowed by effective configuration.
+
+This prevents uncontrolled swarm expansion and unpredictable communication graphs.
+
+---
+
+# 10. Configuration Model
+
+Communication permissions are resolved through hierarchical configuration:
+
+```
+World → City → Department → Lemming Type → Instance
+```
+
+More specific configuration takes precedence, but lower levels may not exceed upper-level restrictions.
+
+This allows, for example:
+
+- a coordinator to contact specific worker types
+- a worker to reply only to coordinators
+- certain departments to block cross-department delegation
+
+---
+
+# 11. Communication Semantics
+
+The communication model is asynchronous by default from the runtime perspective.
+
+A Lemming submits a communication request and later receives:
+
+- a reply
+- a notification
+- a completion event
+- a timeout or failure event
+
+This aligns with OTP-style runtime design and fits naturally with long-running, supervised agent execution.
+
+---
+
+# 12. What Is Intentionally Not Supported
+
+LemmingsOS does not use unrestricted free-form conversation between arbitrary agents as the default communication model.
+
+The runtime does not assume that any Lemming may spontaneously talk to any other Lemming without policy and routing constraints.
+
+This avoids:
+
+- communication loops
+- runaway swarm expansion
+- unclear ownership of results
+- hard-to-debug emergent behavior
+
+---
+
+# 13. Consequences
+
+## Positive
+
+- Clear native runtime model for agent cooperation.
+- Supports specialization without requiring super-agents.
+- Enables controlled swarm execution with deterministic fan-out bounds.
+- Keeps communication auditable and policy-bound; no interaction is invisible.
+- Fits naturally with OTP runtime semantics and asynchronous execution.
+
+## Negative
+
+- The runtime must manage routing, tracing, and reply correlation for all inter-agent messages; this is non-trivial infrastructure.
+- Free-form multi-agent conversation is deliberately constrained; agents that need looser communication patterns require explicit policy grants.
+- Policy design becomes load-bearing: overly restrictive policies create rigid graphs; overly permissive ones recreate the uncontrolled swarm problem.
+
+## Mitigations
+
+- Routing and address resolution are scoped to ADR-0007, which defines the registry and delivery failure semantics separately from this policy model.
+- Policy defaults use an explicit allowlist rather than a denylist; the common case of a coordinator talking to its own spawned workers is always permitted without operator intervention because the coordinator owns the `instance_ref`.
+- Policy validation errors are surfaced as structured runtime errors (`{:error, :not_allowed}`), not silent message drops, so debugging policy misconfigurations is straightforward.
+
+---
+
+# 14. Non-Goals
+
+This ADR defines the conceptual model for communication between Lemmings. The following concerns are intentionally out of scope:
+
+- routing and address resolution implementation details (ADR-0007)
+- event bus usage for observability or broadcasts
+- cross-City communication behavior
+- cross-World communication (structurally impossible — see ADR-0003)
+- communication cost accounting and fan-out limits
+
+---
+
+# 15. Future Extensions
+
+- Cross-City communication within the same World, subject to city-to-city routing capability and policy.
+- Communication cost accounting to track and limit fan-out by budget scope.
+- Broadcast patterns for coordination signals within a Department.
+- Structured timeout policies for pending delegations.
+
+---
+
+# 16. Rationale
+
+The core insight is that communication in a multi-agent system is a governance surface, not just an implementation detail. When an agent can spawn ten workers and each spawns ten more, the result is not emergent intelligence — it is an uncontrolled resource explosion. Making communication policy-controlled and audit-producing is the structural mechanism that keeps multi-agent execution understandable and bounded.
+
+The decision to keep communication separate from the Tool system reflects a real architectural distinction: Tools are about external effects (side effects on the world), while communication is about internal coordination (collaboration within the runtime). Mixing them would either weaken Tool governance or over-burden the communication API with security concerns that are not relevant for in-runtime messaging.

--- a/docs/adr/0007-runtime-routing-registry-address-resolution.md
+++ b/docs/adr/0007-runtime-routing-registry-address-resolution.md
@@ -1,0 +1,416 @@
+# ADR-0007 — Runtime Routing / Registry / Address Resolution
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS models each Lemming instance as an OTP process supervised by the runtime. Instances may execute asynchronously, persist state periodically, and remain alive across multiple interactions before being dismissed or evicted after an idle timeout.
+
+Previous ADRs established the boundaries this ADR builds on:
+
+- **ADR-0004 — Lemming Execution Model**: each Lemming instance is a supervised OTP process with its own lifecycle.
+- **ADR-0005 — Tool Execution Model**: all external side effects must happen through Tools and the Tool Runtime.
+- **ADR-0006 — Agent Communication Model**: Lemmings communicate natively through runtime messaging using request/reply, notification, and delegation patterns.
+
+This ADR defines how a caller resolves a destination, how the runtime addresses concrete instances, what metadata is tracked for routing, and how instance lifecycle interacts with addressing.
+
+The design goal is to keep the mental model simple:
+
+- a caller can create a new worker by asking for an **agent type**
+- a caller can continue talking to the same worker through its **instance reference**
+- the runtime owns liveness, placement, and delivery concerns
+- callers do not pre-check whether an instance is still alive
+
+This model must support multiple concurrent instances of the same agent type, iterative follow-up work on a delegated subtask, and safe routing boundaries aligned with World isolation.
+
+---
+
+# 2. Decision Drivers
+
+1. **Callers must be isolated from OTP internals** — PIDs and node placement are unstable identifiers: a process restart produces a new PID, and a node migration changes the location. Callers must hold a stable logical handle that the runtime resolves to a live process without caller involvement.
+
+2. **Multiple concurrent instances of the same type must be natural** — Agent types are not singletons. A coordinator may spawn two `web_researcher` instances focused on different sources simultaneously. The addressing model must support this without special-casing.
+
+3. **Liveness and placement are runtime concerns, not caller concerns** — Callers must not pre-check process health or perform their own registry lookups. The runtime is responsible for delivery, failure signaling, and reconnection.
+
+4. **World isolation must be a hard routing boundary** — Cross-World routing must be structurally prevented by the addressing model, not only by policy checks. A caller in World A must not be able to address a Lemming in World B through any routing path.
+
+5. **The registry must remain lightweight** — Only routing metadata (instance ref, type, world, city, department, pid, status) belongs in the registry. Working context, model state, and business data must live in the ephemeral store (ADR-0008). Mixing them would bloat the registry and complicate crash recovery.
+
+6. **Idle instances must remain addressable** — Instance references must stay valid through idle periods so a coordinator can send follow-up work to the same worker without respawning. The runtime owns idle TTL and cleanup; callers do not.
+
+---
+
+# 3. Considered Options
+
+## Option A — Direct Elixir Registry with PID-based addressing
+
+Use `{:via, Registry, {LemmingsOs.Registry, instance_ref}}` as the standard Elixir Registry. Callers obtain a PID from the registry and call it directly.
+
+**Pros:**
+- uses a built-in Elixir mechanism; minimal custom infrastructure
+- Registry supervision and cleanup are provided by OTP
+
+**Cons:**
+- PIDs are unstable; callers must re-resolve after any restart, making `instance_ref` not truly stable from the caller's perspective
+- the Registry provides no World-scoped routing boundary; a caller can look up any registered name regardless of World
+- there is no standard way to record routing metadata (city, department, status, last activity) alongside the PID without a separate lookup table
+
+Rejected. PID instability and the lack of World-scoped isolation require a custom routing layer regardless.
+
+---
+
+## Option B — ETS-based ad-hoc name-to-PID table
+
+Maintain a global ETS table mapping `instance_ref` → `{pid, metadata}`. Callers look up the table directly.
+
+**Pros:**
+- fast in-memory lookup; ETS reads are concurrent and cheap
+- flexible schema for storing routing metadata alongside the PID
+
+**Cons:**
+- ETS tables are node-local; no cross-node routing without custom replication
+- the table is a shared global mutable structure; concurrent writes and deletions require careful coordination
+- no supervision integration; stale entries must be cleaned up manually when processes die
+- World isolation must be enforced by lookup logic, not by structural separation
+
+Rejected. A global ETS table grows into a custom registry with the downsides of both approaches and the advantages of neither.
+
+---
+
+## Option C — External service registry (Consul, etcd)
+
+Use an external service registry as the canonical instance directory.
+
+**Pros:**
+- battle-tested for distributed service discovery
+- supports cross-node routing natively
+- health-check integration is built in
+
+**Cons:**
+- requires an external operational dependency on every self-hosted deployment
+- adds network latency to every routing lookup
+- Consul/etcd availability becomes a hard dependency for all inter-agent communication
+- operationally disproportionate for a single-node or small-cluster deployment target
+
+Rejected. The operational dependency is disproportionate to the self-hosted deployment target.
+
+---
+
+## Option D — Two-tier addressing with node-local runtime registry (chosen)
+
+Use two address forms: `agent_type` for spawning new instances and `instance_ref` for addressing existing ones. The runtime maintains a node-local registry with World-scoped lookup. Callers hold stable logical handles; the runtime resolves them to live processes.
+
+**Pros:**
+- simple mental model: create by type, continue by reference
+- World-scoped lookup prevents cross-World routing structurally
+- stable `instance_ref` abstracts PID instability from callers
+- routing metadata (city, department, status, last activity) can be stored alongside routing entries without bloating the registry
+
+**Cons:**
+- requires a custom registry implementation beyond plain Elixir Registry
+- callers must handle delivery failures explicitly when idle instances expire
+
+Chosen. The simplicity of the two-tier model and the structural World isolation are the right design anchors for v1.
+
+---
+
+# 4. Decision
+
+## 4.1 Address forms
+
+Runtime addressing supports exactly two forms in v1:
+
+1. **`agent_type`**
+   - Used to create a new instance of a specific agent class.
+   - Agent types are **not** singletons.
+   - Multiple concurrent instances of the same type are first-class.
+   - Addressing by type does **not** target an existing instance implicitly.
+
+2. **`instance_ref`**
+   - Used to address an existing concrete instance directly.
+   - `instance_ref` is the canonical logical identity of a Lemming instance.
+   - `instance_ref` is stable and opaque.
+   - Runtime internals such as PID or node placement are not exposed as the addressing contract.
+
+## 4.2 Default addressing semantics
+
+The runtime applies the following default semantics:
+
+- `agent_type` → **spawn new instance**
+- `instance_ref` → **send to existing instance**
+
+This keeps routing predictable and avoids hidden reuse decisions in v1.
+
+Example:
+
+- John delegates to `web_buyer_researcher`
+- the runtime spawns two instances of the same type
+- one instance focuses on Amazon
+- one instance focuses on Mercado Livre
+- subsequent follow-up work is sent to each concrete worker through its `instance_ref`
+
+## 4.3 Instance lifecycle and idle behavior
+
+Spawned instances remain alive after completing a task and transition to an **idle** state.
+
+Idle instances:
+
+- preserve their working context
+- remain directly addressable by `instance_ref`
+- may receive follow-up work later
+
+Idle instances may be terminated in two ways:
+
+- **explicit dismissal** by the caller
+- **automatic eviction** by the runtime after `idle_ttl` expiration
+
+The runtime owns idle expiration and cleanup.
+
+## 4.4 Caller responsibilities and liveness
+
+Callers treat `instance_ref` as a stable logical handle.
+
+Callers do **not** pre-check whether an instance is alive before sending follow-up work. Instead:
+
+- the caller sends work to the `instance_ref`
+- the runtime attempts delivery
+- if delivery fails because the instance is unavailable, the caller decides what to do next
+
+Possible caller strategies include:
+
+- spawn a replacement instance
+- retry later
+- ignore that branch
+- mark the delegated subtask as failed
+
+Liveness and placement are runtime concerns, not caller concerns.
+
+## 4.5 Working context ownership
+
+Each Lemming instance owns its own structured working context. The context lives
+in process memory while the instance is active. Model input is reconstructed on
+each LLM invocation from this structured state; the runtime does not rely on
+implicit model memory across requests.
+
+Context structure, field semantics, compaction triggers, and persistence
+semantics are defined in ADR-0008. The registry has no visibility into context
+content — it stores routing metadata only.
+
+## 4.7 Registry responsibilities
+
+The runtime uses an Elixir registry-style routing layer to track addressable instances.
+
+The registry is responsible only for **presence, routing, and placement metadata**. It is **not** the source of truth for the instance working context.
+
+The registry stores minimal routing metadata such as:
+
+- `instance_ref`
+- `agent_type`
+- `world`
+- `city`
+- `department`
+- `pid` or runtime location
+- `status`
+- `last_activity_at`
+
+This keeps routing concerns separated from business or model state.
+
+## 4.8 Routing scope
+
+Routing is always scoped to a single **World** and, in v1, to a single **City**.
+
+- **cross-world routing is never allowed**
+- cross-department routing is allowed within the same City
+- **cross-city routing is not supported in v1**; all routing is City-local
+
+Cross-City routing requires a distributed registry capable of resolving instance
+references across BEAM nodes. This infrastructure adds significant complexity
+without a concrete v1 use case — within a single City, Departments already provide
+the isolation and grouping needed for agent coordination. Cross-City routing is
+deferred to a future extension (see section 8).
+
+This preserves the strong isolation boundary of World while keeping the v1 routing
+model simple, local, and testable without multi-node infrastructure.
+
+## 4.9 Peer communication policy
+
+Peer communication is denied by default.
+
+A Lemming instance may only spawn or address peer agent types that are explicitly allowed by policy.
+
+The runtime must enforce this before:
+
+- spawning a new peer instance by `agent_type`
+- sending work to an existing peer by `instance_ref`
+
+Policy therefore acts as an allowlist for peer communication.
+
+## 4.10 Routing and delivery outcomes
+
+The runtime distinguishes routing and delivery failures explicitly.
+
+Suggested return shapes:
+
+- `{:ok, result}`
+- `{:error, :instance_not_found}`
+- `{:error, :instance_unavailable}`
+- `{:error, :timeout}`
+- `{:error, :not_allowed}`
+- `{:error, :spawn_failed}`
+
+These outcomes allow callers to distinguish between:
+
+- resolution failure
+- delivery failure
+- policy failure
+- spawn failure
+- downstream execution failure
+
+## 4.11 Lifecycle contract
+
+The minimal conceptual lifecycle contract in v1 is:
+
+- `spawn(agent_type, initial_task) -> instance_ref`
+- `send(instance_ref, message) -> result | error`
+- `dismiss(instance_ref) -> ok | error`
+
+This is a conceptual runtime contract, not a final public API.
+
+---
+
+# 5. Diagrams
+
+## Addressing model
+
+```text
+Caller (John)
+   |
+   | delegate by agent_type = web_buyer_researcher
+   v
+Runtime Router / Policy Check
+   |
+   | spawn new instance
+   v
++------------------------------+
+| instance_ref = lem_a         |
+| type = web_buyer_researcher  |
+| focus = Amazon               |
++------------------------------+
+
+Caller (John)
+   |
+   | delegate by agent_type = web_buyer_researcher
+   v
+Runtime Router / Policy Check
+   |
+   | spawn new instance
+   v
++------------------------------+
+| instance_ref = lem_b         |
+| type = web_buyer_researcher  |
+| focus = Mercado Livre        |
++------------------------------+
+
+Follow-up work:
+John -> send(lem_a, "check page 2")
+John -> send(lem_b, "apply price filter")
+```
+
+## Liveness and idle handling
+
+```text
+spawned --> running --> idle --> dismissed
+                    \-> idle_ttl expired --> terminated
+
+While idle:
+- instance_ref stays valid
+- working context remains in memory
+- caller may send follow-up work
+
+If follow-up arrives after termination:
+- runtime returns delivery error
+- caller decides whether to respawn or ignore
+```
+
+## Boundary and routing scope
+
+```text
+World A
+├─ City 1
+│  ├─ Department X
+│  │  └─ John
+│  └─ Department Y
+│     └─ lem_a
+└─ City 2
+   └─ Department Z
+      └─ lem_b
+
+Allowed:
+- John -> lem_a
+- John -> lem_b
+
+Not allowed:
+- World A -> World B
+```
+
+---
+
+# 6. Consequences
+
+## Positive
+
+- Simple mental model: create by type, continue by instance.
+- Supports multiple concurrent workers of the same type naturally.
+- Avoids hidden reuse behavior in v1.
+- Keeps liveness and placement inside the runtime where they belong.
+- Preserves iterative delegated workflows through idle instances.
+- Aligns with OTP process lifecycle and supervision.
+- Keeps World as the hard isolation boundary.
+- Limits peer communication through explicit policy.
+
+## Negative
+
+- Callers must handle delivery failure when an idle instance expires before follow-up work arrives; this requires explicit failure handling in coordinator logic.
+- Context reconstruction remains necessary on every LLM invocation because the runtime does not maintain implicit model state.
+- Without automatic rehydration in v1, an expired instance cannot be transparently resumed; the caller must choose how to handle the gap.
+- Default spawn-new semantics may increase instance count if coordinators do not dismiss workers after they are no longer needed.
+
+## Mitigations
+
+- Delivery failure return values (`{:error, :instance_not_found}`, `{:error, :instance_unavailable}`) are distinct and actionable, giving coordinator logic a clear signal to spawn a replacement.
+- Idle TTL is configurable per Lemming type; long-running research tasks can use a longer TTL than short-lived classification tasks, reducing premature eviction.
+- The minimal lifecycle contract (`spawn`, `send`, `dismiss`) makes explicit dismissal straightforward to add to coordinator logic; the intended pattern is spawn → use → dismiss, not spawn and forget.
+
+---
+
+# 7. Non-Goals
+
+This ADR intentionally does not define:
+
+- cross-City routing; v1 routing is City-local only (see section 4.8 and Future Extensions)
+- snapshot storage backend and retention policy (ADR-0008)
+- automatic instance rehydration after eviction
+- scheduling, queueing, or mailbox prioritization
+- load balancing heuristics across nodes
+
+---
+
+# 8. Future Extensions
+
+- Distributed registry with cross-City routing for Worlds that span multiple City nodes.
+- Automatic instance rehydration from a persisted snapshot when follow-up work arrives after eviction.
+- Mailbox prioritization and work-stealing between idle instances.
+- Load balancing heuristics for spawning instances on less-loaded City nodes.
+
+---
+
+# 9. Rationale
+
+The two-tier addressing model reflects a fundamental distinction in agent workflows: the intent to create new work (spawn by type) versus the intent to continue existing work (address by instance). Conflating these into a single addressing form would either force callers to manage instance uniqueness manually or hide implicit reuse decisions in the runtime.
+
+Keeping the registry lightweight — routing metadata only, no business state — is the boundary that prevents the registry from becoming a bottleneck. The working context belongs in the ephemeral store (ADR-0008), where it has its own TTL, compaction, and persistence semantics. A registry that stores context would couple routing availability to context persistence health, creating failure cascades where none are necessary.

--- a/docs/adr/0008-lemming-persistence-model.md
+++ b/docs/adr/0008-lemming-persistence-model.md
@@ -1,0 +1,434 @@
+# ADR-0008 — Lemming Persistence Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+In LemmingsOS, every Lemming instance runs as an OTP process. Instances maintain a structured working context while executing tasks, coordinating with other agents, invoking tools, and interacting with users.
+
+However, not all runtime state should be persisted the same way. The system must balance:
+
+- resilience and crash recovery
+- security (especially around secrets)
+- resource efficiency
+- operational simplicity for self-hosted deployments
+
+Additionally, LemmingsOS assumes many deployments will run on simple self-hosted environments (single VPS, Docker, etc.), so persistence and secret management must remain lightweight while still providing reasonable safety guarantees.
+
+This ADR defines how Lemming runtime state is stored, when persistence occurs, and how ephemeral versus durable data is handled.
+
+---
+
+# 2. Decision Drivers
+
+1. **OTP crash must not lose meaningful execution progress** — Lemming instances may run for extended periods accumulating task context, tool results, and partial outputs. A crash must allow the runtime to resume from the last valid checkpoint, not restart the task entirely.
+
+2. **Secrets must never appear in any persistence layer** — The attack surface from a storage breach must be bounded. Secret material resolved during tool execution must not leak into checkpoints, context snapshots, audit logs, or any persistence store.
+
+3. **Self-hosted deployments must not require distributed databases** — The persistence model must work correctly on a single-node VPS without Mnesia clustering, distributed ETS replication, or external storage services. Operational simplicity is a first-class constraint.
+
+4. **Durable conversational state and ephemeral working state have different lifetimes** — Human-visible conversation history must survive restarts and be queryable from the control plane. Internal agent working state (tool outputs, partial reasoning, draft summaries) is short-lived and crash-recoverable with lower durability guarantees.
+
+5. **Context compaction must be decoupled from the Lemming instance** — The instance must not pause its own execution to compact its context. Compaction is infrastructure work that should run on dedicated workers at the City level.
+
+6. **The context structure is the integration contract with the Model Runtime** — The `context` sub-map field semantics must be stable because they drive prompt assembly in ADR-0019. Changes to field names or semantics require coordinated updates across the persistence model and the Model Runtime.
+
+---
+
+# 3. Considered Options
+
+## Option A — File-based disk storage for runtime state
+
+Lemming working context, instance snapshots, and checkpoints are written to local files on the host filesystem, optionally encrypted.
+
+**Pros:**
+- survives process crashes and node restarts without a separate in-memory store
+- no external database dependency; suitable for minimal single-node setups
+
+**Cons:**
+- a self-hosted VPS with weak filesystem permissions exposes runtime state to any process or user with host access; operators running LemmingsOS without deep security hardening would be unaware of the exposure
+- file I/O serialization adds latency to every context update during active execution
+- TTL enforcement requires a separate cleanup process; stale files accumulate silently if cleanup fails
+- file locking and concurrent access from multiple instances is error-prone
+
+Rejected. Disk-based storage for runtime state creates unacceptable exposure on self-hosted deployments where filesystem security cannot be assumed. Active Lemming state does not need disk at all; ETS is sufficient.
+
+---
+
+## Option B — ETS-only for all ephemeral state (no disk persistence)
+
+All working context for both active and idle Lemmings lives exclusively in ETS. No DETS, no disk writes for any runtime state.
+
+**Pros:**
+- no disk exposure; runtime state is never written to the filesystem
+- ETS reads and writes are fast with no I/O overhead
+- maximum simplicity for the ephemeral state layer
+
+**Cons:**
+- a node restart evicts all ETS tables, including the working context of idle Lemmings; follow-up work arriving after a restart cannot find the instance
+- idle Lemmings that have not yet been explicitly dismissed lose all working context on restart
+- the restartability guarantee in ADR-0004 cannot be fulfilled for idle instances without some form of crash-surviving storage
+
+ETS-only is the correct model for **active, running** Lemmings — they do not need disk. However, it is insufficient for **idle/sleeping** Lemmings that must survive a node restart and be rehydrated to accept follow-up work. A lightweight disk-backed store is needed exclusively for that case.
+
+Partially accepted for active state; rejected as the complete solution.
+
+---
+
+## Option C — Mnesia for distributed in-memory persistence
+
+Use Mnesia as the in-memory store with optional disk persistence. Mnesia provides BEAM-native distributed tables with replication across nodes.
+
+**Pros:**
+- BEAM-native; no external dependency
+- supports both in-memory and disk-backed tables
+- provides distributed replication across City nodes without additional infrastructure
+
+**Cons:**
+- Mnesia clustering is operationally complex to configure correctly, particularly on self-hosted single-node deployments
+- Mnesia split-brain scenarios require careful handling; the complexity is disproportionate to the v1 deployment target
+- schema migrations require careful coordination across clustered nodes
+
+Rejected. Mnesia's operational complexity is disproportionate to the self-hosted deployment target in v1. Other databases were also evaluated and do not add meaningful benefit over the chosen model — the same reasoning that led to rejecting a time-series database for audit events (ADR-0018) applies here: adding a specialized store for a concern that fits an existing tier is not justified.
+
+---
+
+## Option D — World-level Postgres + ETS (active state) + DETS (idle snapshots only) (chosen)
+
+A single Postgres instance scoped to the World stores durable conversational state. ETS handles all working context for active running Lemmings (no disk). DETS is used exclusively for idle/sleeping Lemming snapshots to enable rehydration after a node restart. Secrets are never persisted in any tier.
+
+**Pros:**
+- active Lemming state never touches disk; no filesystem exposure during execution
+- idle instance rehydration is supported with minimal disk writes (snapshot only at idle transition)
+- a single World-level Postgres instance is operationally simple for self-hosted deployments
+- write amplification is bounded: frequent context updates during active execution stay in ETS; Postgres absorbs only lifecycle-boundary writes
+
+**Cons:**
+- DETS requires TTL enforcement to prevent unbounded disk growth from orphaned idle snapshots
+- rehydration is City-local; if the City node is unavailable, idle snapshots on that node cannot be accessed
+- the ETS/DETS distinction adds implementation surface that must be maintained correctly
+
+Chosen. ETS provides the right semantics for active state (fast, no disk exposure). DETS is the minimum necessary addition to support idle rehydration without introducing the security concerns of general file-based storage.
+
+---
+
+# 4. Decision
+
+The persistence model separates **durable state**, **ephemeral runtime state**, and **secret material** into distinct tiers with different durability guarantees, access patterns, and security properties.
+
+Active Lemming state never requires disk. ETS is sufficient for all in-execution working context. DETS is reserved exclusively for idle instance snapshots. A single World-level Postgres instance stores durable conversational state accessible across Cities.
+
+---
+
+# 5. Durable State (Postgres)
+
+LemmingsOS uses a **single Postgres instance scoped to the World**. There is one database per World, shared across all Cities in that World. Cities do not maintain separate Postgres instances.
+
+Postgres stores only **durable conversational and case state**, similar to a chat history window.
+
+Durable state includes:
+
+- human messages
+- system responses visible to the user
+- promoted or accepted results
+- references to artifacts
+- case status
+- metadata required to resume the conversation
+
+Durable state **must respect the effective token budget** derived from:
+
+- model context window
+- world policy
+- city policy
+- department policy
+- lemming type policy
+
+The runtime enforces these limits before persisting or sending prompts.
+
+Postgres **must never store**:
+
+- internal agent thoughts
+- discarded branches
+- raw tool outputs not promoted to the main thread
+- secrets
+
+---
+
+# 6. Ephemeral Runtime State (ETS / DETS)
+
+Ephemeral state is split into two distinct tiers with different scopes and disk exposure.
+
+## Active State — ETS
+
+All working context for a **running Lemming** lives exclusively in ETS.
+
+- no disk writes during active execution
+- fast concurrent reads and writes
+- evicted automatically when the process terminates
+
+Active state includes:
+
+- working context
+- recent messages
+- in-progress tool results
+- partial outputs
+- instance coordination metadata
+
+Active state must **not contain secret material**.
+
+## Idle Snapshot — DETS
+
+When a Lemming transitions to **idle or sleeping**, the runtime writes a compact snapshot to DETS. This snapshot is the only point at which runtime state touches disk.
+
+Purpose: enable rehydration if the node restarts before the Lemming is explicitly dismissed.
+
+DETS snapshots:
+
+- are written once at idle transition
+- are governed by TTL with activity renewal
+- are deleted on explicit dismissal or TTL expiry
+- must **not contain secret material**
+
+Active running Lemmings do not use DETS. DETS is exclusively the idle-rehydration store.
+
+**Container deployment constraint:** Because OCI containers destroy their filesystem on restart by default, the DETS data directory must be backed by a **persistent volume mount** in all container deployments. Without a persistent volume, idle snapshots are lost on container restart and the rehydration guarantee cannot be fulfilled. This is a mandatory deployment requirement defined in ADR-0022.
+
+---
+
+# 7. Checkpoints
+
+The runtime writes DETS snapshots at lifecycle boundaries, not continuously.
+
+Checkpoint triggers:
+
+1. when an instance transitions to `idle` or `paused`
+2. before instance termination (if instance was idle)
+
+Active running Lemmings do not checkpoint to DETS. Their working state lives in ETS and is considered recoverable-at-best. If a running Lemming crashes, the supervisor restarts the process and the runtime attempts rehydration from the most recent idle snapshot if one exists, or from the durable Postgres record if no snapshot is available.
+
+---
+
+# 8. Context Structure
+
+The runtime context is a structured map.
+
+Example structure:
+
+```
+%{
+  instance_ref: ...,
+  status: ...,
+  parent_instance_ref: ...,
+  updated_at: ...,
+  expires_at: ...,
+  context: %{
+    system_prompt: ...,
+    task_goal: ...,
+    instructions: ...,
+    constraints: ...,
+    working_summary: ...,
+    tool_results: ...,
+    artifacts: ...,
+    recent_messages: ...,
+    last_output: ...
+  }
+}
+```
+
+The `context` sub-map is the **contract between the Lemming and the Model Runtime**
+(ADR-0019). The Lemming never constructs raw prompt strings. The Model Runtime's
+prompt assembler reads this structure and serializes it into a provider-compatible
+message sequence at inference time. The field semantics are:
+
+- `system_prompt` / `instructions` / `constraints` → system message
+- `task_goal` → injected into the first user turn
+- `recent_messages` → prior conversation turns
+- `working_summary` → condensed context after compaction
+- `tool_results` → tool result turns in provider format
+- `last_output` → assistant continuation turn if applicable
+
+Compaction (section 9) rewrites this structure in-place when token limits approach.
+After compaction, the assembled prompt remains within the effective token budget
+derived from the model policy resolved by the Model Runtime.
+
+The **registry stores only instance references** used for routing and presence.
+
+Runtime state lives exclusively in the ephemeral store.
+
+---
+
+# 9. Context Compaction
+
+When context approaches token limits, the runtime triggers compaction.
+
+Compaction is performed by **city-level infrastructure workers**, not by the Lemming itself.
+
+Typical compaction order:
+
+1. recent_messages
+2. tool_results
+3. working_summary rewritten
+4. artifacts referenced rather than embedded
+
+If compaction fails, a **fallback pool of compaction workers** is tried in priority order.
+
+If all workers fail, the operation returns an error.
+
+---
+
+# 10. Rehydration
+
+Instances may be rehydrated from ephemeral checkpoints.
+
+Rules:
+
+- rehydration occurs **only in the original City and Department**
+- no migration between cities or departments
+
+If the original environment is unavailable, rehydration fails.
+
+Sub-lemmings are **not automatically revived** when the parent instance rehydrates.
+
+They may rehydrate independently if their state exists.
+
+---
+
+# 11. Worker Failure Semantics
+
+Sub-lemming failure affects only the branch of work where it was created.
+
+The coordinating instance decides whether to:
+
+- retry
+- create a new worker
+- continue with partial results
+- request human input
+
+---
+
+# 12. Ephemeral State Lifecycle
+
+Ephemeral runtime state uses TTL with activity renewal.
+
+Behavior:
+
+- each context update refreshes TTL
+- runtime attempts best-effort cleanup on case completion
+- TTL guarantees eventual expiration even if cleanup fails
+
+---
+
+# 13. Secret Management
+
+Secrets must **never appear in Lemming context or persistence layers**.
+
+This includes:
+
+- Postgres
+- ETS
+- DETS
+- checkpoints
+- audit logs
+
+Instead, secrets are resolved at tool execution time.
+
+The system provides a **City Secret Bank** abstraction.
+
+### Secret Bank Properties
+
+- exists per City
+- stores sensitive credentials
+- accessed only by tools
+- governed by policy inheritance
+
+Hierarchy:
+
+```
+World
+  → City
+    → Department
+      → Tool policy
+```
+
+Lemmings only reference connection identifiers such as:
+
+```
+connection_ref = "github_prod"
+```
+
+The runtime resolves the actual secret when the tool executes.
+
+---
+
+# 14. Secret Storage (v1)
+
+Secret storage details are intentionally minimal in this ADR and are defined in ADR-0009.
+
+Version 1 supports environment variables as the primary self-hosted secret provider. File-based secret storage is not supported in v1; writing credentials to disk on a self-hosted VPS without strong filesystem security would undermine the protection that the secret isolation model provides.
+
+Full secret storage implementation is defined in ADR-0009.
+
+---
+
+# 15. Consequences
+
+## Positive
+
+- Active Lemming execution never touches disk; no filesystem exposure during normal operation.
+- DETS disk writes are minimal and bounded: one snapshot per idle transition, deleted on dismissal or TTL expiry.
+- A single World-level Postgres instance is operationally simple for self-hosted deployments; there is no per-City database to provision or maintain.
+- Secrets are structurally excluded from every persistence tier, making the storage breach attack surface significantly smaller regardless of which tier is compromised.
+- The `context` sub-map contract is stable and explicit, making the integration boundary with the Model Runtime (ADR-0019) auditable and testable independently.
+
+## Negative
+
+- DETS requires TTL enforcement to prevent orphaned idle snapshots from accumulating on disk indefinitely.
+- Rehydration is City-local; idle snapshots live on the City node's filesystem, so a node failure means those snapshots are inaccessible until the node recovers.
+- Running Lemmings that crash mid-execution can only be recovered to the last idle snapshot, not to the exact point of failure; work accumulated since the last idle transition may be lost.
+- Container deployments require a persistent volume mount for the DETS data directory. Operators who fail to configure this volume will silently lose idle snapshots on container restart; there is no error at startup.
+
+## Mitigations
+
+- DETS snapshots carry a hard `expires_at` field. Even if the dismissal cleanup fails, the TTL guarantees eventual expiration and disk reclaim.
+- The crash-recovery gap for running Lemmings is bounded by how frequently they transition through `idle`. The runtime surfacing `{:error, :recovery_required}` gives coordinator logic a deterministic signal to spawn a fresh instance or request operator input.
+- The City-local rehydration constraint is a documented v1 scope decision, not an oversight. The rehydration failure path is a structured error, not a silent loss.
+
+---
+
+# 16. Non-Goals
+
+This ADR intentionally does not define:
+
+- exact secret storage implementation (ADR-0009)
+- context compaction algorithm details
+- external secret manager integration (future extension)
+- encrypted DETS snapshots
+- distributed checkpoint storage across City nodes
+- vector / RAG database for semantic search or embedding storage (future ADR)
+
+---
+
+# 17. Future Extensions
+
+- External secret manager integration (Infisical, HashiCorp Vault, cloud provider secret managers).
+- Encrypted ephemeral storage for DETS snapshots, reducing the impact of host filesystem compromise.
+- Distributed checkpoint storage across multiple City nodes to enable cross-City rehydration.
+- Automated compaction policies triggered by configurable token budget thresholds.
+
+---
+
+# 18. Rationale
+
+The ETS/DETS distinction is not an arbitrary split — it reflects a precise security boundary. Active Lemming state never needs to touch disk. It changes too frequently, contains too much intermediate data, and exists only for the duration of a running task. ETS provides the right semantics: fast, in-memory, evicted automatically when the process ends. Writing active state to disk on a self-hosted VPS with weak filesystem permissions would expose intermediate reasoning, tool outputs, and partial results to any process or user with host access, most of whom would have no awareness that the files exist.
+
+DETS is the minimum necessary exception: an idle Lemming needs exactly one thing to survive a node restart — a compact snapshot of its context so it can be rehydrated when follow-up work arrives. That is a bounded, infrequent write at a well-defined lifecycle boundary, not a continuous stream.
+
+The single World-level Postgres follows from operational reality. Self-hosted operators running LemmingsOS on a VPS are not running multiple database instances. One Postgres per World is the right default — it is simple to provision, simple to back up, and contains only the state that needs durability: conversation history that a user can see.
+
+Secrets must be structurally excluded from persistence, not just excluded by convention. By defining the rule at the persistence model level — no tier stores secrets, full stop — the attack surface is bounded regardless of which tier is breached. A tool that accidentally logs a secret is a bug in the tool; a secret that legitimately appears in Lemming context or a DETS snapshot is a design violation.
+
+The decision to delegate compaction to City-level workers rather than the Lemming itself follows the same separation-of-concerns principle as the execution model (ADR-0004): the GenServer is the execution coordinator, not the infrastructure. Keeping the Lemming's process state minimal and its responsibilities narrowly scoped makes each component independently testable and independently replaceable.

--- a/docs/adr/0009-secret-bank-hierarchical-secret-management.md
+++ b/docs/adr/0009-secret-bank-hierarchical-secret-management.md
@@ -1,0 +1,412 @@
+# ADR-0009 — Secret Bank (Hierarchical Secret Management)
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+## Context
+
+LemmingsOS needs a secure mechanism for storing and resolving credentials required by Tools (for example API tokens, service credentials, or integration keys).
+
+Because the runtime supports a hierarchical architecture:
+
+```
+World
+  └ City
+      └ Department
+```
+
+secret storage must support scoped resolution so that different environments or departments can override credentials while still allowing shared defaults.
+
+The system must also ensure that:
+
+- Tools cannot request arbitrary secrets
+- Lemmings never see raw secrets
+- secrets are injected only inside the Tool Runtime
+- secrets are never persisted in agent context, logs, or checkpoints
+
+This design must remain simple enough for a self‑hosted open source deployment while allowing future expansion to external secret managers.
+
+---
+
+# Decision
+
+LemmingsOS will implement a **Secret Bank subsystem** responsible for storing and resolving runtime secrets used by Tools.
+
+The Bank stores **logical secret keys** and resolves them according to a **hierarchical scope model**.
+
+Scopes:
+
+```
+Department → City → World
+```
+
+When resolving a secret, the runtime always prefers the **nearest scope**.
+
+Example:
+
+```
+resolve_secret("github.token")
+
+Lookup order:
+1. Department
+2. City
+3. World
+```
+
+The first matching secret found is returned to the Tool Runtime.
+
+---
+
+# Secret Keys
+
+Secrets are stored in the Bank using **logical keys**, not environment variable names.
+
+Examples:
+
+```
+github.token
+openai.api_key
+aws.access_key_id
+aws.secret_access_key
+```
+
+Each key may exist at any scope.
+
+Example:
+
+```
+World
+  github.token = <org default>
+
+City
+  github.token = <region bot>
+
+Department
+  github.token = <team credential>
+```
+
+Resolution precedence ensures local overrides are possible without duplicating configuration globally.
+
+---
+
+# Tool Secret Requirements
+
+Tools declare the logical secrets they require as part of their contract.
+
+Example:
+
+```
+tool: github_issue_creator
+required_secrets:
+  - github.token
+```
+
+These requirement names are **logical identifiers**, not references to concrete storage keys.
+
+Tools therefore remain generic and reusable across deployments.
+
+---
+
+# Secret Bindings
+
+Concrete secret resolution is controlled by **Tool Policy**, not by the Tool itself.
+
+Each Tool configuration may define **secret bindings** mapping logical requirements to concrete Bank keys.
+
+Example:
+
+```
+secret_bindings:
+  github.token: secrets.github.company
+```
+
+This means:
+
+```
+Tool requires: github.token
+Policy binds to: secrets.github.company
+Bank returns value stored under that key
+```
+
+This ensures:
+
+- Tools cannot request arbitrary Bank secrets
+- credential selection is controlled by runtime configuration
+- multiple Tools may use different credentials for the same provider
+
+Example:
+
+```
+Tool: github_issue_creator
+secret_bindings:
+  github.token: secrets.github.company
+
+Tool: github_repo_reader
+secret_bindings:
+  github.token: secrets.github.personal
+```
+
+---
+
+# Runtime Resolution Flow
+
+Execution sequence:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Tool contract declares required secrets
+   ↓
+Tool policy resolves secret bindings
+   ↓
+Bank resolves secret key by scope
+   ↓
+Secret injected into Tool Runtime
+```
+
+Secrets are **never exposed to the Lemming** and must never appear in:
+
+- agent context
+- logs
+- checkpoints
+- persisted agent state
+
+---
+
+# Scope Resolution
+
+Secret lookup follows nearest‑scope precedence:
+
+```
+Department
+  → City
+      → World
+```
+
+This allows local overrides without duplicating configuration globally.
+
+Example:
+
+```
+World
+  github.token = org_default
+
+Department
+  github.token = client_x_token
+```
+
+Tools executed inside that Department will automatically use the department credential.
+
+## Intentional asymmetry with policy evaluation
+
+Secret resolution and tool policy evaluation (ADR-0012) intentionally use **opposite precedence rules**. This is not an inconsistency — it reflects the different nature of each concern.
+
+**Secrets resolve upward (most specific wins):**
+Secret resolution is a *definition lookup*. The runtime searches from the most specific scope upward until it finds a binding. A Department-level secret overrides a City-level secret for the same key because the Department is explicitly providing a more specific credential. This is the standard override model: local configuration overrides shared defaults.
+
+**Policy evaluates downward (deny-dominant):**
+Policy evaluation is *authorization enforcement*. A deny rule at any level in the hierarchy is final and cannot be overridden by a more specific level below it. A Department cannot grant a tool that World has denied. If "most specific wins" applied to denies, any Department admin could escape platform-level restrictions — which would defeat the purpose of hierarchical governance.
+
+In summary:
+- Most specific wins → appropriate for *finding the right credential*
+- Most restrictive wins → appropriate for *enforcing security constraints*
+
+---
+
+# Responsibilities
+
+The Secret Bank is responsible for:
+
+- storing encrypted secret values
+- resolving scoped secret keys
+- returning secret values only to the Tool Runtime
+
+The Bank is **not responsible for**:
+
+- administrator authentication
+- UI access control
+- platform login credentials
+
+Administrative authentication belongs to a separate control‑plane subsystem defined in ADR-0010.
+
+---
+
+# Secret Encryption
+
+All secret values stored in the Bank are encrypted at rest.
+
+Encryption uses a system master key provided through environment configuration.
+
+Example:
+
+```
+LEMMINGS_MASTER_KEY
+```
+
+The master key is never stored in the database.
+
+Secrets are encrypted before persistence and decrypted only when injected into the Tool Runtime.
+
+The v1 encryption algorithm is **XChaCha20-Poly1305**.
+
+Rationale for this choice:
+
+- Provides authenticated encryption (confidentiality + integrity)
+- Uses extended nonces (192-bit) which significantly reduces the risk of nonce reuse errors in distributed systems
+- Well supported by modern cryptographic libraries (libsodium and Rust/Go/Elixir bindings)
+- Considered state-of-the-art for application-level secret encryption
+- Simpler operational model compared to schemes requiring strict nonce management
+
+If the master key is lost or replaced without a coordinated migration process, previously stored secrets become unreadable and cannot be recovered.
+
+For that reason, installation and operational documentation must clearly explain:
+
+- how to generate the master key
+- how to store it securely
+- how to back it up safely
+- the operational consequences of losing or changing it
+
+---
+
+# Security Guarantees
+
+The system guarantees that:
+
+- Lemmings never have direct access to secret values
+- Tools can only access secrets declared in their contract
+- policies control which concrete credentials a Tool receives
+- secrets are resolved only during Tool execution
+
+---
+
+# Audit and Change Tracking
+
+Secret management must include **auditability from day one**.
+
+The system records immutable **audit events** using a generic append‑only audit log shared by the platform.
+
+Each event contains:
+
+- event type
+- world
+- city
+- department
+- tool (if applicable)
+- contextual text / description
+- timestamp
+
+The log is **append‑only and immutable**.
+
+Example audit record:
+
+```
+secret, m1, c1, d1, t1, access gh_token, inserted_at
+```
+
+Typical secret‑related events include:
+
+- secret created
+- secret replaced
+- secret accessed by Tool Runtime
+
+Audit logs must **never include the secret value itself**.
+
+The goal of auditing is operational traceability, not secret recovery.
+
+---
+
+# Secret Immutability
+
+Secret values are treated as **write‑only material**.
+
+Once stored:
+
+- the raw value cannot be retrieved through the UI
+- the value cannot be displayed again
+- the value cannot be exported
+
+Updating a secret replaces the stored value but does not expose the previous one.
+
+This model mirrors common operational patterns used by platforms such as Fly.io, where secrets are write‑once and not readable after creation.
+
+---
+
+# Connection Objects (Day‑0 Support)
+
+Although v1 secret storage operates on logical secret keys, the Bank may also support **Connection Objects** from the start.
+
+A Connection Object groups configuration and secret references required to access an external system.
+
+Example:
+
+```
+connection: github_company
+
+config:
+  base_url: https://api.github.com
+
+secrets:
+  token: github.token
+```
+
+Tools may reference a connection instead of resolving multiple individual secrets.
+
+Connection objects provide:
+
+- cleaner configuration for complex integrations
+- grouping of related credentials
+- easier reuse across tools
+
+Connection objects still rely on the same underlying Bank resolution model and secret bindings.
+
+---
+
+# Consequences
+
+## Positive
+
+- Lemmings and runtime state are structurally isolated from secret values; a
+  storage breach of Postgres, ETS, or DETS does not expose credentials.
+- Secret resolution through a single Bank abstraction means policy inheritance
+  and audit coverage apply consistently to every credential, regardless of the
+  tool consuming it.
+- Connection Objects group related credentials behind a logical name; tool
+  authors reference `connection_ref = "github_prod"` rather than managing
+  individual secret keys.
+- The write-only immutability model prevents accidental secret exposure through
+  the control plane UI or API.
+
+## Negative
+
+- Loss of the master key renders all stored secrets permanently unreadable;
+  there is no recovery path without the key.
+- v1 secret storage is limited to environment-variable-backed values; operators
+  who need secret rotation, fine-grained TTLs, or audit trails beyond the
+  platform's own log must integrate an external manager as a future extension.
+- The Bank is City-local in v1; there is no cross-City secret replication.
+  If a City node is unavailable, its secrets are inaccessible until the node
+  recovers.
+
+## Mitigations
+
+- The master key must be treated as a critical operational secret: generated
+  securely, stored in a separate secure location (not the same system as the
+  database), and backed up. Installation documentation must make the recovery
+  consequences explicit.
+- The environment-variable storage model is acceptable for v1 self-hosted
+  deployments. External secret manager integration (Vault, Infisical, cloud KMS)
+  is a defined Future Extension and the Bank abstraction is designed to support
+  it without changing the tool-facing API.
+
+---
+
+# Future Extensions
+
+Possible future capabilities include:
+
+- external secret manager integration (Vault, cloud KMS, etc.)
+- automatic secret rotation
+

--- a/docs/adr/0010-control-plane-authentication-admin-access.md
+++ b/docs/adr/0010-control-plane-authentication-admin-access.md
@@ -1,0 +1,529 @@
+# ADR-0010 — Control Plane Authentication and Admin Access
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# Context
+
+LemmingsOS exposes a control plane used by human operators to manage the runtime.
+
+The control plane includes the UI and APIs used to:
+
+- create and manage Worlds, Cities, Departments, and Lemmings
+- configure Tool policies
+- manage connections and secrets
+- inspect runtime state
+- operate the system
+
+Because LemmingsOS is designed to be self-hosted and may run on a publicly reachable VPS, the control plane must require authentication.
+
+Without authentication, an exposed instance could allow unauthorized users to:
+
+- spawn or terminate Lemmings
+- execute tools against external systems
+- modify runtime policy
+- inspect internal system state
+
+The architecture separates two different security domains:
+
+Control Plane
+: human operator authentication and administrative access
+
+Runtime Plane
+: Lemmings, tools, secret resolution, and agent execution
+
+The Secret Bank subsystem manages runtime credentials for tools and must **not** be used for administrator authentication.
+
+This ADR also recognizes that LemmingsOS is more valuable than a purely personal single-user tool. For small teams, the system benefits significantly from allowing multiple authenticated users with access limited by hierarchy level.
+
+---
+
+# Decision Drivers
+
+1. **Team viability** — Single-admin access creates poor traceability and prevents shared team operation. Multiple authenticated users with distinct roles must be first-class from v1.
+
+2. **Hierarchy alignment** — Access scope must mirror the World → City → Department structure governing every other runtime concern. A separate model would create inconsistency between the runtime plane and the control plane.
+
+3. **Self-hosted threat model** — The control plane may be exposed on a publicly reachable host. Authentication must be enforced from first boot with no open default.
+
+4. **Separation of planes** — Control-plane user credentials must remain entirely separate from runtime credentials managed by the Secret Bank. The same subsystem must not serve both concerns.
+
+5. **Proportional complexity** — v1 must be operable by a small team without deep security expertise. Fully configurable RBAC would add significant implementation and operational burden with marginal early benefit.
+
+6. **Bootstrap safety** — A fresh installation must not accept connections before the first administrator account exists. The system must enter a constrained bootstrap mode automatically.
+
+---
+
+# Considered Options
+
+## Option A — Single admin account only
+
+One hardcoded admin account. No multi-user support, no scope restrictions.
+
+**Pros:**
+
+- simplest possible implementation
+- no user management surface to secure
+
+**Cons:**
+
+- all control-plane actions are attributed to a single account, destroying per-actor traceability
+- unsuitable for any team environment; multiple operators must share one password
+- the audit log becomes meaningless for accountability when every event has the same actor
+
+Rejected. Shared credentials make the audit model defined in ADR-0018 operationally useless for forensic reconstruction.
+
+---
+
+## Option B — Full configurable RBAC
+
+User-defined roles, custom permission sets, and a policy editor in the control plane UI.
+
+**Pros:**
+
+- maximum flexibility for any organizational structure
+- well-understood enterprise pattern
+
+**Cons:**
+
+- substantial implementation complexity disproportionate to v1 deployment scale
+- policy misconfiguration risk increases when operators can define arbitrary permission matrices
+- most self-hosted deployments will never use the flexibility
+- authorization logic no longer mirrors the runtime hierarchy, creating a separate mental model to maintain
+
+Rejected. Implementation and operational complexity are disproportionate to the realistic scale of v1 deployments.
+
+---
+
+## Option C — Small-team scoped access model (chosen)
+
+Multiple users with fixed built-in roles (admin, operator, viewer) scoped to World, City, or Department.
+
+**Pros:**
+
+- multi-user support enables team deployments with per-actor audit trails
+- fixed roles keep the permission model easy to audit and reason about
+- scope assignments mirror the existing hierarchy — an operator managing a City understands immediately what they can and cannot access
+- significantly simpler to implement and maintain than configurable RBAC
+
+**Cons:**
+
+- fixed roles cannot express all organizational permission structures
+- no per-user exceptions or action-level permissions in v1
+
+Chosen. Sufficient for the target use case and aligned with the system's existing hierarchical design principles.
+
+---
+
+# Decision
+
+Version 1 of LemmingsOS implements a **small-team scoped access model**.
+
+The system supports:
+
+- multiple authenticated users
+- password-based authentication
+- fixed built-in roles
+- scope-limited access aligned with the runtime hierarchy
+- hashed password storage
+- authenticated UI sessions
+- append-only audit events for administrative and operational actions
+
+Built-in roles for v1:
+
+- `admin`
+- `operator`
+- `viewer`
+
+Each non-admin access assignment is scoped to one hierarchy level:
+
+- `world`
+- `city`
+- `department`
+
+Permissions are **static and code-defined** in v1. The system does not implement configurable RBAC policies for individual users.
+
+The effective access model is therefore:
+
+```text
+(role, scope_type, scope_id)
+```
+
+Examples:
+
+- `admin, world, world_main`
+- `operator, city, salvador`
+- `viewer, department, customer_support`
+
+---
+
+# Access Model
+
+## Role semantics
+
+### Admin
+
+Admin users may:
+
+- manage users and assignments
+- install and enable tool packages
+- configure platform availability
+- manage secrets and connections
+- manage policies
+- operate within their assigned scope and all descendants
+
+In most deployments, admin will be assigned at world scope.
+
+### Operator
+
+Operators may perform mutating operational actions within their assigned scope and all descendants.
+
+Examples:
+
+- operator assigned to a `city` may create, update, and operate Departments and Lemmings in that city
+- operator assigned to a `department` may create and operate Lemmings in that department
+
+Operators may use only capabilities already made available by admins for that scope.
+
+Operators may not:
+
+- manage users
+- install packages
+- change platform-wide authentication settings
+- access or manage secrets unless explicitly allowed by future policy work
+
+### Viewer
+
+Viewers have read-only access within their assigned scope and all descendants.
+
+They may inspect:
+
+- runtime state
+- status
+- logs and audit information permitted by the UI
+- results and artifacts permitted by the UI
+
+They may not perform mutating actions.
+
+## Scope inheritance
+
+Scope access flows downward.
+
+A user assigned to a level may act on that level and every descendant level.
+
+Examples:
+
+- a `viewer` at `world` scope can view the full world
+- an `operator` at `city` scope can operate that city and all departments under it
+- an `operator` at `department` scope can operate only that department
+
+This keeps the authorization model aligned with the core LemmingsOS hierarchy:
+
+```text
+World → City → Department → Lemming
+```
+
+---
+
+# Bootstrap Flow (First Access)
+
+A fresh installation contains no users.
+
+When the system detects that no admin user exists, the UI enters **bootstrap mode**.
+
+Bootstrap mode exposes only the initial administrator creation screen.
+
+All other control plane endpoints remain unavailable.
+
+Bootstrap flow:
+
+```text
+User opens UI
+      ↓
+System detects: no admin configured
+      ↓
+Bootstrap mode enabled
+      ↓
+First user creates admin account and password
+      ↓
+Password hashed and stored
+      ↓
+Bootstrap mode permanently disabled
+```
+
+After the first admin account is created:
+
+- bootstrap endpoints are disabled
+- authentication is required for all control plane operations
+- all additional users must be created by an authenticated admin
+
+Re-entering bootstrap mode requires explicit operator action, such as a database reset or dedicated recovery workflow.
+
+---
+
+# Password Storage
+
+User passwords are stored **only as hashes**.
+
+Plaintext passwords are never stored.
+
+The recommended hashing algorithm is:
+
+**Argon2id**
+
+Reasons:
+
+- modern password hashing standard
+- memory-hard algorithm resistant to GPU attacks
+- widely supported in Elixir ecosystems
+
+Implementation guidelines:
+
+- use a well maintained library such as `argon2_elixir`
+- include a unique salt per password
+- store algorithm parameters with the hash
+
+Example schema shape:
+
+```text
+users
+  id
+  email
+  password_hash
+  inserted_at
+  updated_at
+
+user_assignments
+  id
+  user_id
+  role
+  scope_type
+  scope_id
+  inserted_at
+```
+
+Password hashes are never exposed via APIs or logs.
+
+---
+
+# Session Security
+
+Administrative and operational actions require an authenticated session.
+
+Typical flow:
+
+```text
+User login
+   ↓
+Password verification
+   ↓
+Session created
+   ↓
+Session cookie issued
+   ↓
+Subsequent UI/API requests require valid session
+```
+
+Session management should follow Phoenix security best practices:
+
+- signed and encrypted cookies
+- CSRF protection for form actions
+- session invalidation on logout
+- session renewal after login
+
+Session expiration may be configurable.
+
+---
+
+# Password Rotation Policy
+
+The system may optionally enforce password rotation.
+
+Configuration example:
+
+```text
+auth:
+  password_max_age_days: 180
+```
+
+If the password exceeds the configured age:
+
+- the user must change the password before performing further control-plane actions
+
+This feature is optional and may be disabled by default for small self-hosted installations.
+
+---
+
+# Admin-Controlled Platform Availability
+
+Authentication and authorization are distinct from platform capability publication.
+
+Admins control what is available in the system at three separate levels.
+
+## 1. Platform availability
+
+Admins may:
+
+- install tool packages
+- register tools
+- enable or disable tools globally
+- manage connections and secret-backed integrations
+
+## 2. Scope availability
+
+Admins may decide what is available at each hierarchy level.
+
+Examples:
+
+- enable Tool A for a World
+- enable Tool B only for one City
+- allow a Department to use a subset of platform capabilities
+
+## 3. User access
+
+Users may act only within their assigned scope and only on capabilities already made available above them.
+
+This ensures that operators do not define platform capabilities themselves. They operate only on the subset published by admins.
+
+---
+
+# Audit Events
+
+Administrative and operational actions generate events in the global append-only audit log.
+
+Examples of auditable events:
+
+- user login
+- user logout
+- password change
+- user created
+- assignment changed
+- tool package installed
+- tool enabled or disabled
+- policy change
+- secret creation or modification
+- Department created or updated
+- Lemming created, paused, resumed, or terminated
+
+Audit records should contain enough actor and scope detail to support traceability.
+
+Example fields:
+
+```text
+event_type
+actor_user_id
+actor_role
+world
+city
+department
+description
+timestamp
+```
+
+Audit logs are append-only and immutable.
+
+This aligns with the system-wide audit log design already used for secret access and runtime events.
+
+---
+
+# Security Principles
+
+### Control Plane vs Runtime Plane
+
+Authentication applies only to the control plane.
+
+Lemmings and tools do not authenticate using human user accounts.
+
+Runtime components operate using runtime policies and the Secret Bank.
+
+### Secret Bank Separation
+
+The Secret Bank is used only for runtime credentials required by tools.
+
+It must **never** store user passwords or authentication data.
+
+Control-plane authentication and runtime secret management are separate subsystems.
+
+### Static authorization model in v1
+
+Version 1 uses built-in roles and hierarchy-based scope rules.
+
+It does **not** support arbitrary custom permission matrices, per-user exceptions, or dynamic RBAC policy editors.
+
+This keeps the initial security model understandable and auditable.
+
+---
+
+# Non-Goals for v1
+
+The following capabilities are explicitly **out of scope for v1** and will be defined in future ADRs:
+
+- fully configurable RBAC
+- per-action custom permission matrices
+- two-factor authentication (TOTP)
+- hardware security keys
+- VPN-only control plane access
+- IP allowlists
+- SSO integrations (OAuth, OIDC, SAML, etc.)
+
+The v1 goal is a secure, useful, and simple model suitable for single operators and small teams.
+
+---
+
+# Rationale
+
+A pure single-admin model is simpler, but it creates weak traceability and poor fit for team use.
+
+A full enterprise RBAC model would add substantial complexity too early.
+
+The chosen model is the middle path:
+
+- more useful than single-user access
+- much simpler than generic RBAC
+- naturally aligned with the World → City → Department hierarchy
+- sufficient for small teams operating a shared LemmingsOS deployment
+
+This makes LemmingsOS viable not only as a personal self-hosted tool, but also as an internal platform for a company with a small number of employees.
+
+---
+
+# Consequences
+
+## Positive
+
+- Multi-user support with per-actor audit trails makes LemmingsOS viable as a shared team platform, not only as a personal self-hosted tool.
+- Scope-aligned role assignments are immediately intuitive to operators already familiar with the World → City → Department hierarchy.
+- Fixed roles reduce the attack surface of the authorization system itself — there are no policy editors to misconfigure.
+- Bootstrap mode ensures an exposed installation cannot accept unauthorized connections before the first admin account exists.
+
+## Negative / Trade-offs
+
+- Fixed roles cannot model every organizational access structure. Teams with non-standard reporting hierarchies will encounter limitations that configurable RBAC would address.
+- Password-only authentication has weaker assurance than MFA. Until TOTP is introduced, a compromised password grants full access within the user's scope.
+- No per-user exceptions in v1. Granting a user a temporary elevated capability requires assigning a broader role than desired for that period.
+
+## Mitigations
+
+- The `(role, scope_type, scope_id)` tuple schema is designed to accommodate configurable RBAC extension in a future ADR without a table redesign.
+- Argon2id password hashing is memory-hard and resistant to GPU-based brute-force attacks, reducing exposure from compromised password hashes.
+- Append-only audit events record every authentication and administrative action, providing forensic detection capability even in the absence of MFA.
+
+---
+
+# Future Extensions
+
+Potential improvements include:
+
+- multiple roles per user
+- configurable RBAC
+- action-level permissions
+- temporary access grants
+- SSO integration
+- hardware-backed authentication
+- control plane network restrictions
+
+These features will be defined in future ADRs once the core runtime architecture stabilizes.
+

--- a/docs/adr/0011-control-plane-authorization-model.md
+++ b/docs/adr/0011-control-plane-authorization-model.md
@@ -1,0 +1,499 @@
+# ADR-0011 — Control Plane Authorization Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS exposes a control plane used by human operators to manage the runtime.
+
+Authentication verifies the identity of the user, but the system must also determine
+whether that authenticated user is allowed to perform a specific action on a specific
+resource.
+
+Because LemmingsOS is structured around a strict hierarchy:
+
+World → City → Department → Lemming
+
+access control must align with this hierarchy so that permissions remain predictable
+and easy to reason about.
+
+The system already supports:
+
+- multiple authenticated users
+- fixed built-in roles
+- scoped user assignments
+- hierarchical runtime resources
+
+Therefore a consistent authorization model is required to determine whether a user may
+operate on a given resource.
+
+---
+
+# 2. Decision Drivers
+
+1. **Predictability** — Authorization decisions must be deterministic given only the
+   user's assignments and the target resource. Operators must be able to reason about
+   access without consulting a policy engine or dynamic rules.
+
+2. **Hierarchy alignment** — The runtime is organized by World → City → Department →
+   Lemming. The authorization model must mirror this structure so that access
+   assignments have intuitive and consistent scope semantics.
+
+3. **Composability with authentication** — The authorization model must layer cleanly
+   on top of the session-based authentication defined in ADR-0010 without introducing
+   additional identity state or a separate credential store.
+
+4. **Deny dominance** — Access must flow strictly downward. A user scoped to one City
+   must never access a sibling City or a different World. Cross-scope escalation must
+   be structurally impossible, not merely discouraged.
+
+5. **Auditability** — Every authorization decision produces an audit event under the
+   model defined in ADR-0018. The authorization check must supply enough context
+   (actor, role, target resource, scope) for that event to be meaningful.
+
+6. **Simplicity over expressiveness** — v1 must avoid custom policy languages or
+   per-resource ACL matrices. Complexity must remain proportional to the actual
+   deployment scale.
+
+---
+
+# 3. Considered Options
+
+## Option A — Flat permission list per user
+
+Each user receives a direct list of permitted actions (create_department, run_lemming,
+manage_secrets, etc.) with no role abstraction.
+
+**Pros:**
+
+- maximum per-user precision
+- no role semantics to understand
+
+**Cons:**
+
+- every new user assignment requires enumerating all applicable actions
+- no natural grouping makes auditing whether a user has the right access difficult
+- adding new actions to the system requires updating every affected user's permission list
+- does not encode scope in a first-class way; scope logic must be added separately
+
+Rejected. The per-action model creates high operational burden and does not naturally
+compose with the hierarchy-scoped access pattern this system requires.
+
+---
+
+## Option B — Full RBAC with configurable roles
+
+Roles, their permitted actions, and assignments are all configurable by administrators
+at runtime.
+
+**Pros:**
+
+- maximum flexibility for any organizational structure
+- roles can be tuned to exact organizational needs
+
+**Cons:**
+
+- configurable RBAC introduces a permission editor as a security-sensitive surface
+- misconfigured roles can create privilege escalation paths that are hard to detect
+- the implementation complexity is disproportionate to v1 deployment scale
+- roles no longer mirror the fixed runtime hierarchy, creating a second mental model
+  to maintain alongside it
+
+Rejected. See ADR-0010 rationale. The complexity cost exceeds the value at v1 scale.
+
+---
+
+## Option C — Role + Hierarchical Scope authorization (chosen)
+
+Fixed built-in roles (admin, operator, viewer) combined with hierarchy-scoped
+assignments expressed as `(role, scope_type, scope_id)`.
+
+**Pros:**
+
+- authorization is fully deterministic given only role and scope — no policy engine required
+- scope assignment directly mirrors the World → City → Department hierarchy
+- adding a user is a single assignment, not a permission enumeration
+- composable: multiple assignments per user enable cross-scope access when explicitly granted
+
+**Cons:**
+
+- fixed roles cannot express every organizational permission boundary
+- no action-level exceptions in v1
+
+Chosen. Sufficient for the target use case and structurally aligned with the existing
+hierarchy.
+
+---
+
+# 4. Decision
+
+LemmingsOS implements a **Role + Hierarchical Scope Authorization Model**.
+
+Each user receives one or more assignments defined as:
+
+(role, scope_type, scope_id)
+
+Example:
+
+operator, city, salvador
+
+Authorization decisions are based on two checks:
+
+1. The role must permit the requested action.
+2. The user scope must be an ancestor of the target resource scope.
+
+Access flows strictly downward along the system hierarchy.
+
+---
+
+# 5. Authorization Rule
+
+A user may perform an action if both conditions are satisfied.
+
+Condition 1
+
+The assigned role allows the requested action.
+
+Condition 2
+
+The user's assigned scope is an ancestor of the target resource.
+
+Conceptual rule:
+
+ALLOW if
+
+role_allows(role, action)
+AND
+scope_is_ancestor(user_scope, resource_scope)
+
+Pseudocode:
+
+```
+def authorized?(user, action, resource) do
+  Enum.any?(user.assignments, fn assignment ->
+    role_allows?(assignment.role, action) and
+    scope_ancestor?(assignment.scope, resource.scope)
+  end)
+end
+```
+
+---
+
+# 6. Scope Inheritance
+
+Scopes inherit downward along the hierarchy:
+
+World
+  → City
+    → Department
+      → Lemming
+
+A user assigned at a given level may operate on that level and all descendants.
+
+Examples
+
+viewer(world)
+
+→ may inspect the entire world
+
+operator(city=salvador)
+
+→ may operate city salvador
+→ may operate departments in salvador
+→ may operate lemmings inside those departments
+
+operator(department=support)
+
+→ may operate only that department
+→ may operate lemmings inside that department
+
+---
+
+# 7. Role Permissions
+
+Roles define the allowed actions independently from scope.
+
+## Admin
+
+Administrators have full administrative control within their scope.
+
+Capabilities include:
+
+- manage users and assignments
+- install or remove tools
+- configure platform capabilities
+- manage secrets and connections
+- operate runtime resources
+- inspect logs and audit events
+
+Admins cannot exceed their assigned scope.
+
+## Operator
+
+Operators manage runtime operations but cannot change platform configuration.
+
+Capabilities include:
+
+- create or update Cities (if scoped at World)
+- create or update Departments (if scoped at City)
+- create, run, pause, or stop Lemmings
+- use tools enabled by administrators
+- inspect runtime state
+
+Operators cannot:
+
+- manage users
+- install tool packages
+- configure authentication
+- manage secrets
+
+## Viewer
+
+Viewers have read-only access.
+
+Capabilities include:
+
+- inspect runtime state
+- view Cities, Departments, and Lemmings
+- view logs and audit records
+
+Viewers cannot perform mutating operations.
+
+---
+
+# 8. Resource Types
+
+Authorization checks apply to control-plane resources.
+
+Resource categories include:
+
+- worlds
+- cities
+- departments
+- lemmings
+- tools
+- secrets
+- users
+
+Each resource is associated with a scope that belongs to the hierarchy.
+
+---
+
+# 9. Examples
+
+Example 1
+
+Assignment:
+
+operator(city=salvador)
+
+Allowed actions:
+
+- create department salvador/customer_support
+- run lemming salvador/customer_support/bot-1
+- pause lemming salvador/customer_support/bot-1
+
+Denied actions:
+
+- modify city rio
+- create department rio/finance
+- run lemming rio/finance/bot-5
+
+Example 2
+
+Assignment:
+
+viewer(world)
+
+Allowed actions:
+
+- view city salvador
+- inspect departments
+- read logs
+
+Denied actions:
+
+- create lemming
+- modify department
+
+Example 3
+
+Assignment:
+
+admin(city=salvador)
+
+Allowed actions:
+
+- create departments in salvador
+- manage secrets for salvador
+- enable tools usable in salvador
+
+Denied actions:
+
+- manage secrets in rio
+- install tools globally
+
+---
+
+# 10. Security Properties
+
+The model provides several desirable properties.
+
+Deterministic
+
+Authorization decisions depend only on role, scope, and resource scope.
+
+Hierarchy aligned
+
+The authorization structure mirrors the runtime hierarchy.
+
+Minimal complexity
+
+The system avoids complex RBAC matrices and dynamic policy engines.
+
+Safe defaults
+
+Access flows downward only, preventing cross-scope privilege escalation.
+
+---
+
+# 11. Consequences
+
+## Positive
+
+- Authorization is fully deterministic: given a user's assignments and the target
+  resource scope, the outcome is computable without a policy engine or runtime
+  configuration lookup.
+- Scope assignments are self-documenting. An operator assigned to `city=salvador`
+  clearly governs that City and its descendants — no policy documentation required.
+- The two-condition rule (role_allows AND scope_ancestor) keeps the authorization
+  check testable as a pure function, simplifying both implementation and audit.
+
+## Negative / Trade-offs
+
+- Fixed roles cannot model every organizational boundary. Teams where an operator
+  needs read access to one City and write access to another must receive two
+  assignments, and there is no role that permits exactly that combination of actions.
+- No action-level exceptions. Granting a user one elevated permission requires
+  assigning them a broader role for the entire scope.
+- The model does not support temporary access grants. Access remains until an
+  administrator explicitly removes the assignment.
+
+## Mitigations
+
+- Multiple assignments per user accommodate non-standard organizational structures
+  by composing existing roles and scopes rather than requiring custom roles.
+- The `(role, scope_type, scope_id)` schema is designed to extend toward configurable
+  roles in a future ADR without requiring a schema redesign.
+- All assignment changes produce audit events (ADR-0018), providing visibility into
+  access changes even in the absence of temporary grant semantics.
+
+---
+
+# 12. Non-Goals
+
+The following features are explicitly out of scope for v1.
+
+- dynamic RBAC
+- per-action custom policy engines
+- user-defined roles
+- ACL allow/deny lists
+- permission editors in the UI
+
+The v1 goal is a simple and predictable authorization model.
+
+---
+
+# 13. Future Extensions
+
+Potential future work includes:
+
+- full RBAC with configurable roles
+- temporary access grants
+- per-resource policies
+- organization-level roles
+
+
+---
+
+# 14. Authorization Evaluation Flow
+
+Control-plane requests follow a deterministic evaluation pipeline.
+
+```
+request received
+      ↓
+authenticate user session
+      ↓
+load user assignments
+      ↓
+authorization check
+      ↓
+execute control‑plane action
+      ↓
+append audit event
+```
+
+Explanation of each step:
+
+1. **Request received**
+
+A control-plane request arrives through the UI or API.
+
+2. **Authenticate user session**
+
+The system verifies that the request is associated with a valid authenticated session.
+
+3. **Load user assignments**
+
+The runtime retrieves all `(role, scope_type, scope_id)` assignments associated with the user.
+
+4. **Authorization check**
+
+The authorization rule defined in this ADR is evaluated:
+
+```
+role_allows(role, action)
+AND
+scope_is_ancestor(user_scope, resource_scope)
+```
+
+If no assignment satisfies both conditions, the request is rejected.
+
+5. **Execute control-plane action**
+
+If authorization succeeds, the requested control-plane operation is executed.
+
+6. **Append audit event**
+
+The system records the action in the append-only audit log, including:
+
+- actor user
+- role used
+- target resource
+- world / city / department context
+- timestamp
+
+This guarantees traceability for all administrative and operational actions.
+
+---
+
+# 15. Rationale
+
+LemmingsOS already organizes all runtime configuration around the World → City →
+Department hierarchy. An authorization model that introduces a separate structure would
+require operators to maintain two distinct mental models for the same system.
+
+The chosen model keeps authorization aligned with the runtime hierarchy: a user's
+scope of access mirrors the scope of the resources they manage. This makes
+misconfiguration visible — an operator assigned to the wrong City is immediately
+apparent from the assignment record, without needing to trace through a permission
+matrix.
+
+Fixed roles accept the trade-off of reduced expressiveness in exchange for predictable
+semantics, reduced implementation complexity, and an authorization system that is
+auditable by inspection.

--- a/docs/adr/0012-tool-policy-authorization-model.md
+++ b/docs/adr/0012-tool-policy-authorization-model.md
@@ -1,0 +1,604 @@
+# ADR-0012 — Tool Policy and Authorization Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS agents ("Lemmings") operate as supervised runtime processes that may
+interact with external systems through controlled capabilities known as **Tools**.
+
+Previous ADRs established several foundational constraints:
+
+- Lemmings never execute arbitrary external actions.
+- All external effects must pass through the Tool Runtime. (ADR-0005)
+- Secrets are resolved through the Secret Bank subsystem. (ADR-0009)
+- Runtime behavior follows hierarchical configuration inheritance. (ADR-0004)
+
+Because Tools are the only mechanism through which a Lemming can interact with
+external systems, uncontrolled access would introduce significant risks:
+
+- unauthorized external API calls
+- data exfiltration through unrestricted integrations
+- misuse of credentials
+- accidental or malicious side effects
+
+Therefore the runtime must enforce a clear **Tool Authorization and Policy Model**
+that determines:
+
+- which tools exist in the platform
+- which scopes enable those tools
+- which Lemmings may invoke them
+- which secrets and connections they may access
+
+The model must remain consistent with the LemmingsOS hierarchy:
+
+```
+World → City → Department → Lemming
+```
+
+This ADR defines the runtime policy model governing Tool availability,
+authorization, and secret resolution.
+
+---
+
+# 2. Decision Drivers
+
+1. **Least privilege by default** — No tool should be available to a Lemming unless
+   explicitly permitted at every hierarchy level. Open-by-default models create
+   accidental exposure. Deny is the default; allow is an explicit act.
+
+2. **Deny dominance** — Higher-scope denials must not be overridable by lower scopes.
+   A World-level disabled tool cannot be re-enabled at the Department or Lemming type
+   level. This prevents privilege escalation through nested configuration.
+
+3. **Secret isolation** — Tool credentials must never be visible to Lemmings. The
+   policy model must define a binding layer that resolves secrets through the Secret
+   Bank at execution time only.
+
+4. **Hierarchy alignment** — Tool availability must follow the same
+   World → City → Department → Lemming Type chain as all other runtime configuration
+   inheritance.
+
+5. **Auditability** — Every tool invocation must produce an audit event identifying
+   the Lemming, the tool, the Department, and the outcome. The policy model must make
+   the authorization path transparent in the audit record.
+
+6. **Extensibility** — The policy model must accommodate future governance layers
+   (risk classification in ADR-0013, approval workflows in ADR-0014, cost governance
+   in ADR-0015) without requiring a redesign of the authorization structure.
+
+---
+
+# 3. Considered Options
+
+## Option A — Flat allowlist per Lemming type
+
+Each Lemming type declares the tools it is allowed to use. No hierarchical policy
+resolution; each type configuration is self-contained.
+
+**Pros:**
+
+- simple per-type configuration
+- no inheritance chain to reason about
+
+**Cons:**
+
+- World and City level administrators cannot enforce platform-wide restrictions;
+  a rogue Lemming type could claim access to any installed tool
+- credential binding is per-type, creating inconsistent secret management
+- no mechanism for a City to restrict tools that World has enabled for its Departments
+- deny dominance cannot be enforced; lower scopes can always declare tool access
+
+Rejected. Administrators cannot enforce platform-wide restrictions. This model
+inverts the governance structure that LemmingsOS requires.
+
+---
+
+## Option B — Capability tokens per invocation
+
+The Lemming requests a capability token from a central authority before each tool
+invocation. The authority evaluates whether to issue the token at runtime.
+
+**Pros:**
+
+- fine-grained per-invocation control
+- capability can be revoked between invocations
+
+**Cons:**
+
+- introduces a central token authority as a runtime dependency and bottleneck
+- adds a network round-trip to every tool invocation
+- the complexity of token issuance, revocation, and expiry is disproportionate to v1
+- per-invocation decisions are harder to reason about than a static policy snapshot
+
+Rejected. The operational complexity and latency cost are not justified for v1. Static
+policy evaluation at invocation time achieves the same access control without the
+infrastructure burden.
+
+---
+
+## Option C — Hierarchical tool policy model (chosen)
+
+Tool availability is controlled at each level of the hierarchy. Resolution follows the
+World → City → Department → Lemming Type chain with deny dominance. Secret binding is
+declared by the tool and resolved by the Secret Bank at execution time.
+
+**Pros:**
+
+- administrators control availability at each level; lower levels can only restrict
+- deny at any level propagates downward unconditionally
+- secret binding is centralized and never exposes values to Lemmings
+- the model composes cleanly with risk classification and approval workflows
+
+**Cons:**
+
+- policy resolution spans multiple scopes, which increases the complexity of reasoning
+  about what a specific Lemming instance can actually do
+- misconfiguration at one scope can silently deny a tool that was expected to be
+  available
+
+Chosen. The governance requirements demand hierarchy-aligned, deny-dominant policy
+resolution. The operational cost of the complexity is manageable through the control
+plane UI and clear audit events.
+
+---
+
+# 4. Decision
+
+LemmingsOS implements a **hierarchical tool policy model** aligned with the
+system hierarchy.
+
+Policy evaluation follows the configuration chain:
+
+```
+World → City → Department → Lemming Type → Lemming Instance
+```
+
+More specific configuration may further restrict permissions but may **never
+expand capabilities beyond what is allowed by higher scopes**.
+
+Tool usage therefore becomes the result of resolving several layers of policy:
+
+1. Tool installed at platform level
+2. Tool enabled for the relevant hierarchy scope
+3. Tool permitted for the Department
+4. Tool permitted for the Lemming Type
+5. Optional instance-level restrictions
+
+Only when all checks succeed may the Tool Runtime execute the request.
+
+---
+
+# 5. Tool Availability Levels
+
+Tool availability is controlled through hierarchical enablement.
+
+## Platform level
+
+A Tool must first be **installed and registered** in the Tool Registry.
+
+Example lifecycle:
+
+```
+Installed → Registered → Enabled → Policy Allowed
+```
+
+Installation alone does not make a tool available to agents.
+
+## World level
+
+Administrators may enable or disable tools for the entire World.
+
+Example:
+
+```
+Tool: github_repo_reader
+World: enabled
+```
+
+This makes the tool eligible for use within that World.
+
+## City level
+
+Cities may further restrict tool availability.
+
+Example:
+
+```
+World
+  github_repo_reader: enabled
+
+City: salvador
+  github_repo_reader: disabled
+```
+
+Departments inside that City cannot use the tool.
+
+## Department level
+
+Departments may restrict the tools available to their agents.
+
+Example:
+
+```
+Department: finance
+Allowed tools:
+  - postgres_query
+  - http_fetch
+```
+
+Tools not listed remain unavailable.
+
+## Inheritance rules
+
+Policy resolution follows nearest-scope precedence with deny dominance.
+
+Rules:
+
+- lower scopes may **restrict** permissions
+- lower scopes may **not bypass higher-level denies**
+- the effective policy is the intersection of all scopes
+
+Example resolution order:
+
+```
+Department → City → World → Platform
+```
+
+---
+
+# 6. Tool Permission Resolution
+
+The runtime determines whether a Lemming instance may call a Tool using
+hierarchical policy evaluation.
+
+Conceptual pseudocode:
+
+```
+tool_allowed?(lemming, tool)
+```
+
+Example resolution flow:
+
+```
+def tool_allowed?(lemming, tool) do
+  tool_installed?(tool) and
+  tool_enabled_in_world?(tool, lemming.world) and
+  tool_enabled_in_city?(tool, lemming.city) and
+  tool_allowed_in_department?(tool, lemming.department) and
+  tool_allowed_for_type?(tool, lemming.type)
+end
+```
+
+Checks performed:
+
+1. Tool exists and is registered.
+2. Tool is enabled at the World scope.
+3. Tool is enabled at the City scope.
+4. Department policy allows the tool.
+5. Lemming Type configuration allows the tool.
+
+Optional additional checks may include:
+
+- instance-specific overrides
+- rate limits
+- cost budgets
+
+If any check fails, the Tool Runtime rejects the invocation.
+
+---
+
+# 6.1 Policy Evaluation Order
+
+To guarantee deterministic behavior, the runtime evaluates tool authorization
+in a strict order.
+
+Evaluation pipeline:
+
+```
+1. tool_installed?
+2. tool_enabled_world?
+3. tool_enabled_city?
+4. tool_allowed_department?
+5. tool_allowed_lemming_type?
+6. instance_overrides?
+```
+
+Rules:
+
+- evaluation stops on the **first failing rule**
+- lower levels may only **restrict**, never expand permissions
+- deny rules dominate allow rules
+
+This deterministic evaluation order ensures predictable runtime behavior
+and simplifies auditing and debugging.
+
+## Intentional asymmetry with secret resolution
+
+Policy evaluation and secret resolution (ADR-0009) intentionally use **opposite precedence rules**. This is not an inconsistency — it reflects the different nature of each concern.
+
+**Policy is deny-dominant (most restrictive wins):**
+Authorization is *constraint enforcement*. A deny at World level means no entity below World — City, Department, or Lemming — can grant that capability. If a more specific level could override a deny, any Department admin could escape platform-level restrictions. The security model depends on upper-level denies being unbreakable.
+
+**Secrets resolve to the most specific definition (most specific wins):**
+Secret resolution is a *definition lookup*. The runtime walks from the most specific scope upward until it finds a binding for the requested key. A Department-level credential legitimately overrides a City-level credential — there is no security concern with a more specific scope providing a different credential for a tool it is already authorized to use.
+
+The authorization question ("may this Lemming use this tool?") is answered by policy before secret resolution ever begins. Secrets are only resolved after the tool call has been authorized. This ordering means the override semantics of secret resolution never affect whether an action is permitted — only which credential is used to perform an already-authorized action.
+
+---
+
+# 7. Secret and Connection Binding
+
+Some tools require credentials or connection configuration.
+
+Tools do not access secrets directly.
+
+Instead:
+
+- tools declare **logical secret requirements**
+- runtime policy binds those requirements to concrete secret keys
+- secrets are resolved through the Secret Bank
+
+Example tool declaration:
+
+```
+tool: github_issue_creator
+required_secrets:
+  - github.token
+```
+
+Policy binding example:
+
+```
+secret_bindings:
+  github.token: secrets.github.company
+```
+
+Execution resolution flow:
+
+```
+Tool Runtime
+   ↓
+resolve secret binding
+   ↓
+Secret Bank lookup
+   ↓
+Department → City → World
+   ↓
+secret injected into Tool adapter
+```
+
+The secret value is injected only into the Tool Runtime execution context.
+
+Lemmings never receive raw credentials.
+
+---
+
+# 8. Execution Flow
+
+Tool invocation follows a controlled runtime pipeline.
+
+```
+Lemming Instance
+   ↓
+Tool Runtime
+   ↓
+Policy evaluation
+   ↓
+Secret resolution
+   ↓
+Tool adapter execution
+   ↓
+Result returned to Lemming
+```
+
+More detailed runtime flow:
+
+```
+Lemming
+   ↓ Tool.call
+Tool Runtime
+   ↓
+Policy Check
+   ↓
+Secret Binding Resolution
+   ↓
+Secret Bank Lookup
+   ↓
+Tool Adapter
+   ↓
+External System
+   ↓
+Result
+   ↓
+Audit Event
+```
+
+All external side effects therefore occur through a single controlled runtime
+boundary.
+
+---
+
+# 9. Security Properties
+
+The model provides several key security guarantees.
+
+## Least privilege
+
+Each scope restricts the capabilities available to its agents.
+
+Departments and Lemming types receive only the tools required for their role.
+
+## Secret isolation
+
+Lemmings never receive secret values directly.
+
+Secrets are resolved only during tool execution and injected into the tool
+adapter.
+
+## Controlled external effects
+
+All external actions occur through the Tool Runtime.
+
+No direct system calls or arbitrary command execution are allowed.
+
+## Auditable behavior
+
+Every tool invocation produces an audit event containing:
+
+- tool identifier
+- world / city / department
+- lemming instance
+- timestamp
+
+Secret values are never logged.
+
+---
+
+# 10. Examples
+
+## Example 1 — Tool enabled only for one City
+
+```
+Tool installed globally
+
+World
+  http_fetch: enabled
+
+City: salvador
+  http_fetch: enabled
+
+City: rio
+  http_fetch: disabled
+```
+
+Result:
+
+Lemmings in salvador may use the tool.
+
+Lemmings in rio cannot.
+
+---
+
+## Example 2 — Department tool restrictions
+
+```
+Department: research
+Allowed tools:
+  - web_search
+  - http_fetch
+
+Department: finance
+Allowed tools:
+  - postgres_query
+```
+
+Finance agents cannot perform web search.
+
+Research agents cannot access the database.
+
+---
+
+## Example 3 — Different credentials per Department
+
+```
+Tool: github_issue_creator
+
+Department: open_source
+  github.token → github.oss_token
+
+Department: enterprise
+  github.token → github.enterprise_token
+```
+
+The same tool uses different credentials depending on Department.
+
+---
+
+# 11. Consequences
+
+## Positive
+
+- The hierarchical model ensures that World and City administrators retain
+  unconditional veto power over tool availability. No lower-scope configuration
+  can override a deny at a higher level.
+- Secret isolation is structural: Lemmings have no path to raw credentials. Even a
+  compromised Lemming process cannot extract the API keys used to execute its tools.
+- The policy evaluation chain is deterministic and auditable. For any denial, the
+  audit event can identify exactly which layer in the hierarchy caused the rejection.
+
+## Negative / Trade-offs
+
+- Reasoning about effective tool access for a specific Lemming instance requires
+  mentally tracing five levels of policy (platform, world, city, department, type).
+  Operators must understand the full chain to diagnose unexpected denials.
+- A misconfiguration at any level silently denies a tool that was expected to be
+  available. The error is visible in the audit log but not necessarily in the
+  Lemming's failure message.
+- Secret binding configuration must be maintained at each scope that introduces a
+  different credential. As the number of tools and Departments grows, this can
+  become an operational maintenance burden.
+
+## Mitigations
+
+- The control plane UI should provide a resolved policy view showing the effective
+  tool access for a given Lemming type, making the five-level chain inspectable
+  without manual tracing.
+- Audit events for denied tool invocations include the failing policy level, allowing
+  operators to diagnose misconfiguration without reading through five layers of
+  configuration manually.
+- Secret binding follows the same hierarchical inheritance, so a binding set at World
+  scope applies to all lower scopes unless overridden. Teams with uniform credentials
+  need only one binding entry.
+
+---
+
+# 12. Non-Goals
+
+The following capabilities are explicitly out of scope for version 1.
+
+- dynamic policy engines
+- per-user tool permissions
+- marketplace trust scoring
+- tool sandboxing
+
+These features may be introduced later once the core runtime stabilizes.
+
+---
+
+# 13. Future Extensions
+
+The following items from earlier drafts of this ADR have since been addressed by dedicated ADRs and are no longer future work:
+
+- **tool risk classification** → ADR-0013
+- **cost budgets per tool** → ADR-0015
+- **sandboxed tool execution environments** → ADR-0016
+
+Remaining potential improvements:
+
+- external policy engines for dynamic rule evaluation
+- signed tool packages and trust verification
+- per-user tool permissions (below the Lemming-type granularity)
+- marketplace trust scoring for community packages
+
+These would extend the current policy model without changing its hierarchical foundations.
+
+---
+
+# 14. Rationale
+
+Tools are the only mechanism by which a Lemming interacts with the external world.
+Making tool access unrestricted or weakly governed would undermine the safety model
+of the entire runtime.
+
+The hierarchical policy model follows directly from the system's core design principle:
+each level of the hierarchy owns its resources and can further constrain what is
+available below it. Tool policy is an application of that principle, not an exception.
+
+Secret binding at the policy layer rather than in Lemming definitions ensures that
+credentials are an operational concern, not a code concern. Different Departments can
+use the same tool with different credentials without modifying the tool or the Lemming.

--- a/docs/adr/0013-tool-risk-classification-and-runtime-governance.md
+++ b/docs/adr/0013-tool-risk-classification-and-runtime-governance.md
@@ -1,0 +1,560 @@
+# ADR-0013 — Tool Risk Classification and Runtime Governance
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS agents ("Lemmings") interact with the external world only through
+controlled runtime capabilities known as **Tools**.
+
+Previous ADRs already define important parts of this boundary:
+
+- Tools are the only supported mechanism for external side effects. (ADR-0005)
+- Tool authorization determines whether a Lemming may invoke a given tool. (ADR-0012)
+- Secrets are resolved only inside the Tool Runtime. (ADR-0009)
+- Runtime behavior is governed by hierarchical configuration. (ADR-0004)
+
+However, authorization alone is not sufficient.
+
+Two tools may both be authorized for a given Department or Lemming type while still
+having very different operational risk.
+
+Examples:
+
+- a tool that performs a web search
+- a tool that reads a Git repository
+- a tool that sends emails
+- a tool that modifies a production database
+- a tool that executes infrastructure changes
+
+These tools differ materially in:
+
+- blast radius
+- side-effect severity
+- credential sensitivity
+- financial or production impact
+- recovery difficulty after misuse or failure
+
+This creates an important distinction.
+
+**Authorization** answers:
+
+- is this tool allowed for this Lemming under hierarchical policy?
+
+**Runtime risk controls** answer:
+
+- even if the tool is allowed, what additional safeguards must be enforced before execution?
+
+Examples of such safeguards include:
+
+- rate limits
+- cost budgets
+- manual approval requirements
+- domain restrictions
+- concurrency limits
+- network sandboxing
+
+Therefore LemmingsOS needs runtime governance in addition to authorization.
+
+Authorization prevents use of tools outside policy.
+
+Runtime governance limits how authorized tools may execute so that higher-risk tools
+operate under stronger controls.
+
+---
+
+# 2. Decision Drivers
+
+1. **Authorization is not sufficient** — Two tools may both be authorized for a
+   Department while differing dramatically in blast radius. Governance must be a
+   separate, composable layer that applies after authorization succeeds.
+
+2. **Uniformity of enforcement** — Risk controls must apply consistently to all tools
+   through a single enforced runtime boundary. Tools must not self-govern; doing so
+   would create inconsistent coverage and allow bypass.
+
+3. **Incrementality** — Risk classification must enable progressively stronger controls
+   without requiring changes to the authorization model or tool definitions. New
+   governance hooks should attach to existing risk levels without modifying tool
+   metadata.
+
+4. **Auditability of governance decisions** — Runtime governance outcomes (rate limit
+   applied, approval required, execution denied by budget) must appear in audit events,
+   not just execution outcomes. Operators must be able to reconstruct the governance
+   path for any tool invocation.
+
+5. **Operational transparency** — Operators must be able to see, in the control plane,
+   what risk class a tool carries and what runtime controls that implies for their
+   configuration.
+
+---
+
+# 3. Considered Options
+
+## Option A — No risk classification; all authorized tools execute uniformly
+
+Tools are either authorized or not. All authorized tools execute under identical
+runtime controls regardless of their operational characteristics.
+
+**Pros:**
+
+- simplest model — no tool metadata beyond authorization policy
+- no classification decisions to make or maintain
+
+**Cons:**
+
+- a `web_search` tool and a `terraform_apply` tool execute under exactly the same
+  governance, which is operationally incorrect
+- there is no runtime hook point for adding manual approval to high-impact tools
+  without building entirely separate infrastructure
+- risk controls cannot be introduced incrementally as new tools are added
+- operators have no signal in the control plane about the relative risk of available tools
+
+Rejected. The model cannot express the safety requirements for high-impact tools without
+a redesign. A runtime that treats infrastructure mutation identically to a read-only web
+search is not suitable for production use.
+
+---
+
+## Option B — Binary safe/unsafe classification
+
+Each tool is classified as either `safe` (unrestricted execution) or `unsafe` (requires
+explicit operator approval before every invocation).
+
+**Pros:**
+
+- simple two-state model — no spectrum to reason about
+- a single classification decision per tool
+
+**Cons:**
+
+- the binary does not capture the meaningful spectrum between a medium-risk external API
+  call and a critical infrastructure change; both are `unsafe` but warrant very different
+  governance
+- `safe` tools with no rate limits are vulnerable to cost and volume abuse
+- approval-for-every-unsafe-invocation creates operator fatigue for medium-risk tools
+  that execute frequently and legitimately
+
+Rejected. The binary cannot express the gradient of risk that real tool inventories
+exhibit. Collapsing medium and critical risk into one category leads to either
+over-approval overhead or under-governance of genuinely dangerous operations.
+
+---
+
+## Option C — Four-tier risk classification with escalating governance baseline (chosen)
+
+Each tool declares a risk level (`low`, `medium`, `high`, `critical`). The risk level
+informs the baseline governance controls applied by the Tool Runtime after authorization
+succeeds.
+
+**Pros:**
+
+- captures the operational risk spectrum without requiring per-tool custom governance
+  configuration
+- governance hooks attach to risk tiers, so adding a new high-risk tool automatically
+  inherits the correct control baseline
+- critical-risk tools can require approval workflows without affecting medium-risk tools
+  that should execute automatically
+- the tier structure is easy to communicate to tool authors and administrators
+
+**Cons:**
+
+- tool authors must make a classification judgment that may be subjective for
+  borderline cases
+- the four tiers cannot capture all nuance; a `postgres_query` for read-only use and
+  the same tool for production write operations technically share a classification
+
+Chosen. The four-tier model captures the meaningful risk distinctions in real tool
+inventories while remaining operationally simple to explain and configure.
+
+---
+
+# 4. Decision
+
+LemmingsOS introduces a **Tool Risk Classification Model**.
+
+Each Tool declares a **risk level** as part of its metadata.
+
+The initial risk levels are:
+
+- `low`
+- `medium`
+- `high`
+- `critical`
+
+Risk classification is part of the Tool contract and is registered in the Tool
+Registry together with the rest of the tool metadata.
+
+Example conceptual metadata:
+
+```text
+tool_id: web_search
+risk_level: low
+```
+
+The declared risk level does not by itself grant or deny authorization.
+
+Instead, the risk level informs how the Tool Runtime evaluates and enforces
+runtime safeguards after authorization succeeds and before execution begins.
+
+---
+
+# 5. Risk Level Semantics
+
+The risk levels represent the expected operational impact of a tool if it is used
+incorrectly, excessively, or in the wrong context.
+
+## Low
+
+Low-risk tools are primarily read-only and have little or no external side-effect.
+
+Typical properties:
+
+- read-only behavior
+- low blast radius
+- limited credential sensitivity
+- failures are easy to contain
+
+Examples:
+
+- web search
+- public HTTP fetch with restricted scope
+- local document parsing without external mutation
+
+## Medium
+
+Medium-risk tools interact with external systems but usually have limited impact
+or constrained side effects.
+
+Typical properties:
+
+- external requests are performed
+- actions may create bounded side effects
+- misuse is undesirable but typically recoverable
+
+Examples:
+
+- creating a GitHub issue
+- posting to a non-critical webhook
+- writing to a non-production collaboration system
+
+## High
+
+High-risk tools perform state-changing actions or access sensitive systems where
+mistakes may create material operational impact.
+
+Typical properties:
+
+- state mutation in important systems
+- stronger credential sensitivity
+- higher recovery cost
+- increased risk of data corruption, user impact, or service disruption
+
+Examples:
+
+- database writes
+- repository mutations
+- email sending
+- actions against internal systems with persistent effects
+
+## Critical
+
+Critical-risk tools may affect infrastructure, financial systems, production
+systems, or other high-consequence environments.
+
+Typical properties:
+
+- very high blast radius
+- difficult or costly recovery
+- production or financial impact
+- requires the strongest governance expectations
+
+Examples:
+
+- infrastructure change execution
+- production database administration
+- cloud resource mutation
+- financial transaction execution
+
+Risk classification is a runtime governance signal, not a moral judgment about a
+Tool. A critical tool may be valid and necessary, but it must operate under stricter
+controls than a low-risk one.
+
+---
+
+# 6. Runtime Governance Hooks
+
+Risk classification influences the safeguards the Tool Runtime may attach during
+execution.
+
+The baseline expectation in v1 is:
+
+## Low
+
+Low-risk tools typically execute with minimal additional restrictions beyond normal
+authorization, validation, and standard runtime limits.
+
+## Medium
+
+Medium-risk tools may execute under additional controls such as:
+
+- rate limits
+- concurrency limits
+- domain or endpoint restrictions
+
+## High
+
+High-risk tools may execute under stronger governance such as:
+
+- rate limits
+- budget tracking
+- stricter timeout enforcement
+- stronger connection restrictions
+
+## Critical
+
+Critical-risk tools may require the strongest controls, including optional approval
+workflows where configured.
+
+Examples:
+
+- budget tracking
+- strict rate limits
+- manual approval before execution
+- restricted runtime environments
+- hardened network policies
+
+The Tool Runtime may attach policies based on risk level before dispatching the tool
+adapter.
+
+This means that risk level becomes an input into runtime enforcement, not just a
+label shown in the control plane.
+
+---
+
+# 7. Example Runtime Controls
+
+The following runtime controls may be applied based on risk level and effective
+policy:
+
+- rate limits
+- concurrency limits
+- cost budgets
+- manual approval requirements
+- domain allowlists
+- network sandboxing
+- execution timeouts
+
+These controls are enforced by the **Tool Runtime**.
+
+Tools do not self-enforce platform governance.
+
+This preserves a single authoritative execution boundary where LemmingsOS can:
+
+- apply controls consistently
+- audit decisions centrally
+- evolve governance without changing every tool implementation
+
+---
+
+# 8. Execution Pipeline Integration
+
+Risk classification is integrated into the runtime tool execution pipeline.
+
+Conceptual flow:
+
+```text
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Authorization check (ADR-0012)
+   ↓
+Risk policy evaluation
+   ↓
+Secret resolution
+   ↓
+Tool execution
+   ↓
+Audit event
+```
+
+Risk evaluation happens **after authorization but before execution**.
+
+This ordering is intentional.
+
+1. The runtime first verifies that the Lemming is allowed to use the tool at all.
+2. If authorization succeeds, the runtime evaluates the controls required for that
+   tool's risk level.
+3. Only then does the runtime resolve secrets and execute the tool.
+
+This preserves a clean separation of concerns:
+
+- **authorization** decides whether execution is permitted in principle
+- **risk governance** decides how permitted execution must be constrained
+
+The runtime should emit audit information sufficient to explain not only tool usage,
+but also governance decisions such as approval requirements, denied execution due to
+budget exhaustion, or sandbox restrictions applied at execution time.
+
+---
+
+# 9. Examples
+
+## Example 1 — `web_search`
+
+```text
+risk: low
+```
+
+Typical governance:
+
+- standard validation
+- normal timeout
+- minimal additional runtime restrictions
+
+This tool is read-oriented and has low direct side-effect risk.
+
+## Example 2 — `github_issue_creator`
+
+```text
+risk: medium
+```
+
+Typical governance:
+
+- rate limits
+- domain allowlist for approved GitHub endpoints
+- bounded concurrency
+
+This tool creates an external side effect, but the blast radius is usually limited.
+
+## Example 3 — `postgres_query`
+
+```text
+risk: high
+```
+
+Typical governance:
+
+- rate limits
+- budget tracking
+- stricter connection restrictions
+- tighter timeout policies
+
+If configured for writes or production-adjacent systems, misuse may have material
+impact.
+
+## Example 4 — `terraform_apply`
+
+```text
+risk: critical
+```
+
+Typical governance:
+
+- strict rate limits
+- hardened runtime environment
+- optional manual approval workflow
+- strong network and credential restrictions
+
+This tool can modify infrastructure directly and may have production-wide impact.
+
+---
+
+# 10. Consequences
+
+## Positive
+
+- Risk classification makes the governance expectations for each tool explicit and
+  inspectable in the control plane. Operators can evaluate a tool's risk level before
+  enabling it, rather than discovering it through an incident.
+- Governance hooks attach to risk tiers, so new tools automatically inherit the
+  correct control baseline without additional configuration.
+- The separation of authorization and governance creates a clean extension point:
+  approval workflows (ADR-0014), cost controls (ADR-0015), and isolation (ADR-0016)
+  all plug in after risk evaluation without changing the authorization model.
+
+## Negative / Trade-offs
+
+- Risk classification is a judgment call made by tool authors. Borderline cases (a
+  `postgres_query` that only reads versus one that writes) require per-tool context
+  that the classification label cannot fully capture.
+- The four-tier classification does not prevent operators from enabling critical-risk
+  tools without approval workflows configured. Classification informs governance; it
+  does not enforce a specific governance baseline automatically.
+- Tool authors who underclassify (setting `low` for a tool that deserves `high`)
+  reduce the governance signal without any system-level detection.
+
+## Mitigations
+
+- The control plane should display the effective governance controls for each enabled
+  tool so operators can verify that risk-appropriate controls are configured.
+- Tool package review processes and signing (a future extension) can provide a second
+  check on classification accuracy before a tool is available to agents.
+- Audit events for tool executions include the risk level, enabling retrospective
+  detection of tools that consistently operate near governance thresholds and may
+  warrant reclassification.
+
+---
+
+# 11. Non-Goals
+
+The following capabilities are explicitly out of scope for v1:
+
+- automatic risk scoring
+- dynamic runtime ML policies
+- full sandbox virtualization
+- external compliance engines
+
+Version 1 requires explicit tool classification and runtime enforcement hooks, not
+fully automated governance.
+
+---
+
+# 12. Future Extensions
+
+The following items have since been addressed by dedicated ADRs and are no longer future work:
+
+- **human-in-the-loop approvals** → ADR-0014
+- **cost governance** → ADR-0015
+
+Remaining potential future work:
+
+- per-Department risk policies and environment-aware risk profiles
+- dynamic risk escalation based on repeated failures or suspicious behavior
+- external policy engines for rule evaluation
+- stronger sandbox isolation for critical-risk tools (beyond the OS-level model in ADR-0016)
+- policy templates by Department type
+
+These extensions can build on the classification model defined here without changing the core execution order:
+
+authorization first, risk governance second, execution last.
+
+---
+
+# 13. Rationale
+
+LemmingsOS already treats Tools as the controlled boundary for all external effects.
+That boundary becomes significantly stronger when authorization and runtime governance
+are separated but composed.
+
+This ADR therefore establishes three layers of control:
+
+1. **Tool existence and registration**
+2. **Tool authorization through hierarchical policy**
+3. **Runtime governance based on declared risk**
+
+This keeps the system:
+
+- predictable
+- auditable
+- extensible
+- safer for high-impact tool execution
+
+It also creates a foundation for future work such as approvals, cost controls,
+and stronger sandboxing without requiring a redesign of the Tool model itself.

--- a/docs/adr/0014-tool-approval-workflow.md
+++ b/docs/adr/0014-tool-approval-workflow.md
@@ -1,0 +1,507 @@
+# ADR-0014 — Tool Approval Workflow
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS agents ("Lemmings") interact with external systems exclusively through **Tools**. Tool usage is governed by multiple runtime safeguards defined in earlier ADRs:
+
+- Tool execution boundary (ADR-0005)
+- Hierarchical tool authorization (ADR-0012)
+- Risk classification and runtime governance (ADR-0013)
+
+Tool authorization determines **whether a Lemming is permitted to use a specific Tool** according to hierarchical policy.
+
+However, authorization alone is insufficient for certain high‑impact operations.
+
+Some tool invocations may be technically authorized yet still represent actions that require explicit human review before execution.
+
+Examples include:
+
+- modifying production infrastructure
+- executing Terraform or cloud configuration changes
+- performing financial operations
+- destructive database mutations
+- high‑cost external API operations
+
+In these situations the system must support **human‑in‑the‑loop decision points** to ensure that sensitive actions are executed intentionally and with operator awareness.
+
+It is therefore necessary to distinguish two separate concepts:
+
+Authorization
+: Determines whether a tool *may be used at all* by a Lemming according to runtime policy.
+
+Approval
+: Determines whether a **specific invocation** of a tool should be allowed to proceed at a particular moment.
+
+Authorization is a static policy evaluation.
+Approval is a dynamic runtime decision applied to an individual execution request.
+
+Human approval gates are a widely used safeguard in systems that allow automation to affect critical infrastructure or financial resources. Introducing an approval workflow allows LemmingsOS to safely support high‑risk automation without removing human oversight.
+
+---
+
+# 2. Decision Drivers
+
+1. **Human oversight for high-impact actions** — Autonomous agents executing
+   infrastructure mutations, financial operations, or destructive database changes
+   without human review is unacceptable for most organizations. The runtime must
+   support mandatory human gates as a first-class feature.
+
+2. **Separation from authorization** — Approval is a per-invocation runtime decision,
+   not a static policy evaluation. The implementation must be architecturally separate
+   from ADR-0012 tool authorization. Conflating the two would make the authorization
+   model dynamic and unpredictable.
+
+3. **Durability** — Pending approval requests must survive BEAM process restarts. A
+   Lemming crash must not silently lose the waiting state or resume without the
+   required approval having been granted.
+
+4. **Hierarchy alignment** — Approval authority must follow the same scope rules as
+   the rest of the system. An operator may approve only requests within their assigned
+   hierarchy scope.
+
+5. **Simplicity of initial implementation** — v1 must be operable without complex
+   configuration. Multi-step approval chains and quorum requirements are future work.
+   A single human gate that any qualified operator can resolve is sufficient.
+
+---
+
+# 3. Considered Options
+
+## Option A — No approval workflow; rely on post-hoc audit
+
+All authorized tool executions proceed immediately. Operators review the audit log
+after the fact and terminate agents or roll back changes if problems are detected.
+
+**Pros:**
+
+- no additional runtime infrastructure required
+- no execution latency introduced by waiting for approval
+
+**Cons:**
+
+- production infrastructure changes and financial operations execute before any human
+  can review them; by the time the audit log is reviewed, the blast radius has already
+  materialized
+- audit records satisfy compliance requirements but do not prevent damage
+- operators cannot express "this specific tool must never run autonomously"
+
+Rejected. For critical-risk tools, post-hoc detection is not an acceptable substitute
+for pre-execution review. The blast radius of an autonomous infrastructure change cannot
+be unwound by reading a log.
+
+---
+
+## Option B — LLM self-approval; the Lemming's own reasoning evaluates whether to proceed
+
+Before executing a high-risk tool, the Lemming uses its model to reason about whether
+the action is appropriate and decides whether to proceed.
+
+**Pros:**
+
+- no additional infrastructure required
+- the Lemming's context about the task informs the approval decision
+
+**Cons:**
+
+- LLM reasoning cannot substitute for human accountability; operators cannot delegate
+  production infrastructure decisions to a language model
+- the approval decision is non-deterministic and cannot be audited as a human act
+- prompt injection or model hallucination could cause unintended approval of dangerous
+  operations
+- the Lemming's self-assessment is not visible to operators until after execution
+
+Rejected. Human accountability for high-impact actions cannot be delegated to an LLM.
+The governance requirements are not satisfiable by model-based self-evaluation.
+
+---
+
+## Option C — Single-step human approval gate via ApprovalManager (chosen)
+
+A dedicated ApprovalManager runtime component pauses execution when an invocation
+meets approval criteria. The request enters a pending state visible in the control
+plane. A qualified operator approves or rejects it. The decision is durable and
+auditable.
+
+**Pros:**
+
+- provides a genuine human accountability gate for high-impact operations
+- approval requests are durable: a Lemming restart does not lose the pending decision
+- approval authority follows the existing hierarchy scope rules from ADR-0011
+- the ApprovalManager is a discrete runtime component that can be tested and evolved
+  independently of individual Lemming implementations
+- every approval decision produces an audit record satisfying forensic and compliance
+  requirements
+
+**Cons:**
+
+- introduces a new durable runtime component (ApprovalManager) that must be
+  supervised, persisted, and maintained
+- execution latency for approval-gated tools depends on how quickly an operator
+  responds; an unattended system with critical-risk tools in the execution path
+  will block indefinitely
+- operators must actively monitor the approval queue for time-sensitive operations
+
+Chosen. The durability, auditability, and genuine human accountability justify the
+operational overhead for the class of operations that approval is designed to protect.
+
+---
+
+# 4. Decision
+
+LemmingsOS introduces a **Tool Approval Workflow** mechanism.
+
+The Tool Runtime may require explicit human approval before executing a tool invocation.
+
+Approval requirements are evaluated dynamically during tool execution and may depend on runtime policy conditions such as:
+
+- tool risk classification
+- specific tool identity
+- execution scope (World / City / Department)
+- execution environment (for example staging vs production)
+- operation type or parameters
+
+If an invocation requires approval, execution is paused and the request enters a pending state until a qualified operator reviews the request.
+
+The approval workflow acts as a runtime control layer that sits **after authorization and risk evaluation but before tool execution**.
+
+Approval requirement detection is performed by the **Tool Runtime through deterministic policy evaluation**. It is not delegated to the LLM and is not implemented independently inside each Lemming.
+
+Pending approval state and lifecycle management are owned by a dedicated runtime subsystem, referred to in this ADR as the **ApprovalManager**.
+
+---
+
+# 5. Approval Triggers
+
+Approval may be required for certain tool invocations depending on administrator-defined policy.
+
+Typical triggers include:
+
+- tools classified as **critical risk**
+- destructive operations (delete, drop, terminate)
+- operations that mutate infrastructure
+- operations with significant financial impact
+- operations exceeding configured cost thresholds
+- actions outside normal operational policies
+
+Approval requirements are configured by administrators through runtime policy.
+
+Different scopes may apply different approval rules.
+
+Example:
+
+```
+World
+  terraform_apply → approval required
+
+City: staging
+  terraform_apply → approval optional
+
+City: production
+  terraform_apply → approval mandatory
+```
+
+The runtime determines whether approval is required based on the **effective policy after hierarchical resolution**.
+
+For v1, approval policy is intended to remain simple to operate.
+
+The primary administrator experience is:
+
+- a simple per-tool approval setting in the control plane
+- an optional advanced YAML configuration for more specific approval rules
+
+Tools provide structured metadata that helps the runtime evaluate approval requirements, for example:
+
+- risk level
+- supported actions
+- mutating or destructive action hints
+
+Tools do **not** define approval policy themselves.
+
+Instead:
+
+- tool packages provide metadata
+- administrators configure approval behavior
+- the Tool Runtime evaluates the effective policy deterministically
+
+This keeps governance centralized and operationally manageable.
+
+---
+
+# 6. Approval Workflow Model
+
+When approval is required, tool execution follows a structured lifecycle.
+
+```
+Tool invocation requested
+        ↓
+Runtime detects approval requirement
+        ↓
+Invocation enters pending state
+        ↓
+Approval request created
+        ↓
+Authorized operator reviews request
+        ↓
+Approve or reject
+        ↓
+Runtime continues or aborts execution
+```
+
+If the request is approved, execution resumes normally.
+
+If the request is rejected, the invocation terminates and the Lemming receives a failure result.
+
+Pending approval requests must be:
+
+- durable
+- auditable
+- visible to operators through the control plane
+
+Approval requests therefore persist independently of the requesting Lemming process so that system restarts do not lose pending decisions.
+
+The pending request lifecycle is managed by a dedicated **ApprovalManager** runtime component.
+
+ApprovalManager responsibilities include:
+
+- creating approval requests
+- persisting pending approval state
+- exposing approve and reject operations
+- resuming or aborting blocked execution after a decision
+- emitting audit events for approval lifecycle transitions
+
+This keeps approval governance outside individual Lemming implementations and avoids duplicating approval logic across agents.
+
+---
+
+# 7. Approval Scope and Permissions
+
+Only authorized human operators may approve tool executions.
+
+Approval permissions follow the same hierarchical authorization model defined for the control plane.
+
+Users may approve requests if:
+
+1. their role allows approval actions
+2. their assigned scope is an ancestor of the request scope
+
+Example:
+
+```
+operator(city = salvador)
+```
+
+This operator may approve tool executions originating from:
+
+- departments within the Salvador city
+- lemmings within those departments
+
+Role capabilities:
+
+Admin
+: may approve requests within their scope and all descendants.
+
+Operator
+: may approve requests within their operational scope.
+
+Viewer
+: cannot approve or reject requests.
+
+This ensures that approval authority aligns with the same hierarchy used for runtime governance.
+
+---
+
+# 8. Execution Pipeline Integration
+
+The approval mechanism integrates into the Tool Runtime execution pipeline.
+
+Conceptual execution flow:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Authorization check (ADR-0012)
+   ↓
+Risk policy evaluation (ADR-0013)
+   ↓
+Approval requirement check
+   ↓
+(optional) Approval Workflow
+   ↓
+Secret resolution
+   ↓
+Tool execution
+   ↓
+Audit event
+```
+
+More explicitly:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Authorization check
+   ↓
+Risk evaluation
+   ↓
+Approval policy evaluation
+   ↓
+ApprovalManager
+   ├─ no approval required → continue
+   └─ approval required → create pending request
+   ↓
+Secret resolution
+   ↓
+Tool execution
+   ↓
+Audit event
+```
+
+If approval is required, execution pauses at the approval step.
+
+The Lemming instance transitions to a **waiting_approval** state until the decision is made.
+
+Once approval is granted, execution continues automatically without requiring additional intervention from the Lemming.
+
+The Lemming does not decide whether approval is needed and does not own the approval workflow state.
+
+---
+
+# 9. Approval Record
+
+Each approval decision must produce a persistent record stored in the system audit log.
+
+The record must include:
+
+- tool invocation identifier
+- requesting lemming instance
+- world / city / department scope
+- tool name
+- summarized parameters
+- approval decision (approved / rejected)
+- approving user
+- decision timestamp
+
+Example record:
+
+```
+approval_event
+  invocation_id: inv-78421
+  lemming_id: lem-23
+  world: prod
+  city: salvador
+  department: infra
+  tool: terraform_apply
+  decision: approved
+  approved_by: operator_17
+  timestamp: 2026-03-14T18:21:03Z
+```
+
+Approval records must never contain secret values or sensitive credentials.
+
+The audit trail ensures that every high-risk action executed by the system remains traceable.
+
+In addition to final approve or reject decisions, the ApprovalManager should emit audit events for key approval lifecycle transitions, such as:
+
+- approval requested
+- approval granted
+- approval rejected
+
+This provides full traceability from pending request creation through final resolution.
+
+---
+
+# 10. Consequences
+
+## Positive
+
+- Human accountability is guaranteed for configured high-risk operations. An autonomous
+  agent cannot execute a production infrastructure change or destructive mutation without
+  an explicit human decision being recorded.
+- Approval state is durable. A Lemming crash while waiting for approval does not lose
+  the pending request; the system can resume execution once the operator decides.
+- Approval authority follows the same hierarchy scope rules as the rest of the system.
+  Operators approve only what they are already authorized to manage.
+- The ApprovalManager is a discrete subsystem. Approval logic does not leak into
+  individual Lemming implementations.
+
+## Negative / Trade-offs
+
+- A new durable runtime component (ApprovalManager) must be designed, supervised,
+  persisted, and maintained. Bugs in the ApprovalManager affect every approval-gated
+  tool execution across all Lemmings in the system.
+- Execution latency for approval-gated tools is unbounded at runtime. If no operator
+  is available to respond, the Lemming blocks indefinitely in `waiting_approval` state.
+- Operators must actively monitor an approval queue for time-sensitive operations.
+  There is no timeout or escalation in v1.
+- Systems where many tools require approval may create operator fatigue, reducing the
+  effectiveness of the approval gate over time.
+
+## Mitigations
+
+- The approval queue is visible in the control plane with enough context (tool, scope,
+  parameters summary) for operators to make decisions without navigating to the Lemming
+  detail view.
+- Approval requirements are configurable per scope: a staging environment can have
+  approval optional while production keeps it mandatory, reducing routine approval
+  volume for non-production work.
+- Future extensions (approval expiration, escalation, chat-based notifications) can
+  address operator response latency without changing the core approval model.
+
+---
+
+# 11. Non‑Goals
+
+The following capabilities are explicitly **out of scope for v1**:
+
+- complex approval chains
+- multi‑stage approvals
+- external policy engines (for example OPA)
+- automated risk scoring
+- Slack or Telegram approval integrations
+- approval delegation workflows
+
+Version 1 focuses on a **simple single‑step approval gate** integrated directly into the Tool Runtime.
+
+---
+
+# 12. Future Extensions
+
+Potential future improvements include:
+
+- multi‑approver workflows
+- quorum‑based approvals
+- approval expiration and TTL
+- escalation rules
+- integration with external approval systems
+- chat‑based approval flows
+- programmable policy engines
+
+These extensions would expand the approval system while preserving the fundamental separation between **authorization**, **risk governance**, and **human approval**.
+
+---
+
+# 13. Rationale
+
+Authorization determines whether a tool may be used at all. Risk classification
+determines the governance baseline that applies. Approval determines whether a specific
+invocation should proceed at this specific moment.
+
+These are three separate concerns and must remain architecturally separate. Merging
+approval into authorization (making authorization dynamic) would make the policy model
+unpredictable. Delegating approval to the LLM removes human accountability. Skipping
+approval entirely for high-risk tools is not acceptable for production systems.
+
+The ApprovalManager as a dedicated runtime component keeps approval state durable and
+visible, and keeps approval logic out of individual Lemming implementations. This means
+that adding approval requirements to a new tool is a configuration change, not a code
+change.

--- a/docs/adr/0015-runtime-cost-governance.md
+++ b/docs/adr/0015-runtime-cost-governance.md
@@ -1,0 +1,570 @@
+# ADR-0015 — Runtime Cost Governance
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS allows autonomous agents ("Lemmings") to operate for extended periods of time. These agents may continuously invoke Tools, call external APIs, communicate with other agents, or interact with large language models.
+
+Because many of these operations incur **monetary cost**, the runtime must include deterministic mechanisms to prevent uncontrolled spending.
+
+Typical cost sources include:
+
+- LLM token usage
+- external API billing
+- cloud compute usage
+- third‑party service fees
+- long‑running tool executions
+
+Without runtime governance, autonomous systems may unintentionally generate excessive cost.
+
+Examples include:
+
+- a research agent executing thousands of web searches
+- repeated LLM inference calls consuming large token volumes
+- tools triggering expensive infrastructure operations
+- recursive agent loops invoking tools repeatedly
+
+Because LemmingsOS is designed for **long‑running autonomous execution**, cost governance must be enforced by the runtime rather than relying solely on operator supervision.
+
+Cost controls must apply consistently across all runtime interactions that may generate external cost, including:
+
+- LLM usage
+- external API usage
+- tool execution
+- long‑running processes
+
+The system must also align cost governance with the **hierarchical architecture** of LemmingsOS:
+
+```
+World → City → Department → Lemming
+```
+
+Budgets must be enforceable at higher scopes and restrict the execution capacity of lower scopes.
+
+This allows operators to allocate cost budgets safely across organizational units.
+
+---
+
+# 2. Decision Drivers
+
+1. **Autonomous systems can generate unbounded cost** — A recursive agent loop or
+   runaway research agent can consume large token volumes or trigger expensive API
+   calls without human intervention. Hard stops are a first-class safety requirement,
+   not an optional monitoring feature.
+
+2. **Hierarchy-aligned budgets** — Budget allocation must follow the
+   World → City → Department structure so operators can delegate spending authority
+   predictably. Lower scopes must not be able to exceed limits set by their parent.
+
+3. **Integration with the existing execution pipeline** — Cost enforcement must plug
+   into the same Tool Runtime execution pipeline as authorization, risk evaluation,
+   and approval. A bolt-on post-hoc check would create bypass paths.
+
+4. **Operational intent over billing precision** — v1 goal is deterministic runtime
+   protection against runaway spending, not billing-grade financial reconciliation.
+   The model must avoid over-engineering for precision that is not required.
+
+5. **Token tracking regardless of monetary cost** — Local providers (Ollama) and
+   free-tier cloud providers carry zero or near-zero monetary cost but still consume
+   context budget and operational capacity. Volume tracking is valuable even when the
+   cost estimate is zero.
+
+---
+
+# 3. Considered Options
+
+## Option A — No runtime cost governance; rely on operator supervision
+
+Operators monitor dashboards and manually terminate agents that generate excessive cost.
+
+**Pros:**
+
+- no additional runtime infrastructure required
+- no execution pipeline changes
+
+**Cons:**
+
+- autonomous agents run unattended; operators are not available 24/7 to intervene
+- by the time an operator detects runaway spending, the cost has already materialized
+- no mechanism to enforce organizational budget allocation across Cities and Departments
+- LLM providers enforce their own spending limits at the account level, which is too
+  coarse for per-Department governance
+
+Rejected. Relying on operator supervision to prevent runaway spending in an autonomous
+system is not viable. The system is explicitly designed for unattended operation.
+
+---
+
+## Option B — Provider-side limits only
+
+Configure rate limits and spending caps directly at each API provider's account or
+project level.
+
+**Pros:**
+
+- no changes to the LemmingsOS runtime
+- provider-enforced limits are guaranteed to be respected
+
+**Cons:**
+
+- provider limits are account-scoped, not hierarchy-scoped; there is no mechanism to
+  enforce per-Department budgets using provider controls alone
+- local providers (Ollama) have no monetary billing; token volume cannot be governed
+  at all with this approach
+- budget exhaustion produces provider-level errors (HTTP 429) rather than a controlled
+  runtime signal; agents receive opaque failures rather than a `budget_exhausted` result
+- budget allocation across organizational units requires coordination with every
+  provider independently
+
+Rejected. Provider-side limits cannot model the hierarchical budget allocation that
+LemmingsOS requires, and they provide no coverage for local or free-tier providers.
+
+---
+
+## Option C — Checkpoint-based runtime budget subsystem (chosen)
+
+A dedicated cost governance subsystem tracks usage at runtime, evaluates budget
+availability before cost-generating operations, and enforces hard stops when budgets
+are exhausted. Budgets are hierarchical and aligned to the World → City → Department
+structure.
+
+**Pros:**
+
+- hard stops prevent runaway spending before it occurs, not after
+- budget allocation follows the hierarchy, enabling per-Department spending controls
+- token volume is tracked for all providers including zero-cost local models
+- cost governance integrates into the same execution pipeline as other runtime
+  safeguards, with no bypass path
+
+**Cons:**
+
+- introduces a new runtime subsystem with its own persistence and failure modes
+- checkpoint-based persistence means recent usage may be lost after a crash; the
+  model is best-effort, not exact
+- cost estimation for some tools is approximate; actual provider billing may differ
+  from runtime estimates
+
+Chosen. The operational protection benefit justifies the implementation cost. The
+best-effort persistence model is an explicitly accepted trade-off for v1.
+
+---
+
+# 4. Decision
+
+LemmingsOS introduces a **Runtime Cost Governance subsystem**.
+
+The subsystem tracks and enforces runtime cost budgets across the system hierarchy:
+
+```
+World → City → Department
+```
+
+Each scope may define limits that restrict the execution capacity of agents below it.
+
+Budget controls may include:
+
+- total budget
+- execution limits
+- cost thresholds
+- usage quotas
+
+Costs accumulate as agents perform operations that may generate monetary expense.
+
+The runtime evaluates budget availability before executing cost-generating operations.
+
+If a limit is exceeded, the runtime prevents the operation from executing.
+
+Budget enforcement therefore becomes a **first-class runtime safeguard**, similar to policy authorization, tool approval, and risk classification.
+
+Version 1 uses **checkpoint-based, best-effort cost persistence** rather than full event-level billing storage.
+
+Runtime usage is persisted at significant lifecycle boundaries such as:
+
+- LLM call completion
+- expensive tool completion
+- transition to `idle`
+- completion
+- failure
+- cancellation
+
+At these checkpoints, the runtime attempts to update aggregated cost counters for the Lemming instance and its enclosing scopes.
+
+If cost persistence fails, the failure does **not** block Lemming lifecycle progression, although the most recent usage update may be lost.
+
+This model is intentionally operational rather than billing-grade. Its purpose is deterministic runtime governance, not precise financial reconciliation.
+
+# 5. Budget Model
+
+Budgets are hierarchical and align with the system architecture.
+
+Example allocation structure:
+
+```
+World
+  total monthly budget
+
+City
+  allocated portion of world budget
+
+Department
+  allocated portion of city budget
+```
+
+Higher levels constrain lower levels.
+
+Lower scopes may define stricter limits but cannot exceed the limits of their parent scope.
+
+Budgets may be defined using different units depending on the type of resource.
+
+Supported budget units include:
+
+- currency (e.g., USD)
+- token counts
+- API call counts
+- execution quotas
+
+Examples:
+
+```
+World
+  monthly_budget_usd: 1000
+
+City: salvador
+  monthly_budget_usd: 300
+
+Department: research
+  llm_tokens_per_day: 2_000_000
+```
+
+Budgets may exist simultaneously across multiple resource categories.
+
+The runtime evaluates the effective budget by combining constraints inherited from all parent scopes.
+
+---
+
+# 6. Cost Sources
+
+The runtime tracks cost events generated by operations performed by agents.
+
+Typical cost sources include the following categories.
+
+## 6.1 LLM Usage
+
+Operations involving model inference may generate cost.
+
+Token usage data originates exclusively from the **Model Runtime** (ADR-0019). After
+every provider response, the Model Runtime emits a usage event directly to this
+subsystem before returning the result to the Lemming. The cost governance subsystem
+never polls Lemmings for token counts — the Model Runtime is the authoritative and
+sole source for all LLM usage events.
+
+For zero-cost providers (Ollama) and free-tier providers (Gemini free tier), token
+volume is still recorded. This enables context budget enforcement and capacity
+planning even when the monetary cost estimate is zero.
+
+Metadata tracked per inference call:
+
+- model provider
+- model identifier
+- prompt tokens
+- completion tokens
+- cache read / cache write tokens (where provider supports it)
+- estimated monetary cost
+
+## 6.2 External API Usage
+
+Many tools invoke external APIs that charge per request.
+
+Examples:
+
+- web search APIs
+- SaaS integrations
+- AI providers
+
+Tracked metrics may include:
+
+- request count
+- provider identifier
+- estimated cost per request
+
+## 6.3 Tool Execution
+
+Some tools trigger operations that incur infrastructure cost.
+
+Examples:
+
+- compute jobs
+- database operations
+- infrastructure automation
+
+Tracked metrics may include:
+
+- execution duration
+- compute resource usage
+- estimated infrastructure cost
+
+## 6.4 Long‑Running Processes
+
+Certain operations may accumulate cost over time.
+
+Examples:
+
+- continuous research agents
+- streaming API usage
+- batch processing tasks
+
+The runtime may track elapsed time or usage volume as part of cost accounting.
+
+---
+
+# 7. Budget Enforcement
+
+Budget enforcement occurs during the runtime execution pipeline.
+
+Before executing any operation that may generate cost, the runtime verifies whether sufficient budget remains.
+
+Possible enforcement strategies include:
+
+- blocking tool invocation
+- pausing agent execution
+- requiring approval for high-cost operations
+- throttling execution rate
+
+When the effective budget is exhausted, the runtime applies a **hard stop**.
+
+This means:
+
+- the Lemming may no longer execute cost-generating operations
+- the runtime blocks further spending immediately
+- execution is stopped even if the task has not yet completed
+
+Budget exhaustion therefore takes precedence over task completion.
+
+If a budget is exhausted, the runtime must **prevent further cost-generating operations** until the budget is replenished, reset, or the execution is manually resumed under updated policy.
+
+This ensures deterministic protection against runaway spending.
+
+Operators may later adjust budgets or resume execution manually.
+
+# 8. Runtime Integration
+
+Cost governance integrates directly into the runtime execution pipeline.
+
+Conceptual execution flow:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Authorization Check
+   ↓
+Risk Evaluation
+   ↓
+Approval Check
+   ↓
+Cost Budget Evaluation
+   ↓
+Tool Execution
+```
+
+The cost budget evaluation step occurs immediately before execution.
+
+If the runtime determines that the operation would exceed the effective budget, execution is rejected.
+
+The Lemming receives a runtime error indicating that budget constraints prevent the operation.
+
+This design ensures that cost governance operates consistently with other runtime safeguards.
+
+---
+
+# 9. Cost Tracking
+
+The following diagram illustrates the checkpoint-based tracking and hard-stop enforcement model:
+
+```text
+Lemming Instance
+      │
+      │ executes LLM call / Tool / external API
+      ▼
+Cost-generating operation
+      │
+      │ usage produced
+      ▼
+Runtime checkpoint boundary
+(idle / completion / failure / cancellation / expensive call finished)
+      │
+      ├── attempt aggregate cost update
+      │      ▼
+      │   Lemming cost counters
+      │   (best-effort persistence)
+      │
+      └── emit governance / audit event when relevant
+             ▼
+         Audit / Telemetry
+
+Before next cost-generating operation:
+
+Lemming
+   ▼
+Tool Runtime
+   ▼
+Authorization
+   ▼
+Risk / Approval
+   ▼
+Budget Evaluation
+   ├── budget available  ──► execute
+   └── budget exhausted ──► HARD STOP
+                              - no further spending
+                              - task may remain unfinished
+```
+
+A second view of hierarchical budget enforcement:
+
+```text
+World Budget
+   │
+   ├── City A Budget
+   │      │
+   │      ├── Department X Budget
+   │      │       └── Lemming instances consume from here,
+   │      │          while remaining bounded by all ancestors
+   │      │
+   │      └── Department Y Budget
+   │
+   └── City B Budget
+```
+
+
+The runtime emits **cost events** whenever a cost‑generating operation occurs.
+
+These events are recorded through the system's audit and telemetry infrastructure.
+
+Each event may include:
+
+- tool name
+- cost category
+- estimated or actual cost
+- world identifier
+- city identifier
+- department identifier
+- lemming instance identifier
+- timestamp
+
+Example conceptual event:
+
+```
+{:cost_event,
+  tool: "web_search",
+  cost_usd: 0.002,
+  world: "world_main",
+  city: "salvador",
+  department: "research",
+  lemming: "lem_123",
+  timestamp: ...
+}
+```
+
+These events support:
+
+- budget tracking
+- operational monitoring
+- audit and traceability
+
+The runtime uses these events to update cumulative usage counters associated with each budget scope.
+
+---
+
+# 10. Consequences
+
+## Positive
+
+- Hard stops guarantee that no Lemming can spend beyond its effective budget regardless
+  of how long it runs or how many tool calls it makes. The protection is structural, not
+  dependent on operator monitoring.
+- Hierarchical budget allocation enables per-Department spending controls without
+  requiring changes to individual Lemming definitions. Budget policy is an operational
+  concern, not a code concern.
+- Token volume is tracked for all providers including zero-cost local models. This
+  supports context budget enforcement and capacity planning even when the monetary cost
+  is zero.
+- Cost governance uses the same audit event model as other runtime safeguards, keeping
+  cost visibility consistent with the rest of the platform's observability.
+
+## Negative / Trade-offs
+
+- Checkpoint-based persistence means that usage accrued between the last checkpoint and
+  a process crash may be lost. The effective budget enforcement may temporarily allow
+  slightly more spending than the configured limit in crash recovery scenarios.
+- Cost estimation for external tools is approximate. The runtime cannot know the exact
+  provider billing in advance; post-hoc reconciliation may reveal discrepancies between
+  runtime estimates and actual charges.
+- Budget exhaustion stops execution even if the agent was performing valuable work close
+  to completion. Operators must tune budgets carefully to avoid premature termination
+  of legitimate long-running tasks.
+
+## Mitigations
+
+- The checkpoint-based model is explicitly documented as best-effort and operational
+  rather than billing-grade. Operators requiring financial precision must use provider
+  billing dashboards as the authoritative source.
+- Budget exhaustion produces a structured `{:error, :budget_exhausted}` result, not an
+  opaque failure. Lemmings can transition to a recoverable state rather than crashing.
+- Operators can set budgets with headroom to account for estimation approximation and
+  the checkpoint gap, treating the runtime budget as a conservative soft ceiling.
+
+---
+
+# 11. Non‑Goals
+
+Version 1 intentionally excludes several advanced features.
+
+Out of scope for v1:
+
+- precise billing reconciliation with providers
+- real‑time provider billing synchronization
+- predictive cost estimation
+- financial reporting systems
+- automated budget rebalancing
+
+The initial implementation focuses on **deterministic runtime enforcement** rather than full financial accounting.
+
+---
+
+# 12. Future Extensions
+
+Possible improvements include:
+
+- dynamic budget allocation between departments
+- predictive cost estimation
+- budget alerts and notifications
+- cost monitoring dashboards
+- integration with provider billing APIs
+- automatic throttling policies
+
+These extensions may build on the event model defined in this ADR without changing the core runtime enforcement architecture.
+
+---
+
+# 13. Rationale
+
+Autonomous systems that operate unattended must have structural guardrails against
+runaway resource consumption. Relying on operator supervision for cost control is not
+viable when agents are designed to run continuously without human interaction.
+
+The hierarchical budget model follows directly from the system's governance philosophy:
+each level of the hierarchy allocates resources to lower levels, and lower levels cannot
+exceed their allocation. This is the same principle applied to tool policy and
+authorization.
+
+The checkpoint-based persistence model is an explicit acceptance of the best-effort
+trade-off. Billing-grade precision would require event-level persistence with
+transactional guarantees on every operation, which is operationally expensive and
+architecturally complex. For the v1 goal of preventing runaway spending, checkpoint-based
+counters are sufficient.

--- a/docs/adr/0016-tool-execution-isolation-model.md
+++ b/docs/adr/0016-tool-execution-isolation-model.md
@@ -1,0 +1,708 @@
+# ADR-0016 — Tool Execution Isolation Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+In LemmingsOS, agents ("Lemmings") never interact with the external world directly. All external interactions occur through **Tools**, which are executed by the **Tool Runtime**.
+
+Tools may perform operations such as:
+
+- accessing external networks
+- calling third‑party APIs
+- executing local processes
+- reading or writing files
+- running compute workloads
+- interacting with external services
+
+Because tools are distributed as third‑party packages and may execute arbitrary logic, they represent a **major security boundary** in the architecture.
+
+Without proper isolation, a malicious or buggy tool could compromise the runtime environment. Potential risks include:
+
+### Filesystem Access
+
+A tool with unrestricted filesystem access could:
+
+- read sensitive host files
+- access runtime configuration
+- read secret storage locations
+- modify system files
+
+### Unrestricted Network Access
+
+Tools with unrestricted network access could:
+
+- exfiltrate sensitive data
+- communicate with unauthorized external services
+- scan internal networks
+- access cloud metadata endpoints
+
+### Arbitrary Process Execution
+
+Tools capable of launching unrestricted processes could:
+
+- execute shell commands
+- run malicious binaries
+- escape runtime supervision
+
+### Resource Exhaustion
+
+A faulty tool could consume unlimited resources such as:
+
+- CPU
+- memory
+- disk space
+- execution time
+
+This could degrade or crash the runtime host.
+
+### Data Exfiltration
+
+Tools may attempt to extract sensitive information through:
+
+- network requests
+- logs
+- external integrations
+
+### Privilege Escalation
+
+A tool running without isolation could attempt to:
+
+- escalate system privileges
+- access runtime internals
+- interfere with the BEAM VM
+
+Because tools may originate from **third‑party packages**, the runtime must assume that tool code cannot be fully trusted.
+
+Therefore the **Tool Runtime must enforce strong isolation guarantees** so that tools cannot compromise the host environment.
+
+At the same time, the system must remain simple enough to operate in **self‑hosted deployments**, such as:
+
+- single VPS installations
+- Docker environments
+- small on‑premise setups
+
+The isolation model must therefore balance **security and operational simplicity**.
+
+---
+
+# 2. Decision Drivers
+
+1. **Third-party tool packages cannot be fully trusted** — Tools originate from
+   external packages. The runtime must assume that tool code may be malicious or
+   buggy. Security must not depend on tool authors being trustworthy.
+
+2. **BEAM VM must be protected** — A tool crash or exploit must not affect the
+   runtime host's BEAM VM or other running Lemmings. Process isolation between the
+   VM and tool execution is a hard requirement.
+
+3. **Self-hosted constraint** — The isolation mechanism must work on a single VPS
+   without requiring container orchestration, a Kubernetes cluster, or cloud-specific
+   infrastructure. Operational complexity must remain proportional to deployment scale.
+
+4. **Defense in depth** — No single isolation mechanism is sufficient. The model must
+   compose multiple lightweight layers (process isolation, filesystem sandbox, network
+   restrictions, resource limits) rather than relying on any one mechanism.
+
+5. **Operational manageability** — Administrators must be able to configure isolation
+   policies (allowed commands, network allowlists, resource limits) without deep
+   systems expertise or infrastructure changes.
+
+---
+
+# 3. Considered Options
+
+## Option A — In-process execution inside the BEAM VM
+
+Tools run as Elixir processes within the BEAM VM, managed by the supervisor tree.
+
+**Pros:**
+
+- simplest implementation; no external process management
+- tools benefit from BEAM process isolation and supervision
+- straightforward error handling via OTP patterns
+
+**Cons:**
+
+- a tool that crashes with a segfault or similar native error can destabilize the BEAM
+  VM and affect all running Lemmings
+- tools running inside the VM have access to VM internals through Erlang's reflection
+  and introspection capabilities
+- filesystem and network access cannot be sandboxed at the process level inside the VM
+- a tool consuming unlimited memory inside the VM causes the entire node to fail
+
+Rejected. In-process execution cannot provide the process isolation and filesystem/
+network sandboxing required for untrusted third-party tool code.
+
+---
+
+## Option B — Full container isolation per invocation
+
+Each tool execution creates an ephemeral container. The container is destroyed after
+the tool completes.
+
+**Pros:**
+
+- strong isolation: container namespaces provide process, filesystem, and network
+  isolation by default
+- widely understood operational model
+
+**Cons:**
+
+- container lifecycle overhead (image pull, container start, teardown) adds latency to
+  every tool invocation; unsuitable for low-latency tools
+- requires a container runtime (Docker, containerd) as an operational dependency on
+  every deployment host, significantly increasing the self-hosted operational burden
+- image management for tool containers adds complexity to the tool packaging model
+- impractical for single VPS deployments without Docker infrastructure configured
+
+Rejected. The operational dependency on a container runtime is disproportionate to the
+target self-hosted deployment scale. The latency overhead per invocation is also
+unacceptable for frequently-invoked low-risk tools.
+
+---
+
+## Option C — Layered OS-level isolation (chosen)
+
+Tools execute in separate OS processes with filesystem sandboxing, network restrictions,
+and resource limits applied by the Tool Runtime. Each layer is independently
+configurable and can be strengthened as requirements evolve.
+
+**Pros:**
+
+- process isolation between tools and the BEAM VM without requiring a container runtime
+- filesystem and network restrictions are enforceable at the OS process level
+- resource limits (CPU, memory, execution time) prevent runaway tool processes
+- composable: each isolation layer can be configured independently; adding stronger
+  isolation in one dimension does not require redesigning others
+- works on a bare VPS without any container infrastructure
+
+**Cons:**
+
+- OS-level filesystem and network sandboxing is less hermetic than container namespaces
+- implementation must handle platform differences (Linux vs macOS for development)
+- command allowlist management requires ongoing maintenance as tool inventories grow
+
+Chosen. The model provides sufficient isolation for the self-hosted deployment target
+without requiring container infrastructure. The defense-in-depth composition of layers
+addresses the limitations of any single mechanism.
+
+---
+
+# 4. Decision
+
+LemmingsOS introduces a **Tool Execution Isolation Model** enforced by the Tool Runtime.
+
+All tool executions occur inside **controlled execution environments** managed by the runtime.
+
+Tools are never executed directly inside the BEAM VM or with unrestricted host access.
+
+Instead, the runtime creates a sandboxed execution context that applies several layers of isolation.
+
+Primary isolation mechanisms include:
+
+- process isolation
+- filesystem sandboxing
+- network sandboxing
+- resource limits
+
+These protections ensure that tools cannot access host resources beyond what is explicitly permitted.
+
+---
+
+# 5. Isolation Layers
+
+The Tool Runtime enforces multiple isolation layers. Each layer restricts a different class of potential attacks.
+
+The model intentionally composes several lightweight protections rather than relying on a single heavy isolation mechanism.
+
+```
+Tool Runtime
+      │
+      ▼
+Sandbox Environment
+      │
+      ├─ Process Isolation
+      ├─ Filesystem Sandbox
+      ├─ Network Sandbox
+      └─ Resource Limits
+```
+
+Each layer is described below.
+
+---
+
+# 6. Process Isolation and Trust Gradient
+
+The isolation requirement for a tool depends on its **trust classification**.
+LemmingsOS defines two tiers.
+
+## 6.1 Trusted first-party tools (in-process)
+
+Tools shipped as part of the LemmingsOS platform and reviewed by maintainers may
+execute as **native Elixir modules inside the BEAM VM**. These tools implement
+the `LemmingsOs.Tool` behaviour contract directly and run in a supervised Elixir
+process within the Tool Runtime.
+
+This tier is appropriate for:
+
+- low-risk, high-frequency operations where external process overhead is
+  unacceptable (e.g., text parsing, schema validation, local arithmetic)
+- tools that have no external side-effects or network access
+- tools whose complete source is audited and co-versioned with the platform
+
+In-process tools are still subject to all policy, authorization, audit, and cost
+governance enforcement by the Tool Runtime. In-process execution does **not** bypass
+governance; it only relaxes the process isolation layer.
+
+## 6.2 Third-party and community tools (external process)
+
+All tools originating from external Hex packages — including community tools and
+operator-supplied integrations — must execute in **separate operating system
+processes** managed by the Tool Runtime.
+
+This prevents untrusted tool code from:
+
+- crashing the BEAM VM
+- corrupting runtime memory
+- accessing internal runtime state or secrets
+
+The runtime may implement external-process isolation using one of several
+mechanisms:
+
+- supervised OS processes via `Port` or `MuonTrap`
+- containerized execution (future extension)
+- external tool runner processes
+
+Example execution path for external-process tools:
+
+```
+BEAM Runtime
+   │
+   ▼
+Tool Runtime (governance boundary)
+   │
+   ▼
+External Tool Runner Process
+   │
+   ▼
+Tool Adapter
+```
+
+If an external tool crashes or misbehaves, the BEAM runtime remains protected.
+
+## 6.3 Classification is explicit
+
+The trust tier of a tool is a field in its Tool Registry entry, not an implicit
+property of its package origin. The Tool Runtime reads this field at execution
+time to determine which isolation path to use. Misclassifying a third-party tool
+as first-party is a configuration error that will be flagged during tool
+installation review.
+
+---
+
+# 7. Filesystem Sandbox
+
+Tools must not have unrestricted access to the host filesystem.
+
+The Tool Runtime provides a **restricted working directory** for each tool execution.
+
+Allowed access typically includes:
+
+- temporary execution workspace
+- explicitly mounted directories
+- tool-specific working files
+
+Access is **denied by default** for:
+
+- host filesystem root
+- runtime configuration directories
+- secret storage locations
+- system directories
+
+Conceptual sandbox structure:
+
+```
+/sandbox
+   ├─ workspace/
+   ├─ input/
+   └─ output/
+```
+
+Tools may read and write only within the sandbox unless explicit mounts are configured.
+
+This prevents tools from reading sensitive host files or modifying system configuration.
+
+---
+
+# 8. Network Sandbox
+
+Tools must not be able to open unrestricted network connections.
+
+The runtime may enforce network restrictions such as:
+
+- outbound allowlists
+- DNS filtering
+- blocked internal networks
+- blocked metadata endpoints
+
+Example policy:
+
+```
+allowed_hosts:
+  - api.openai.com
+  - api.github.com
+```
+
+Connections to other destinations are denied by default.
+
+The runtime should also block access to common internal network targets such as:
+
+- localhost services
+- container metadata endpoints
+- cloud instance metadata APIs
+
+This significantly reduces the risk of data exfiltration and lateral movement.
+
+---
+
+# 9. Resource Limits
+
+Tools must not be able to consume unlimited system resources.
+
+The Tool Runtime may enforce resource limits including:
+
+- CPU usage
+- memory consumption
+- execution duration
+- concurrent tool executions
+
+Example runtime limits:
+
+```
+max_execution_time: 30s
+max_memory: 512MB
+max_cpu: 1 core
+```
+
+If a tool exceeds its limits, the runtime terminates execution and reports a failure.
+
+This protects the runtime host from resource exhaustion attacks or runaway workloads.
+
+---
+
+# 10. Controlled Command Execution
+
+Some tools may need to execute local binaries available on the host system. Examples include utilities such as `git`, `ffmpeg`, `jq`, or `rg`.
+
+To prevent arbitrary shell access, LemmingsOS introduces a **controlled command execution model**.
+
+Tools must not execute unrestricted shell commands (for example `bash -c`). Instead, process execution occurs through a runtime‑controlled command adapter.
+
+The adapter enforces an **allowlisted command catalog**.
+
+Example configuration:
+
+```
+allowed_commands:
+  git
+  gh
+  rg
+  jq
+```
+
+Each command entry defines runtime enforcement rules.
+
+Example conceptual definition:
+
+```
+commands:
+  git:
+    binary: /usr/bin/git
+    risk: medium
+    allowed_args:
+      - clone
+      - status
+      - diff
+      - log
+      - show
+    allowed_workdirs:
+      - /sandbox/workspace
+
+  gh:
+    binary: /usr/bin/gh
+    risk: high
+    allowed_args:
+      - issue
+      - pr
+      - repo
+    allow_network: true
+    allowed_hosts:
+      - api.github.com
+```
+
+The runtime validates command invocations before execution.
+
+Invocation format should use structured arguments rather than raw shell strings.
+
+Example invocation:
+
+```
+{
+  "command": "gh",
+  "args": ["issue", "list", "--limit", "20"]
+}
+```
+
+This allows the runtime to validate:
+
+- the binary being executed
+- permitted subcommands
+- argument structure
+- working directory constraints
+- network policy
+
+Tools may optionally include **LLM usage guidance** to reduce command guesswork.
+
+Example guidance:
+
+```
+llm_usage:
+  summary: GitHub CLI for repository operations
+  examples:
+    - gh issue list --limit 20
+    - gh pr view <number>
+```
+
+Runtime enforcement always takes precedence over LLM guidance.
+
+Unrestricted shell tools are considered **critical‑risk capabilities** and should be disabled by default or require explicit approval.
+
+---
+
+## Command Adapter Runtime
+
+The command execution path inside the Tool Runtime follows a structured validation and enforcement pipeline.
+
+```
+Tool Runtime
+     │
+     ▼
+Command Adapter
+     │
+     ├─ command allowlist check
+     ├─ argument validation
+     ├─ working directory policy
+     ├─ filesystem sandbox
+     ├─ network policy enforcement
+     └─ resource limits applied
+     │
+     ▼
+OS Process Execution
+```
+
+This adapter acts as a security boundary between tool logic and the host operating system.
+
+The adapter is responsible for rejecting any invocation that violates the command catalog rules before the process is spawned.
+
+---
+
+# 11. Model Runtime to Tool Runtime Integration
+
+Lemmings do not construct tool call requests directly. The model produces a structured
+output (ADR-0019) that the **Model Runtime** validates and returns to the Lemming as a
+`ModelResponse` with `stop_reason: :tool_use`. The Lemming extracts the tool decision
+from the response and dispatches it to the Tool Runtime.
+
+Conceptual decision handoff:
+
+```
+Model Runtime
+   ↓
+ModelResponse{stop_reason: :tool_use, content: [%ToolUseBlock{...}]}
+   ↓
+Lemming (extracts tool name + args)
+   ↓
+Tool Runtime
+   ↓
+Authorization → Risk → Approval → Budget → Sandbox → Execute
+```
+
+The Lemming is the boundary between the reasoning layer (Model Runtime) and the effect
+layer (Tool Runtime). Neither runtime calls the other directly. This keeps the two
+subsystems independently testable and independently governable.
+
+If the model produces an invalid or unparseable tool call, the Model Runtime's
+structured output validation (ADR-0019, section 9) handles retry before the response
+reaches the Lemming, preventing malformed inputs from entering the Tool Runtime pipeline.
+
+---
+
+# 12. Execution Flow
+
+The sandbox model integrates directly into the Tool Runtime pipeline.
+
+Conceptual execution flow:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Policy authorization
+   ↓
+Risk classification
+   ↓
+Approval workflow
+   ↓
+Cost governance
+   ↓
+Sandbox environment created
+   ↓
+Tool executed inside isolation
+   ↓
+Result returned
+```
+
+Expanded view:
+
+```
+Lemming Instance
+       │
+       ▼
+Tool Runtime
+       │
+       ├─ Authorization Check
+       ├─ Risk Governance
+       ├─ Approval Workflow
+       ├─ Budget Evaluation
+       │
+       ▼
+Sandbox Creation
+       │
+       ├─ Process isolation
+       ├─ Filesystem sandbox
+       ├─ Network sandbox
+       └─ Resource limits
+       │
+       ▼
+Tool Execution
+       │
+       ▼
+Result Returned to Lemming
+```
+
+Sandbox creation occurs **immediately before tool execution**.
+
+This ensures that all runtime governance decisions are evaluated before the tool receives any execution privileges.
+
+---
+
+# 13. Security Guarantees
+
+The isolation model provides several critical protections.
+
+Tools cannot:
+
+- access arbitrary host filesystem paths
+- read runtime configuration files
+- retrieve secrets directly
+- open unrestricted network connections
+- consume unlimited CPU or memory
+- execute inside the BEAM runtime
+
+As a result:
+
+- the runtime host remains protected
+- secret exposure risk is reduced
+- resource exhaustion attacks are limited
+
+The BEAM runtime remains isolated from tool execution failures.
+
+---
+
+# 14. Consequences
+
+## Positive
+
+- The BEAM VM is protected from tool crashes, memory corruption, and native-level
+  failures. A tool process that segfaults or is killed by resource limits does not
+  affect other Lemmings or the supervisor tree.
+- Secret values are never accessible to tool processes. The sandbox boundary ensures
+  that even a compromised tool cannot read credentials from the host filesystem or
+  environment.
+- Defense in depth means that bypassing one isolation layer (e.g., the filesystem
+  sandbox) does not automatically compromise other layers (e.g., network restrictions
+  or resource limits).
+
+## Negative / Trade-offs
+
+- OS-level sandboxing is less hermetic than container namespaces. A sufficiently
+  sophisticated exploit against the OS process isolation primitives could escape the
+  sandbox. Container-based isolation would provide stronger guarantees.
+- The command allowlist requires ongoing maintenance. As tool inventories grow,
+  administrators must keep the catalog up-to-date; a tool that needs a binary not in
+  the catalog will fail silently at the policy check.
+- Network allowlists must be configured per deployment. Tools that call external APIs
+  require their endpoints to be explicitly permitted, which creates operational overhead
+  for every new integration.
+
+## Mitigations
+
+- Container-based isolation is explicitly listed as a future extension. The layered
+  isolation model is designed so that containers can be added as an optional stronger
+  layer without changing the Tool Runtime contract.
+- The command adapter rejects unlisted commands with a clear policy error, not a
+  cryptic failure. Operators can diagnose allowlist gaps from audit events.
+- The control plane should provide a tool configuration review surface so administrators
+  can verify sandbox policies before enabling new tools for agent use.
+
+---
+
+# 15. Non‑Goals
+
+Version 1 intentionally avoids complex infrastructure requirements.
+
+The following capabilities are **out of scope for v1**:
+
+- full container orchestration
+- kernel-level virtualization
+- complex policy engines
+- remote sandbox clusters
+
+The initial implementation focuses on **practical local isolation** suitable for self‑hosted deployments.
+
+---
+
+# 16. Future Extensions
+
+Possible future improvements include:
+
+- container-based sandboxing
+- microVM execution environments (e.g., Firecracker)
+- remote tool execution clusters
+- signed tool packages
+- capability-based sandbox policies
+
+These extensions could further strengthen isolation without changing the core Tool Runtime architecture.
+
+---
+
+# 17. Rationale
+
+Tools are untrusted third-party code that executes in response to LLM-driven agent
+decisions. This combination — external code, AI-directed invocation — demands a defense
+posture that does not assume good faith from tool authors.
+
+The layered isolation model follows from this assumption: no single protection is
+sufficient, but composing process isolation, filesystem restrictions, network allowlists,
+and resource limits creates a meaningful security boundary without requiring container
+infrastructure on every deployment host.
+
+The self-hosted constraint is a real design driver. Requiring Docker or Kubernetes to run
+LemmingsOS on a VPS would exclude a significant part of the target audience. The OS-level
+isolation model provides adequate protection at the right operational cost for v1.

--- a/docs/adr/0017-runtime-topology-city-execution-model.md
+++ b/docs/adr/0017-runtime-topology-city-execution-model.md
@@ -1,0 +1,515 @@
+# ADR-0017 — Runtime Topology and City Execution Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS defines a hierarchical logical model for organizing autonomous agents:
+
+```
+World → City → Department → Lemming
+```
+
+**ADR-0002** established the foundational definition of City: *"a running Elixir/OTP node — Cities join and leave Worlds dynamically, mapping directly to a `Node` in Elixir distributed computing."*
+
+This ADR expands that definition. Where ADR-0002 names the concept, this ADR specifies the full runtime topology: what services run inside a City node, how isolation boundaries are enforced at the node level, how credentials are kept local, and how multi-City deployments are structured.
+
+Other ADRs define execution behavior (ADR-0004), tool governance (ADR-0005, ADR-0012, ADR-0016), and security boundaries (ADR-0003, ADR-0009). However, the **physical runtime topology** of the system has not yet been explicitly defined.
+
+Specifically, the system requires a clear definition of:
+
+- how Cities map to runtime infrastructure
+- where BEAM nodes execute
+- where the Tool Runtime operates
+- where the Secret Bank resides
+- how isolation boundaries are enforced
+- how routing works between runtime nodes
+
+LemmingsOS is designed to run across a wide range of operational environments:
+
+- single VPS self‑hosted deployments
+- small clusters
+- distributed infrastructures
+
+Therefore the runtime topology must satisfy several design goals:
+
+- remain simple for small installations
+- support horizontal scaling
+- provide strong isolation boundaries
+- maintain predictable runtime behavior
+
+The logical hierarchy therefore must map to infrastructure in a deterministic and operationally understandable way.
+
+To achieve this, LemmingsOS treats **Cities as runtime execution units and isolation boundaries**.
+
+This approach provides several benefits:
+
+- **fault isolation** — failures in one City do not impact others
+- **operational boundaries** — Cities can be deployed, upgraded, or restarted independently
+- **deployment flexibility** — Cities may run on separate infrastructure
+- **scaling capability** — additional Cities can be added horizontally
+
+---
+
+# 2. Decision Drivers
+
+1. **Operational simplicity at minimal scale** — A single VPS deployment must be
+   straightforward to install and operate. The topology must not require a cluster by
+   default. A developer should be able to run a fully functional World with one City
+   on one host.
+
+2. **Horizontal scaling** — Adding more agent execution capacity must not require
+   redesigning the architecture. The topology must scale by adding City nodes, not by
+   vertically growing a monolith or centralizing all execution in one process.
+
+3. **Fault isolation** — A failure in one City (a crash, a resource exhaustion, a
+   misconfigured tool) must not cascade to other Cities. Isolation boundaries must be
+   structural, not reliant on graceful error handling.
+
+4. **Alignment with the logical hierarchy** — The physical deployment model must
+   mirror the logical World → City → Department structure. An operational topology
+   that diverges from the logical model creates a dual mental model burden.
+
+5. **Secret and credential locality** — Each City must own and isolate its runtime
+   credentials. Secrets must not transit between City runtime boundaries, even within
+   the same World.
+
+---
+
+# 3. Considered Options
+
+## Option A — Single monolithic BEAM node for all Cities
+
+All Departments and Lemmings across all Cities run in one BEAM node. Cities are
+logical namespaces in the application code, not runtime boundaries.
+
+**Pros:**
+
+- simplest deployment: one Elixir application, one node to operate
+- no inter-node communication required
+- shared memory simplifies state access across Departments
+
+**Cons:**
+
+- a failure or resource exhaustion in one Department can destabilize the entire node,
+  affecting all Cities and Departments simultaneously
+- Cities cannot be deployed, upgraded, or scaled independently
+- secrets for all Cities reside in the same process tree, reducing the isolation
+  guarantee even if the Secret Bank is logically partitioned
+- there is no physical boundary enforcing the isolation that the logical model implies
+
+Rejected. The monolith provides no fault isolation and makes independent City
+operations impossible. For a system where Cities may run different workloads with
+different risk profiles, shared execution is a structural liability.
+
+---
+
+## Option B — World-scoped runtime with City process groups
+
+One BEAM node per World. Cities are isolated as OTP application boundaries or process
+groups within the node, but the underlying BEAM instance is shared.
+
+**Pros:**
+
+- finer granularity than a single monolith
+- OTP supervision can restart a City's process group without affecting others
+
+**Cons:**
+
+- shared BEAM node means a BEAM-level crash (hardware failure, OOM kill) still affects
+  all Cities simultaneously
+- the isolation guarantee is weaker: a runaway Elixir process inside one City can
+  consume VM memory or scheduler capacity affecting other Cities
+- independent deployment and upgrade of individual Cities is not possible
+
+Rejected. The shared BEAM node does not provide the fault and operational isolation
+that City-as-a-boundary requires. The model is a partial improvement over the monolith
+but does not reach the isolation standard.
+
+---
+
+## Option C — City as an independent BEAM runtime node (chosen)
+
+Each City runs as an independent BEAM node with its own supervised process tree. The
+World provides shared durable persistence (PostgreSQL) but does not act as a shared
+execution environment.
+
+**Pros:**
+
+- complete fault isolation: a City crash affects only that City's Lemmings
+- Cities can be deployed, upgraded, and scaled independently
+- secret isolation is structural: each City's Secret Bank runs in a separate process
+  tree with no shared memory
+- the deployment model is naturally simple at small scale (one City = one node on one
+  host) and scales horizontally without architecture changes
+
+**Cons:**
+
+- the World layer requires coordination between City nodes for governance data (audit
+  events, approval records, cost counters); this must flow through the shared
+  persistence layer, not directly between nodes
+- cross-City communication requires explicit routing if needed (disabled by default)
+- operating a multi-City World requires managing multiple BEAM nodes
+
+Chosen. The isolation, scalability, and operational clarity benefits justify the
+multi-node coordination cost. The shared persistence layer (PostgreSQL) handles the
+cross-City governance data with well-understood operational characteristics.
+
+---
+
+# 4. Decision
+
+In LemmingsOS, a **City represents a runtime execution node**.
+
+Each City runs a complete runtime environment that includes all services required to execute agents within that City.
+
+Each City runs:
+
+- a BEAM node
+- the Lemmings runtime
+- the Tool Runtime
+- the Secret Bank
+- supporting runtime services
+
+Departments and Lemmings exist **inside a City** and execute exclusively within that City's runtime environment.
+
+Cities do not share runtime state with one another.
+
+The **World** represents the logical grouping of Cities but does not act as a shared runtime execution environment.
+
+This model keeps runtime boundaries simple and explicit.
+
+---
+
+# 5. Runtime Topology
+
+The conceptual runtime structure is as follows:
+
+```
+World
+  ├─ City (runtime node)
+  │     ├─ Tool Runtime
+  │     ├─ Secret Bank
+  │     ├─ Departments
+  │     │     └─ Lemmings
+  │
+  └─ City (another runtime node)
+```
+
+Each City may be deployed on different types of infrastructure.
+
+Possible deployment targets include:
+
+- a single host
+- a virtual machine
+- a container
+- a BEAM cluster node
+
+A minimal deployment may run a single World with a single City on a single host.
+
+Larger installations may deploy multiple Cities across different machines or regions.
+
+This model allows operators to scale the system by **adding additional City nodes** without changing the core architecture.
+
+---
+
+# 6. Isolation Boundary
+
+A **City is the primary runtime isolation boundary** within a World.
+
+Cities isolate several critical aspects of the runtime environment.
+
+Isolation applies to:
+
+- runtime processes
+- secret storage
+- tool execution
+- network access
+- agent execution context
+
+Cities must not share:
+
+- secrets
+- internal runtime state
+- agent memory or context
+- local runtime services
+
+Each City maintains its own Secret Bank instance and Tool Runtime.
+
+This ensures that:
+
+- credentials remain local to the City
+- governance policies apply locally
+- operational failures remain contained
+
+Isolation at the City level also simplifies operational reasoning.
+
+If a City experiences failure, misconfiguration, or overload, the impact remains limited to that City's agents.
+
+---
+
+# 7. Cross‑City Communication
+
+Cities are isolated by default.
+
+Cross‑City communication is **disabled unless explicitly configured**.
+
+If communication between Cities is required, it must occur through an explicit routing mechanism such as a gateway or external integration layer.
+
+Implicit sharing of runtime state is not permitted.
+
+Typical default behavior:
+
+```
+cross_city_communication = disabled
+```
+
+Optional deployments may enable controlled communication using explicit routing components.
+
+Benefits of this approach include:
+
+- stronger security guarantees
+- predictable multi‑tenant isolation
+- prevention of accidental coupling between runtime nodes
+
+This design mirrors the strong isolation guarantees already defined at the World level.
+
+---
+
+# 8. Execution Locality
+
+Agent execution is always **local to the City in which the agent resides**.
+
+Execution locality rules:
+
+- Lemmings execute only within their City
+- Tool Runtime executes within the same City
+- Secrets are resolved by the City's Secret Bank
+- Tool adapters execute locally within the City environment
+
+This locality model ensures:
+
+- policy enforcement occurs locally
+- secrets never cross runtime boundaries
+- predictable cost governance
+- deterministic runtime behavior
+
+Tool execution therefore follows a local pipeline.
+
+---
+
+# 9. Example Execution Flow
+
+Example tool invocation inside a City:
+
+```
+Lemming
+   ↓
+Tool Runtime
+   ↓
+Sandbox
+   ↓
+External System
+```
+
+Expanded conceptual flow:
+
+```
+Lemming Instance
+      ↓
+Tool Runtime
+      ↓
+Policy / Risk / Approval / Budget checks
+      ↓
+Secret resolution (Secret Bank)
+      ↓
+Sandboxed Tool Execution
+      ↓
+External System
+      ↓
+Result returned to Lemming
+```
+
+Because all runtime components reside inside the City boundary, the runtime can enforce governance policies consistently.
+
+---
+
+# 10. Runtime Topology Overview
+
+Example distributed deployment:
+
+```
+World
+   │
+   ├─ City A (host/node)
+   │      ├─ Lemmings
+   │      ├─ Tool Runtime
+   │      └─ Secret Bank
+   │
+   └─ City B (host/node)
+          ├─ Lemmings
+          ├─ Tool Runtime
+          └─ Secret Bank
+```
+
+Each City operates independently while belonging to the same logical World.
+
+Operational actions such as:
+
+- scaling
+- upgrades
+- maintenance
+- restarts
+
+may occur independently for each City.
+
+---
+
+# 11. Consequences
+
+## Positive
+
+- Fault isolation is structural: a City that crashes, runs out of memory, or executes
+  a runaway tool does not affect Lemmings in other Cities. The blast radius of any
+  single failure is bounded by the City boundary.
+- Cities can be independently deployed, upgraded, and scaled. An operator upgrading
+  one City's runtime version does not need to coordinate with or restart other Cities.
+- Secret isolation is enforced at the process boundary. A Secret Bank in City A has no
+  memory or process access to secrets in City B, regardless of application-level code.
+
+## Negative / Trade-offs
+
+- Operating a multi-City World requires managing multiple BEAM nodes. Operators must
+  understand how to deploy, monitor, and restart independent nodes rather than a single
+  application process.
+- Cross-City coordination (governance data, audit events, cost counters) flows through
+  the shared PostgreSQL layer. This layer becomes a shared dependency; a database
+  outage affects all Cities' ability to write governance records.
+- A minimal single-City deployment carries the same topology model as a large
+  multi-City deployment. There is no simplified single-process mode for local
+  development or evaluation.
+
+## Mitigations
+
+- The minimal deployment (one World, one City, one host) runs a single BEAM node.
+  Multi-node complexity only materializes when operators choose to add Cities.
+- PostgreSQL is already required by the platform for all persistent storage. The
+  shared persistence layer does not introduce a new operational dependency.
+- City runtime failures are independent; a City that cannot reach the database for
+  governance writes continues executing locally and retries writes when connectivity
+  restores. Execution is not blocked by governance persistence failures.
+
+---
+
+# 12. Non‑Goals
+
+The following features are explicitly out of scope for version 1:
+
+- complex multi‑cluster orchestration
+- cross‑City state replication
+- distributed actor migration
+- global secret storage
+- automatic runtime load balancing between Cities
+
+These features introduce significant complexity and are unnecessary for the initial runtime architecture.
+
+The v1 goal is a **simple, predictable, and secure runtime topology**.
+
+---
+
+# 13. Future Extensions
+
+Possible future improvements include:
+
+- BEAM clustering between Cities
+- City auto‑scaling
+- remote tool runners
+- multi‑region World deployments
+- distributed telemetry aggregation
+
+These extensions may build on the City execution model defined in this ADR without changing the core isolation principle.
+
+Cities remain the fundamental runtime boundary of LemmingsOS.
+
+---
+
+# Persistence and Shared Services
+
+The **World** provides the durable storage layer used by all Cities.
+
+Cities are independent runtime nodes but rely on shared World‑scoped infrastructure for persistence and governance data.
+
+Typical World‑level shared services include:
+
+- PostgreSQL database
+- control plane APIs and UI
+- audit log storage
+- approval workflow persistence
+- cost governance counters
+
+Cities do **not** route persistence operations through other Cities.
+
+Instead, each City runtime communicates directly with the World persistence layer.
+
+Conceptual flow:
+
+```text
+Lemming (City B)
+      ↓
+City Runtime Services
+      ↓
+World Persistence Layer (PostgreSQL)
+```
+
+This design ensures:
+
+- Cities remain operationally independent
+- failure of one City does not block persistence for others
+- audit and governance data remain globally visible
+
+Direct City‑to‑City routing for persistence is intentionally avoided.
+
+The City boundary therefore isolates **execution**, while the World layer provides **durable governance storage**.
+
+## Local vs Shared Responsibilities
+
+World‑scoped components:
+
+- PostgreSQL storage
+- control plane
+- audit events
+- approval records
+- cost accounting
+
+City‑scoped components:
+
+- BEAM runtime node
+- Lemming execution processes
+- Tool Runtime
+- Secret Bank
+- sandbox execution environments
+
+This separation preserves runtime isolation while allowing consistent governance across the system hierarchy.
+
+---
+
+# 14. Rationale
+
+The City-as-runtime-node model follows directly from the system's core design principle:
+the logical hierarchy must map predictably to operational boundaries. A topology that
+diverges from the logical model forces operators to maintain two separate mental models
+simultaneously.
+
+Making Cities the unit of operational isolation means that capacity, failure, and
+upgrade decisions all operate at the City granularity. This is the right level for a
+system organized around organizational units: a team managing a City can operate it
+independently without coordinating with other City operators.
+
+The shared PostgreSQL persistence layer is a deliberate trade-off. Distributed consensus
+or event streaming infrastructure would provide stronger isolation but at significant
+operational cost. PostgreSQL is already required, well-understood, and sufficient for
+the governance data volume that v1 will generate.

--- a/docs/adr/0018-audit-log-event-model.md
+++ b/docs/adr/0018-audit-log-event-model.md
@@ -1,0 +1,1041 @@
+# ADR-0018 — Audit Log / Event Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+Multiple LemmingsOS ADRs already depend on a shared audit and event model, but that model has not yet been defined centrally.
+
+Today the architecture already references concepts such as:
+
+- append-only audit log
+- audit events for secret access and secret changes
+- authentication and authorization audit events
+- tool approval lifecycle events
+- tool execution events
+- cost governance events
+- structured telemetry and runtime observability
+
+However, without a single ADR defining the platform event model, several important questions remain ambiguous:
+
+- what fields every event must contain
+- how actors, scope, and resources are represented
+- how traceability works across multi-step flows
+- how audit events differ from telemetry events
+- what immutability guarantees apply
+- how events are queried, retained, and indexed
+
+Because LemmingsOS is designed as a self-hosted runtime for autonomous systems, auditability is not optional.
+
+Operators must be able to answer questions such as:
+
+- who changed this policy?
+- which user approved this tool execution?
+- which Lemming accessed this credential-bound capability?
+- why was a tool execution denied?
+- which sequence of events led to a failure or cost spike?
+
+The event model must therefore support both:
+
+1. **forensic auditability** for security and governance
+2. **operational observability** for debugging and monitoring
+
+The model must also align with the system hierarchy:
+
+```text
+World → City → Department → Lemming
+```
+
+and remain practical for version 1 self-hosted deployments using PostgreSQL as the default durable system database.
+
+---
+
+# 2. Decision Drivers
+
+1. **Multiple subsystems already depend on audit events** — ADRs 0009 through 0015 all
+   reference audit events without a shared contract. A central definition is required
+   to resolve field naming ambiguity, prevent per-subsystem schema drift, and ensure
+   cross-subsystem correlation works.
+
+2. **Forensic traceability is a first-class requirement** — The system manages
+   autonomous agents that may affect production systems, infrastructure, and financial
+   resources. Operators must be able to reconstruct any multi-step event chain post-hoc,
+   including who approved what and which agent caused which side effect.
+
+3. **Self-hosted constraint** — The event model must work with PostgreSQL as the only
+   required storage dependency. Kafka, NATS, or dedicated event infrastructure must not
+   be required. Self-hosted operators should not need to operate a message broker to
+   have governance coverage.
+
+4. **Distinct semantics for audit vs telemetry** — Security and governance records
+   require strong immutability and long retention. Operational metrics may have shorter
+   retention and different querying patterns. Both must share infrastructure but must
+   remain semantically distinct.
+
+5. **Cross-subsystem correlation** — A single operator action may produce events across
+   auth, tool authorization, approval, secret resolution, and cost governance. The model
+   must provide a `correlation_id` and `causation_id` mechanism to reconstruct these
+   chains without requiring a separate tracing infrastructure.
+
+6. **Prevent per-subsystem schema drift** — Without a central ADR, each subsystem
+   invents slightly different field names, actor representations, and scope encodings.
+   A unified canonical envelope eliminates this class of consistency problem.
+
+---
+
+# 3. Considered Options
+
+## Option A — Per-subsystem event schemas, each subsystem defines its own format
+
+Each subsystem (auth, tool runtime, approval manager, cost governance) defines its own
+event table or log format independently.
+
+**Pros:**
+
+- each subsystem can optimize its schema for its specific query patterns
+- no cross-subsystem coordination required during development
+
+**Cons:**
+
+- forensic reconstruction across subsystems requires joining inconsistently structured
+  records with different field names for the same concepts (actor, scope, resource)
+- `correlation_id` semantics must be agreed on informally; without a central definition,
+  implementations will diverge
+- adding a new observability dashboard requires understanding multiple incompatible schemas
+- the audit guarantee (append-only, immutable) must be implemented and verified
+  independently in every subsystem
+
+Rejected. The forensic traceability requirement cannot be satisfied by a collection of
+independently designed schemas. Cross-subsystem event reconstruction is the primary
+governance use case and must be a first-class design goal.
+
+---
+
+## Option B — Separate audit log and telemetry infrastructure with distinct tables and schemas
+
+Audit events go to a dedicated `audit_events` table (or service). Telemetry events go
+to a separate `telemetry_events` table with different fields. Each family is managed
+independently.
+
+**Pros:**
+
+- strict separation of retention and immutability policies
+- each table can be optimized independently
+
+**Cons:**
+
+- shared query patterns (filtering by correlation_id, by actor, by City) must be
+  implemented against two separate tables
+- the canonical envelope fields (event_id, occurred_at, world_id, correlation_id) would
+  be duplicated between schemas, creating maintenance overhead
+- the conceptual overhead of routing each new event type to the correct table adds
+  friction for contributors
+
+Rejected. The overhead of maintaining two separate schemas for what are structurally
+similar records does not justify the separation. Retention and semantic differences can
+be expressed through an `event_family` field in a shared table.
+
+---
+
+## Option C — Unified canonical event envelope with explicit event_family distinction (chosen)
+
+All durable platform events share the same base envelope schema stored in a single
+PostgreSQL table. Events are distinguished by `event_family` (audit vs telemetry) and
+`event_type`. Retention policy and immutability guarantees are enforced at the
+`event_family` level.
+
+**Pros:**
+
+- single schema to implement, document, and query across all subsystems
+- cross-subsystem forensic reconstruction works with a single query by `correlation_id`
+- adding a new event type requires only naming the event and defining its payload;
+  the envelope and infrastructure are already in place
+- immutability guarantees apply uniformly to the entire store
+- PostgreSQL is already required; no new operational dependency
+
+**Cons:**
+
+- all event producers must adopt the shared envelope, which requires up-front
+  coordination during development
+- a single table may grow large in active systems; retention and indexing require
+  deliberate maintenance
+- telemetry and audit sharing storage means a misconfigured deletion policy could
+  accidentally affect audit records
+
+Chosen. The forensic traceability and operational simplicity requirements favor a single
+unified model. The risks are manageable through explicit retention policy separation
+and careful index design.
+
+---
+
+# 4. Decision
+
+LemmingsOS adopts a **unified platform event model** with a shared canonical envelope and two explicit event families:
+
+- `audit`
+- `telemetry`
+
+All durable platform events use the same base envelope.
+
+Each event:
+
+- is immutable once written
+- is append-only
+- is tagged with hierarchy scope
+- records actor and resource context when applicable
+- supports correlation across multi-step workflows
+- stores event-specific details in a structured payload
+
+Version 1 stores durable events in a **single PostgreSQL-backed event store**.
+
+The platform distinguishes clearly between:
+
+- **audit events**: security, governance, control-plane, approval, and important runtime decision records
+- **telemetry events**: operational lifecycle, counters, timings, and other observability-oriented records
+
+Both families may share the same storage table and base schema in v1, but they must remain semantically distinct through explicit fields and retention policy.
+
+---
+
+# 5. Event Families
+
+## 5.1 Audit Events
+
+Audit events record actions or decisions that matter for governance, accountability, security, or forensic reconstruction.
+
+Typical audit events include:
+
+- user login
+- user logout
+- password change
+- user created
+- assignment changed
+- secret created
+- secret replaced
+- secret accessed by Tool Runtime
+- tool invocation requested
+- tool invocation denied
+- approval requested
+- approval granted
+- approval rejected
+- budget exhausted hard stop
+- model request blocked by budget (`model.budget_denied`)
+- policy changed
+- tool enabled or disabled
+- Department or Lemming created, updated, paused, resumed, or terminated
+
+Audit events are intended to answer:
+
+- who did what
+- to which resource
+- in which scope
+- when
+- as part of which workflow
+- with what outcome
+
+## 5.2 Telemetry Events
+
+Telemetry events record operational behavior for debugging, monitoring, capacity management, and performance analysis.
+
+Typical telemetry events include:
+
+- Lemming started
+- Lemming completed
+- Lemming failed
+- Department restarted
+- City unreachable
+- tool execution duration
+- retry count incremented
+- queue depth sampled
+- compaction executed
+- sandbox resource limit hit
+- checkpoint written
+- model request dispatched (`model.request_started`)
+- model response received (`model.response_received`)
+- model retry attempt (`model.retry`)
+- model request failed after retries (`model.request_failed`)
+- model token usage recorded (`model.usage`) — primary input for ADR-0015
+- model structured output validation failed (`model.structured_output_invalid`)
+
+Model Runtime events (ADR-0019, section 13) follow the same canonical envelope as
+all other platform events, using `world_id`, `city_id`, `department_id`,
+`lemming_id`, and `correlation_id` to provide full hierarchy context. `model.usage`
+carries the token breakdown in `payload` and is the sole source for token accounting
+in the cost governance subsystem (ADR-0015).
+
+Telemetry events are intended to answer:
+
+- what is the system doing
+- how often it is happening
+- how long it took
+- where performance or reliability problems exist
+
+## 5.3 Shared Envelope, Distinct Semantics
+
+Audit and telemetry use the same base envelope so that infrastructure remains simple and query patterns remain consistent.
+
+However:
+
+- `audit` is governance-oriented and must preserve strong immutability expectations
+- `telemetry` is observability-oriented and may have shorter retention or aggregation rules
+
+This distinction must be explicit in the schema through `event_family`.
+
+---
+
+# 6. Canonical Event Envelope
+
+Every durable event must contain the following canonical fields.
+
+## 6.1 Required Fields
+
+- `event_id`
+- `event_family`
+- `event_type`
+- `occurred_at`
+- `inserted_at`
+- `world_id`
+- `correlation_id`
+- `payload`
+
+## 6.2 Standard Optional Fields
+
+The following fields are optional in the general schema, but should be populated whenever applicable.
+
+### Hierarchy Scope
+
+- `city_id`
+- `department_id`
+- `lemming_id`
+
+### Actor
+
+- `actor_type`
+- `actor_id`
+- `actor_role`
+
+### Resource
+
+- `resource_type`
+- `resource_id`
+
+### Workflow / Execution Context
+
+- `causation_id`
+- `tool_invocation_id`
+- `approval_request_id`
+- `request_id`
+
+### Outcome / Description
+
+- `action`
+- `status`
+- `message`
+
+## 6.3 Field Semantics
+
+### `event_id`
+
+Globally unique identifier for the event.
+
+### `event_family`
+
+One of:
+
+- `audit`
+- `telemetry`
+
+### `event_type`
+
+Stable machine-readable event name.
+
+Examples:
+
+- `auth.login_succeeded`
+- `auth.login_failed`
+- `secret.accessed`
+- `tool.invocation_requested`
+- `tool.invocation_denied`
+- `approval.requested`
+- `approval.approved`
+- `approval.rejected`
+- `budget.exhausted`
+- `model.request_started`
+- `model.response_received`
+- `model.retry`
+- `model.request_failed`
+- `model.usage`
+- `model.budget_denied`
+- `model.structured_output_invalid`
+- `lemming.failed`
+- `city.unreachable`
+
+### `occurred_at`
+
+Timestamp representing when the underlying action or observation happened.
+
+### `inserted_at`
+
+Timestamp representing when the event was persisted in the durable event store.
+
+These may differ if the system buffers or retries insertion.
+
+### `world_id`, `city_id`, `department_id`, `lemming_id`
+
+Hierarchy scope for the event.
+
+At minimum, every event must include `world_id`.
+
+More specific scope fields are included when the event belongs to that part of the hierarchy.
+
+### `actor_type`
+
+Originator category.
+
+Typical values:
+
+- `user`
+- `lemming`
+- `system`
+- `tool_runtime`
+- `approval_manager`
+- `control_plane`
+
+### `actor_id`
+
+Identifier of the actor within its category.
+
+Examples:
+
+- user id
+- lemming instance id
+- system component name
+
+### `actor_role`
+
+Relevant for human control-plane actions, where the acting role matters.
+
+Examples:
+
+- `admin`
+- `operator`
+- `viewer`
+
+### `resource_type` and `resource_id`
+
+Describe the target object affected by the action.
+
+Examples:
+
+- `user`
+- `secret`
+- `tool`
+- `tool_invocation`
+- `approval_request`
+- `department`
+- `lemming`
+- `policy`
+
+### `correlation_id`
+
+A stable identifier tying together all events belonging to the same end-to-end workflow, request, or runtime execution path.
+
+### `causation_id`
+
+Points to the immediately preceding event that caused the current event.
+
+Used to reconstruct chains such as:
+
+```text
+user action
+  → tool invocation requested
+  → approval requested
+  → approval approved
+  → tool executed
+  → cost recorded
+```
+
+### `payload`
+
+Structured JSON object containing event-specific details.
+
+Payload must remain machine-readable and bounded in size.
+
+### `message`
+
+Short human-readable summary for operators and dashboards.
+
+### `action`
+
+Normalized action name when useful.
+
+Examples:
+
+- `create`
+- `update`
+- `delete`
+- `approve`
+- `reject`
+- `execute`
+- `deny`
+
+### `status`
+
+Normalized outcome status when useful.
+
+Examples:
+
+- `requested`
+- `allowed`
+- `denied`
+- `approved`
+- `rejected`
+- `succeeded`
+- `failed`
+
+---
+
+# 7. Actor, Scope, and Resource Model
+
+The event model separates three concepts that must not be conflated.
+
+## 7.1 Actor
+
+The **actor** is who or what initiated the action.
+
+Examples:
+
+- a human operator
+- a Lemming instance
+- the Tool Runtime
+- the ApprovalManager
+- an internal recovery process
+
+## 7.2 Scope
+
+The **scope** is where in the hierarchy the event occurred.
+
+Examples:
+
+- world `prod`
+- city `salvador`
+- department `infra`
+- lemming `lem_123`
+
+## 7.3 Resource
+
+The **resource** is the object affected by the action.
+
+Examples:
+
+- secret `github.token`
+- approval request `apr_998`
+- tool invocation `inv_78421`
+- department `support`
+
+These may differ.
+
+Example:
+
+```text
+actor     = user:operator_17
+scope     = world=prod, city=salvador, department=infra
+resource  = tool_invocation:inv_78421
+```
+
+This distinction is mandatory because many important governance events involve one actor operating on a different resource within a larger scope.
+
+---
+
+# 8. Correlation and Traceability
+
+LemmingsOS must support reconstruction of multi-step flows across runtime subsystems.
+
+Therefore:
+
+- every durable event must include a `correlation_id`
+- events should include `causation_id` whenever the triggering event is known
+
+## 8.1 Correlation ID
+
+The `correlation_id` ties together all events belonging to the same logical execution flow.
+
+Examples:
+
+- one user request through the control plane
+- one lemming execution instance
+- one tool invocation workflow
+- one approval-gated execution path
+
+## 8.2 Causation ID
+
+The `causation_id` links an event to the immediately prior event that caused it.
+
+This enables causality reconstruction rather than only loose grouping.
+
+## 8.3 Example Flow
+
+```text
+event-1  auth.login_succeeded
+event-2  lemming.created                causation_id=event-1
+event-3  tool.invocation_requested      causation_id=event-2
+event-4  approval.requested             causation_id=event-3
+event-5  approval.approved              causation_id=event-4
+event-6  tool.invocation_succeeded      causation_id=event-5
+event-7  cost.recorded                  causation_id=event-6
+```
+
+All of the above share the same `correlation_id` when they belong to the same operational flow.
+
+---
+
+# 9. Append-Only and Immutability Invariants
+
+The durable event store is **append-only**.
+
+## 9.1 Core Invariants
+
+1. Events are never updated in place.
+2. Events are never rewritten to change historical meaning.
+3. Corrections must be represented as new compensating events.
+4. `occurred_at` and `inserted_at` are immutable once written.
+5. Event identity is permanent.
+
+## 9.2 Correction Model
+
+If a prior event is incorrect, the system must not mutate it.
+
+Instead, write a new event such as:
+
+- `policy.change_reverted`
+- `approval.corrected`
+- `secret.rotation_superseded`
+- `audit.annotation_added`
+
+This preserves history and forensic trust.
+
+## 9.3 Deletion Semantics
+
+In v1:
+
+- audit events must not be physically deleted during normal operation
+- telemetry events may be subject to retention or archival policy, but never mutated
+
+---
+
+# 10. Payload Rules and Sensitive Data
+
+The payload is intentionally flexible, but not unbounded.
+
+## 10.1 Allowed Payload Content
+
+Payload may include:
+
+- parameter summaries
+- identifiers
+- counters
+- durations
+- model names
+- cost estimates
+- sandbox decisions
+- validation errors
+- structured reason codes
+
+## 10.2 Forbidden Content
+
+Events must never store:
+
+- raw secret values
+- API tokens
+- passwords
+- session secrets
+- full credential blobs
+- private keys
+- encryption master keys
+
+Events should also avoid storing:
+
+- oversized raw tool outputs
+- full prompt transcripts unless explicitly promoted by design
+- arbitrary internal chain-of-thought style reasoning
+
+## 10.3 Large Data Handling
+
+If event-related data is too large, the event should store:
+
+- a bounded summary in `payload`
+- an artifact reference or external storage reference if needed
+
+Example:
+
+```json
+{
+  "artifact_ref": "artifact://tool-results/abc123",
+  "summary": "terraform plan produced 14 changes"
+}
+```
+
+---
+
+# 11. Storage Model for v1
+
+Version 1 uses a **single PostgreSQL-backed durable event store**.
+
+The recommended initial schema is a single `events` table with a JSONB payload and explicit indexed columns for common query dimensions.
+
+## 11.1 Recommended Table Shape
+
+Conceptual schema:
+
+```text
+events
+  event_id               uuid / ulid primary key
+  event_family           text not null
+  event_type             text not null
+  occurred_at            timestamptz not null
+  inserted_at            timestamptz not null
+
+  world_id               text not null
+  city_id                text null
+  department_id          text null
+  lemming_id             text null
+
+  actor_type             text null
+  actor_id               text null
+  actor_role             text null
+
+  resource_type          text null
+  resource_id            text null
+
+  correlation_id         text not null
+  causation_id           text null
+  request_id             text null
+  tool_invocation_id     text null
+  approval_request_id    text null
+
+  action                 text null
+  status                 text null
+  message                text null
+
+  payload                jsonb not null
+```
+
+## 11.2 Why a Single Table in v1
+
+This choice is preferred because it:
+
+- keeps self-hosted deployments simple
+- works well with PostgreSQL already required by the platform
+- supports both audit and telemetry with minimal extra infrastructure
+- avoids premature complexity such as separate event pipelines or dedicated event databases
+
+This is an operational event store, not a full event-sourcing architecture.
+
+---
+
+# 12. Queryability and Indexing
+
+The event model must support both fast operational lookup and forensic reconstruction.
+
+## 12.1 Required Query Dimensions
+
+At minimum, the system must support querying by:
+
+- time range
+- `event_family`
+- `event_type`
+- `world_id`
+- `city_id`
+- `department_id`
+- `lemming_id`
+- `actor_type`
+- `actor_id`
+- `resource_type`
+- `resource_id`
+- `correlation_id`
+- `tool_invocation_id`
+- `approval_request_id`
+- `status`
+
+## 12.2 Recommended Indexes
+
+Version 1 should create indexes optimized for the most common operational and forensic queries.
+
+Recommended initial indexes:
+
+- `(occurred_at desc)`
+- `(event_family, occurred_at desc)`
+- `(event_type, occurred_at desc)`
+- `(world_id, occurred_at desc)`
+- `(world_id, city_id, department_id, occurred_at desc)`
+- `(lemming_id, occurred_at desc)`
+- `(actor_type, actor_id, occurred_at desc)`
+- `(resource_type, resource_id, occurred_at desc)`
+- `(correlation_id)`
+- `(tool_invocation_id)`
+- `(approval_request_id)`
+
+A JSONB GIN index on `payload` may be added selectively if query needs justify it.
+
+## 12.3 Query Use Cases
+
+Typical queries include:
+
+- show all approval events in department `infra`
+- show all events for correlation id `corr_123`
+- show all tool denials in city `salvador` in the last 24 hours
+- show all secret accesses by tool `github_issue_creator`
+- show all budget exhaustion events in world `prod`
+
+---
+
+# 13. Retention Model
+
+Retention must distinguish between audit and telemetry.
+
+## 13.1 Audit Retention
+
+Audit events should be retained for a long period and, by default, indefinitely in v1 unless operators configure archival procedures.
+
+Reason:
+
+- audit events support compliance, forensics, and accountability
+- deleting them too aggressively weakens trust in the system history
+
+## 13.2 Telemetry Retention
+
+Telemetry events may have shorter retention or be aggregated over time.
+
+Possible policies include:
+
+- retain raw telemetry for N days
+- archive or summarize older telemetry
+- keep only high-value telemetry beyond the short horizon
+
+## 13.3 Retention Principle
+
+Retention may remove old telemetry rows, but it must never alter the meaning of rows that remain.
+
+---
+
+# 14. Event Production Rules
+
+To keep event quality consistent, event producers must follow shared rules.
+
+## 14.1 Stable Event Names
+
+Event types must use stable, namespaced identifiers.
+
+Recommended style:
+
+```text
+auth.login_succeeded
+secret.created
+secret.accessed
+tool.invocation_requested
+tool.invocation_denied
+approval.requested
+approval.approved
+approval.rejected
+budget.exhausted
+lemming.failed
+city.unreachable
+```
+
+## 14.2 Prefer Structured Fields Over Free Text
+
+Event details should be stored in structured form whenever possible.
+
+Bad:
+
+```text
+"something failed in tool runtime"
+```
+
+Better:
+
+```json
+{
+  "reason_code": "budget_exhausted",
+  "tool": "web_search",
+  "remaining_budget_usd": 0.0
+}
+```
+
+## 14.3 Message Is Supplemental
+
+`message` is for operator readability only.
+
+System behavior must not depend on parsing `message`.
+
+---
+
+# 15. Examples
+
+## 15.1 Secret Access Audit Event
+
+```json
+{
+  "event_id": "evt_001",
+  "event_family": "audit",
+  "event_type": "secret.accessed",
+  "occurred_at": "2026-03-14T18:20:00Z",
+  "inserted_at": "2026-03-14T18:20:00Z",
+  "world_id": "prod",
+  "city_id": "salvador",
+  "department_id": "infra",
+  "actor_type": "tool_runtime",
+  "actor_id": "tool_runtime",
+  "resource_type": "secret",
+  "resource_id": "secrets.github.company",
+  "correlation_id": "corr_78421",
+  "tool_invocation_id": "inv_78421",
+  "action": "access",
+  "status": "succeeded",
+  "message": "Secret resolved for approved tool invocation",
+  "payload": {
+    "tool": "github_issue_creator",
+    "binding": "github.token",
+    "resolution_scope": "department"
+  }
+}
+```
+
+## 15.2 Approval Audit Event
+
+```json
+{
+  "event_id": "evt_002",
+  "event_family": "audit",
+  "event_type": "approval.approved",
+  "occurred_at": "2026-03-14T18:21:03Z",
+  "inserted_at": "2026-03-14T18:21:03Z",
+  "world_id": "prod",
+  "city_id": "salvador",
+  "department_id": "infra",
+  "actor_type": "user",
+  "actor_id": "operator_17",
+  "actor_role": "operator",
+  "resource_type": "approval_request",
+  "resource_id": "apr_998",
+  "correlation_id": "corr_78421",
+  "causation_id": "evt_approval_requested",
+  "tool_invocation_id": "inv_78421",
+  "approval_request_id": "apr_998",
+  "action": "approve",
+  "status": "approved",
+  "message": "Operator approved terraform apply",
+  "payload": {
+    "tool": "terraform_apply",
+    "risk_level": "critical"
+  }
+}
+```
+
+## 15.3 Telemetry Event
+
+```json
+{
+  "event_id": "evt_003",
+  "event_family": "telemetry",
+  "event_type": "lemming.failed",
+  "occurred_at": "2026-03-14T18:22:10Z",
+  "inserted_at": "2026-03-14T18:22:10Z",
+  "world_id": "prod",
+  "city_id": "salvador",
+  "department_id": "research",
+  "lemming_id": "lem_123",
+  "actor_type": "system",
+  "actor_id": "department_manager",
+  "resource_type": "lemming",
+  "resource_id": "lem_123",
+  "correlation_id": "corr_123",
+  "action": "fail",
+  "status": "failed",
+  "message": "Lemming exceeded retry policy",
+  "payload": {
+    "restart_count": 5,
+    "reason_code": "retry_limit_exceeded"
+  }
+}
+```
+
+---
+
+# 16. Consequences
+
+## Positive
+
+- establishes one canonical event contract across the platform
+- removes ambiguity between audit, approval, cost, auth, and runtime events
+- provides strong forensic traceability through actor, scope, resource, and correlation fields
+- keeps v1 operationally simple by using PostgreSQL
+- supports future dashboards, search, and analytics without redesigning event production
+
+## Negative / Trade-offs
+
+- a shared event schema requires discipline across all producers
+- one central event table may grow quickly in active systems
+- telemetry and audit sharing storage requires careful retention policy and indexing
+- some producers may need adaptation work to emit structured events consistently
+
+## Mitigations
+
+- keep envelope fields explicit and stable
+- enforce event emission through shared runtime helpers
+- define naming conventions for event types early
+- introduce archival and partitioning later if growth requires it
+
+---
+
+# 17. Non-Goals
+
+The following are explicitly out of scope for v1:
+
+- full event sourcing of all runtime state
+- Kafka, NATS, or dedicated stream infrastructure as a requirement
+- billing-grade financial reconciliation
+- arbitrary user-defined event schemas in the control plane
+- long-term analytics warehouse design
+- distributed tracing protocol integration standards
+
+The goal of this ADR is to define a durable, pragmatic, self-hosted event model suitable for governance and observability in version 1.
+
+---
+
+# 18. Future Extensions
+
+Potential future work includes:
+
+- PostgreSQL table partitioning by time or event family
+- archival of old telemetry events
+- dedicated search views or materialized views
+- dashboards and audit explorers in the control plane
+- event annotations for incident review
+- export pipelines to external observability systems
+- stronger schema validation per event type
+- OpenTelemetry bridge or external tracing integration
+
+These extensions can build on the canonical envelope defined here without changing the core model.
+
+---
+
+# 19. Rationale
+
+LemmingsOS already assumes that governance-critical actions are auditable and that runtime behavior is observable.
+
+Without a central event model, every subsystem risks inventing a slightly different schema and weakening the architecture.
+
+This ADR creates a shared contract that is:
+
+- explicit
+- append-only
+- traceable
+- hierarchy-aware
+- practical for v1
+
+It therefore becomes the common foundation for secrets, auth, approvals, cost governance, tool execution tracing, and runtime observability.

--- a/docs/adr/0019-llm-model-provider-execution-model.md
+++ b/docs/adr/0019-llm-model-provider-execution-model.md
@@ -1,0 +1,860 @@
+# ADR-0019 — Model Runtime
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS is a runtime for autonomous agents that interact with large language
+models as their primary reasoning engine. Multiple ADRs already assume the
+existence of a model execution layer:
+
+- ADR-0004 defines the Lemming execution model and references model calls as
+  runtime events, but does not define the provider contract.
+- ADR-0008 describes context persistence and compaction, but does not define
+  how the context is assembled into a prompt or how provider responses are
+  processed.
+- ADR-0015 defines cost governance and tracks LLM token usage as a first-class
+  cost source, but assumes token counts are available without specifying how
+  they are produced.
+
+Without a formal definition of the model execution layer, each Lemming
+implementation risks coupling directly to a specific provider, and governance
+subsystems such as cost tracking and policy inheritance have no clear runtime
+boundary to hook into.
+
+LemmingsOS is explicitly designed to be **accessible by default**. A developer
+or small team should be able to run a fully functional installation at zero
+cost. This means Ollama is the primary provider, free-tier cloud providers
+are the recommended cloud fallback, and paid providers are optional
+operator-configured upgrades.
+
+> **Note:** Consumer AI subscriptions (ChatGPT Plus, Claude.ai Pro,
+> Gemini Advanced) do not include API access. They are separate products
+> with per-seat billing. Programmatic API access requires dedicated API keys
+> with per-token pricing, independent of any subscription. LemmingsOS
+> integrates with provider APIs, not consumer products.
+
+The system must also support several operational requirements that go beyond
+a simple HTTP call to an inference endpoint:
+
+- **Model policy inheritance** — which model a Lemming uses must be resolvable
+  through the hierarchy `World → City → Department → Lemming type → instance`.
+- **Token usage tracking** — raw usage data from the provider must be captured
+  and forwarded to the cost governance subsystem.
+- **Retry and timeout policy** — provider calls may fail transiently and must
+  operate under configurable runtime limits.
+- **Structured output** — some Lemmings require machine-readable responses.
+  The execution model must define how structured outputs are requested and
+  validated.
+- **Streaming** — long-form responses benefit from streaming delivery. The
+  execution model must define whether streaming is supported and how it
+  interacts with the Lemming state machine.
+- **Prompt assembly** — the structured context stored in ADR-0008 must be
+  serialized into a provider-compatible message sequence. This translation
+  must happen at a well-defined boundary, not scattered across Lemming
+  implementations.
+
+---
+
+# 2. Decision Drivers
+
+1. **Accessibility** — zero-cost operation must be possible out of the box,
+   with no API keys or cloud accounts required. This drives Ollama as the
+   default and shapes the provider tier design.
+
+2. **Provider independence** — Lemming definitions must remain unchanged
+   regardless of which provider backs them. Provider selection is an
+   operational concern, not a code concern.
+
+3. **Governance integration** — model calls generate cost, require audit
+   trails, and must respect the same hierarchical policy model as tools
+   and secrets. The execution boundary must be a first-class governance
+   integration point, not an afterthought.
+
+4. **Consistency with existing runtime boundaries** — the system already
+   has a Tool Runtime as the controlled boundary for external side effects.
+   The model execution layer must follow the same design patterns: supervised,
+   auditable, policy-driven, and City-scoped.
+
+5. **Operational simplicity** — the abstraction must not introduce accidental
+   complexity. A developer building a Lemming should not need to understand
+   provider-specific APIs. Configuration changes at World or Department scope
+   must be sufficient to switch providers.
+
+6. **OTP alignment** — model calls are asynchronous, may be slow, and can
+   fail transiently. The execution model must fit naturally within the
+   GenServer state machine defined in ADR-0004.
+
+---
+
+# 3. Considered Options
+
+## Option A — Direct provider calls inside each Lemming
+
+Each Lemming implementation calls the provider API directly, managing its
+own HTTP client, retries, and token tracking.
+
+**Pros:**
+
+- simplest implementation per Lemming
+- no shared infrastructure to design or maintain
+
+**Cons:**
+
+- every Lemming duplicates provider client logic and retry handling
+- no central point for cost governance integration
+- provider credentials would need to be passed to every Lemming process,
+  violating the Secret Bank isolation model from ADR-0009
+- switching providers requires modifying every Lemming definition
+- audit coverage is inconsistent across implementations
+
+Rejected. Violates governance, secret isolation, and provider independence
+requirements simultaneously.
+
+---
+
+## Option B — Model calls as Tools
+
+Wrap LLM inference as a Tool, routed through the existing Tool Runtime
+(ADR-0005). Lemmings invoke an `llm_complete` tool the same way they invoke
+any other tool.
+
+**Pros:**
+
+- reuses existing Tool Runtime infrastructure, policy model, and audit pipeline
+- no new runtime subsystem required
+
+**Cons:**
+
+- conceptually incorrect: Tools are for external side effects with defined
+  inputs and outputs. Model inference is the agent's internal reasoning engine.
+  Treating it as a Tool conflates the reasoning layer with the effect layer.
+- the Tool invocation model assumes structured, bounded inputs and outputs.
+  Model calls involve large context windows, streaming, and complex assembly
+  logic that does not fit the Tool contract.
+- tool authorization (ADR-0012) is not the right governance model for model
+  selection. Policy inheritance for model selection has different semantics
+  than tool allowlists.
+- model calls are on the critical path of every Lemming execution step.
+  Routing them through the Tool approval and risk classification pipeline
+  (ADR-0013, ADR-0014) adds unnecessary overhead for a non-side-effecting
+  operation.
+
+Rejected. Conceptually incorrect and adds governance overhead that does not
+apply to model inference.
+
+---
+
+## Option C — Dedicated Model Runtime with provider behaviour abstraction (chosen)
+
+Introduce a dedicated **Model Runtime** subsystem as a peer of the Tool
+Runtime. It defines a provider behaviour that all adapters implement, owns
+prompt assembly, enforces model policy, integrates with cost governance,
+and emits audit events through the shared event model.
+
+**Pros:**
+
+- clean separation of concerns: reasoning engine vs external effects
+- single authoritative integration point for cost governance and audit
+- provider abstraction enables zero-code provider switching via configuration
+- fits naturally with the OTP supervision model and City execution boundary
+- prompt assembly is centralized, preventing divergent implementations
+
+**Cons:**
+
+- introduces a new supervised subsystem that must be designed, tested,
+  and maintained
+- adds an abstraction layer between Lemming and provider; debugging
+  inference issues requires understanding the assembly pipeline
+
+Chosen. The trade-offs are justified by the governance requirements and the
+consistency with existing runtime design patterns.
+
+---
+
+## Option D — Single OpenAI-compatible adapter for all providers
+
+Standardize on the OpenAI HTTP API contract and require all providers to be
+accessed through an OpenAI-compatible endpoint (Ollama supports this;
+providers like LiteLLM or OpenRouter can proxy others).
+
+**Pros:**
+
+- single adapter implementation
+- any OpenAI-compatible provider works without code changes
+
+**Cons:**
+
+- Anthropic's API has a different message structure (system field, tool use
+  blocks) that loses expressiveness when proxied through an
+  OpenAI-compatible layer
+- Gemini's native API exposes features not available through the compatibility
+  shim
+- provider-specific usage reporting (cache tokens, reasoning tokens) is lost
+  or inconsistently mapped, breaking accurate cost governance
+- operators are forced to run a proxy service even for direct provider
+  integrations, adding operational overhead
+
+Rejected. The cost in expressiveness and governance accuracy is not justified
+by the implementation simplicity gain. Native adapters per provider remain
+the correct approach.
+
+---
+
+# 4. Decision
+
+LemmingsOS introduces a **Model Runtime** subsystem responsible for all
+interactions between Lemming instances and LLM providers.
+
+Lemmings never call providers directly. All inference requests flow through
+the Model Runtime, which acts as the controlled boundary for:
+
+- provider routing and abstraction
+- prompt assembly from structured context
+- model policy resolution
+- response validation and structured output handling
+- token usage capture
+- retry and timeout enforcement
+- audit event emission
+
+The Model Runtime is a peer of the Tool Runtime in the execution architecture.
+It is not a Tool. Tools are for external side effects. The Model Runtime is
+the internal reasoning engine boundary.
+
+---
+
+# 5. Provider Abstraction
+
+The Model Runtime defines a **provider behaviour** that all provider adapters
+must implement.
+
+Conceptual behaviour contract:
+
+```elixir
+@callback complete(request :: ModelRequest.t(), opts :: keyword()) ::
+  {:ok, ModelResponse.t()} | {:error, reason}
+
+@callback stream(request :: ModelRequest.t(), pid :: pid(), opts :: keyword()) ::
+  {:ok, stream_ref} | {:error, reason}
+
+@callback health_check(config :: map()) ::
+  :ok | {:error, reason}
+```
+
+Provider adapters are registered at startup and resolved by name.
+
+Built-in adapters for v1 are organized by cost tier:
+
+**Zero cost (default)**
+
+- `ollama` — local inference via Ollama HTTP API. No API key required.
+  Runs on any machine with sufficient RAM. Recommended models for agents:
+  `llama3.2`, `qwen2.5-coder`, `mistral`, `phi4`.
+
+**Free tier (cloud, no credit card required)**
+
+- `gemini` — Google AI Studio free tier. Requires a Google account and an
+  API key from Google AI Studio. Specific rate limits and daily quotas are
+  set by Google and subject to change; consult the Google AI Studio
+  documentation for current limits before relying on this tier for
+  production workloads.
+
+**OpenAI-compatible (paid, optional)**
+
+- `openai` — OpenAI direct API and any provider that implements the OpenAI
+  HTTP contract. This includes OpenRouter, which aggregates multiple providers
+  and exposes some free-tier models under the same interface. Requires a
+  configured API key and paid credits, except for OpenRouter's free-tier models.
+
+**Paid cloud (optional, operator-configured)**
+
+- `anthropic` — Anthropic Messages API. Requires an API key with billing
+  configured. Intended for organizations that want access to more capable
+  models and are willing to pay per token.
+
+The adapter is selected from the resolved model policy at execution time.
+Lemmings reference a logical model name, not a provider-specific model string.
+
+Example logical model reference in Lemming configuration:
+
+```
+model: default
+```
+
+The Model Runtime resolves `default` to a concrete provider and model
+identifier using the inherited model policy. Out of the box, `default`
+resolves to Ollama.
+
+---
+
+# 6. Model Policy Inheritance
+
+Each Lemming executes against an **effective model policy** resolved
+hierarchically from:
+
+```
+World → City → Department → Lemming type → instance override
+```
+
+A model policy entry defines:
+
+- provider adapter
+- provider-specific model identifier
+- temperature and sampling parameters
+- max token budget for completion
+- timeout
+- retry policy
+
+Example policy at World scope (out-of-the-box default, zero cost):
+
+```
+model_policy:
+  default:
+    provider: ollama
+    model: llama3.2
+    temperature: 0.7
+    max_tokens: 4096
+    timeout_ms: 60_000
+    retries: 2
+```
+
+Example World-level policy using the Gemini free tier:
+
+```
+model_policy:
+  default:
+    provider: gemini
+    model: gemini-1.5-flash
+    temperature: 0.7
+    max_tokens: 4096
+    timeout_ms: 30_000
+    retries: 2
+```
+
+Example override at Department scope for an organization using paid models:
+
+```
+# A company configures their Anthropic key at World scope via the Secret Bank.
+# Individual Departments that need more capable models override the policy here.
+# Departments without an override continue using the World default (free tier).
+
+model_policy:
+  default:
+    provider: anthropic
+    model: claude-sonnet-4-6
+    max_tokens: 8192
+```
+
+This pattern means an operator can run most Departments on Ollama or Gemini
+free tier while pointing a single high-stakes Department at a paid model.
+The cost difference remains visible in cost governance without any Lemming
+code change.
+
+Resolution follows nearest-scope precedence. The instance executes against
+a resolved snapshot of this policy, consistent with how tool policy and cost
+budgets are resolved throughout the system.
+
+---
+
+# 7. Prompt Assembly
+
+The Model Runtime assembles the inference request from the Lemming's
+structured working context defined in ADR-0008.
+
+Prompt assembly is the exclusive responsibility of the Model Runtime.
+Lemming implementations do not construct raw prompt strings.
+
+The assembly pipeline maps structured context fields to a provider-compatible
+message sequence:
+
+```
+Working context
+  system_prompt       → system message
+  task_goal           → injected into first user turn
+  instructions        → injected into system or user message
+  constraints         → injected as system guidance
+  recent_messages     → prior conversation turns
+  working_summary     → condensed context if compaction has occurred
+  tool_results        → tool result turns as required by provider format
+  last_output         → assistant turn for continuation if applicable
+```
+
+The output of assembly is a `ModelRequest` struct:
+
+```elixir
+%ModelRequest{
+  provider: :anthropic,
+  model: "claude-sonnet-4-6",
+  messages: [...],
+  system: "...",
+  max_tokens: 8192,
+  temperature: 0.7,
+  response_format: :text | :json,
+  tools: [...],
+  metadata: %{
+    world_id: ...,
+    city_id: ...,
+    department_id: ...,
+    lemming_id: ...,
+    correlation_id: ...
+  }
+}
+```
+
+The `metadata` field carries hierarchy context used for cost governance
+and audit event emission. It is never sent to the provider.
+
+---
+
+# 8. Response Model
+
+The Model Runtime returns a `ModelResponse` struct to the Lemming:
+
+```elixir
+%ModelResponse{
+  content: "...",
+  role: :assistant,
+  stop_reason: :end_turn | :max_tokens | :tool_use | :stop_sequence,
+  usage: %{
+    input_tokens: integer(),
+    output_tokens: integer(),
+    cache_read_input_tokens: integer() | nil,
+    cache_write_input_tokens: integer() | nil
+  },
+  model: "...",
+  provider: :anthropic,
+  latency_ms: integer()
+}
+```
+
+The `usage` field is always populated. The Model Runtime forwards usage
+data to the cost governance subsystem immediately after receiving the
+provider response, before returning to the Lemming.
+
+Lemmings receive only the `ModelResponse`. They never receive raw provider
+HTTP responses.
+
+---
+
+# 9. Structured Output
+
+Some Lemmings require machine-readable responses rather than free-form text.
+
+The Model Runtime supports two structured output modes.
+
+**JSON mode**
+
+The provider is instructed to return valid JSON. The Model Runtime validates
+that the response parses as JSON before returning it to the Lemming. If
+validation fails, the response is treated as a provider error.
+
+```elixir
+%ModelRequest{response_format: :json, ...}
+```
+
+**Schema-validated JSON**
+
+The Lemming type may declare an expected output schema. The Model Runtime
+validates the parsed JSON against the schema. If validation fails, the
+runtime may retry or return a structured error.
+
+```elixir
+%ModelRequest{response_format: {:json_schema, schema}, ...}
+```
+
+v1 supports both modes where the provider natively allows it. For providers
+that do not support JSON mode, the runtime injects a system instruction
+requesting JSON output and applies best-effort parsing.
+
+---
+
+# 10. Streaming
+
+Streaming is **supported but opt-in** in v1.
+
+The Lemming execution model (ADR-0004) treats model calls as asynchronous
+events. Streaming is compatible with this model: the Lemming transitions to
+a `waiting_model` state and receives either a completion event or incremental
+stream events depending on the configured mode.
+
+Streaming mode:
+
+```
+Lemming
+   ↓ request with stream: true
+Model Runtime
+   ↓
+Provider adapter (streaming)
+   ↓
+Incremental token events → Lemming process mailbox
+   ↓
+Completion event with full usage stats → Lemming
+```
+
+Non-streaming mode (default):
+
+```
+Lemming
+   ↓ request
+Model Runtime
+   ↓
+Provider adapter (blocking request)
+   ↓
+ModelResponse → Lemming
+```
+
+Token usage is always reported on the completion event, regardless of mode.
+
+---
+
+# 11. Retry and Timeout Policy
+
+The Model Runtime enforces a **retry policy** derived from the effective
+model policy.
+
+Default retry behavior:
+
+```
+retries: 2
+retry_backoff: exponential
+initial_backoff_ms: 500
+timeout_ms: 30_000
+```
+
+Retryable conditions:
+
+- network timeout
+- provider 429 (rate limit)
+- provider 500 / 503 (transient server error)
+
+Non-retryable conditions:
+
+- provider 400 (invalid request — retrying without input change will not help)
+- provider 401 / 403 (authentication failure)
+- response validation failure (structured output did not match schema)
+- max token budget exceeded
+
+If all retries are exhausted, the Model Runtime returns a structured error
+to the Lemming. The Lemming transitions to a failure or retry-backoff state
+as defined in ADR-0004.
+
+---
+
+# 12. Cost Governance Integration
+
+After every provider response, the Model Runtime emits a usage event to the
+cost governance subsystem defined in ADR-0015.
+
+The event includes:
+
+- provider
+- model identifier
+- input token count
+- output token count
+- estimated cost in USD
+- hierarchy scope: world, city, department, lemming instance
+- correlation identifier
+
+**Cost estimation by provider tier:**
+
+Local providers such as Ollama report token counts but carry zero monetary
+cost. The cost governance subsystem still records token volume — this matters
+for context budget enforcement and operational observability even when there
+is no financial cost.
+
+Free-tier cloud providers report token counts. Monetary cost is zero within
+free-tier limits. The runtime records usage for observability and future
+policy decisions, but does not trigger monetary budget enforcement until the
+operator configures explicit limits.
+
+Paid providers report token counts and have a known per-token price. The
+runtime computes estimated cost and enforces monetary budgets as defined
+in ADR-0015.
+
+Conceptual execution flow:
+
+```
+Lemming
+   ↓
+Model Runtime
+   ↓
+Model policy resolution
+   ↓
+Budget evaluation (cost governance check)
+   ↓
+Prompt assembly
+   ↓
+Provider call
+   ↓
+Usage captured → cost governance updated
+   ↓
+Audit event emitted
+   ↓
+ModelResponse returned to Lemming
+```
+
+If budget is exhausted at the evaluation step, the Model Runtime rejects
+the request before any provider call is made. The Lemming receives
+`{:error, :budget_exhausted}`.
+
+For zero-cost providers this check is a no-op unless the operator has
+configured explicit token quotas.
+
+---
+
+# 13. Audit Events
+
+The Model Runtime emits a minimal, stable set of events covering every significant
+lifecycle transition. These events are the authoritative contract between the Model
+Runtime and the rest of the platform — cost governance (ADR-0015), audit
+(ADR-0018), and the Lemming execution model (ADR-0004) all depend on them.
+
+**Telemetry events** (observability, operational monitoring):
+
+- `model.request_started` — inference request assembled and dispatched to the
+  provider adapter; payload includes provider, model, token budget, correlation_id
+- `model.response_received` — provider returned a successful response; payload
+  includes stop_reason, latency_ms, correlation_id
+- `model.retry` — a retryable provider error triggered a retry attempt; payload
+  includes attempt number, error code, backoff_ms
+- `model.request_failed` — all retry attempts exhausted; payload includes final
+  error code and total attempt count
+
+**Audit events** (governance, accountability):
+
+- `model.budget_denied` — request blocked before dispatch because the effective
+  cost budget (ADR-0015) was exhausted; audit family, requires actor/scope fields
+- `model.structured_output_invalid` — provider response failed schema validation
+  after retries; payload includes schema name and validation error summary
+
+**Cost event** (emitted to cost governance subsystem, also stored as telemetry):
+
+- `model.usage` — emitted immediately after every successful response, before
+  returning to the Lemming; payload includes provider, model, input_tokens,
+  output_tokens, cache_read_tokens, cache_write_tokens, cost_usd_estimate;
+  this event is the sole input for token accounting in ADR-0015
+
+The distinction between `model.response_received` and `model.usage` is intentional:
+`model.response_received` is the general lifecycle signal; `model.usage` is the
+cost-governance-specific event with the full token breakdown. Separating them keeps
+the cost governance subsystem decoupled from the broader response lifecycle.
+
+Each event carries the full hierarchy scope (`world_id`, `city_id`, `department_id`,
+`lemming_id`) and `correlation_id`, consistent with the canonical envelope defined
+in ADR-0018.
+
+Secret material (API keys, credentials) must never appear in event payloads.
+Provider credentials are resolved through the Secret Bank (ADR-0009) and
+injected only into the adapter at execution time.
+
+---
+
+# 14. Runtime Architecture
+
+## Internal subsystem view
+
+Each inference request passes through five internal components of the Model Runtime
+before reaching the provider and after receiving the response:
+
+```
+Lemming
+   │
+   ▼
+Model Runtime
+   │
+   ├─ PromptAssembler        reads working context (ADR-0008), builds ModelRequest
+   ├─ ProviderRouter         resolves model policy, selects provider adapter
+   ├─ RetryEngine            enforces retry/backoff policy on transient failures
+   ├─ StructuredOutputValidator  validates JSON schema on structured responses
+   └─ UsageTracker           captures token counts, emits model.usage event (ADR-0015)
+   │
+   ▼
+Provider Adapter
+   │
+   ▼
+Model Provider (Ollama / Gemini / OpenAI-compatible / Anthropic)
+```
+
+Each component has a single responsibility. A Lemming that calls the Model Runtime
+is unaware of which component handles any given concern — the interface is always
+`ModelRequest → ModelResponse`.
+
+## Position in the full runtime
+
+The Model Runtime is a peer of the Tool Runtime. Both are subordinate to the Lemming
+execution layer and report to the same governance infrastructure:
+
+```
+                 ┌──────────────────┐
+                 │     Lemming      │
+                 └────────┬─────────┘
+                          │
+           ┌──────────────┴──────────────┐
+           │                             │
+           ▼                             ▼
+   ┌───────────────┐             ┌───────────────┐
+   │ Model Runtime │             │  Tool Runtime │
+   └───────┬───────┘             └───────┬───────┘
+           │                             │
+           ▼                             ▼
+   model providers                external world
+```
+
+Neither runtime calls the other. The Lemming is the only component that interacts
+with both — it sends a `ModelRequest`, receives a `ModelResponse`, interprets any
+tool-use decision, and dispatches it to the Tool Runtime as a separate call.
+
+Both runtimes feed the same cross-cutting infrastructure in parallel:
+
+```
+Model Runtime ──► Cost Governance  (model.usage)
+Model Runtime ──► Audit Log        (model.* events)
+Tool Runtime  ──► Audit Log        (tool.* events)
+Tool Runtime  ──► Cost Governance  (tool cost events)
+```
+
+## OTP supervision tree
+
+The Model Runtime is a supervised process tree within each City.
+
+```
+City Supervisor
+   └─ Model Runtime Supervisor
+         ├─ Provider Registry
+         ├─ Prompt Assembler
+         └─ Provider Adapters (per configured provider)
+               ├─ Ollama Adapter             (zero cost, always available)
+               ├─ Gemini Adapter             (free tier, Google AI Studio key)
+               ├─ OpenAI-compatible Adapter  (OpenAI direct, OpenRouter, etc.)
+               └─ Anthropic Adapter          (paid, optional)
+```
+
+Provider adapters may maintain connection pools or persistent HTTP clients.
+This is an internal adapter concern and does not affect the Lemming-facing
+contract.
+
+The Model Runtime is City-scoped, consistent with the City execution model
+defined in ADR-0017. Lemming instances interact with the Model Runtime of
+their own City and never cross City boundaries for inference.
+
+---
+
+# 15. Consequences
+
+## Positive
+
+- **Provider independence is guaranteed at the contract level.** A Lemming
+  definition never references a provider or model string. Operators switch
+  providers through configuration alone, with no code changes required.
+
+- **Accessibility goal is met structurally.** The default World policy points
+  to Ollama. A fresh installation runs with zero API keys, zero cost, and zero
+  cloud dependencies. Upgrading to a paid provider is a single configuration
+  change at World scope.
+
+- **Cost governance has a reliable integration point.** Every token consumed
+  flows through the Model Runtime. ADR-0015 enforcement is consistent and
+  complete — there is no path for a Lemming to bypass token accounting.
+
+- **Prompt assembly is centralized.** Divergent prompt construction across
+  Lemming types is structurally prevented. Context field semantics are defined
+  once, translated once, and tested once.
+
+- **The governance model is consistent across the runtime.** Model calls
+  follow the same audit, credential isolation, and City-scoping patterns
+  as tool execution. Contributors working on one subsystem can reason about
+  the other by analogy.
+
+## Negative / Trade-offs
+
+- **A new supervised subsystem adds operational surface area.** The Model
+  Runtime Supervisor, Provider Registry, and individual adapters all need
+  to be started, monitored, and maintained. A bug in the prompt assembler
+  affects every Lemming in the City.
+
+- **The abstraction layer adds a debugging indirection.** When a provider
+  returns an unexpected response, the failure is observed at the
+  `ModelResponse` level, not at the raw HTTP level. Adapter-level
+  introspection requires understanding the assembly pipeline.
+
+- **Provider-specific features require explicit adapter work.** Features
+  that do not map to the shared `ModelRequest` / `ModelResponse` contract
+  (Anthropic cache control, Gemini grounding, OpenAI reasoning effort)
+  require deliberate adapter implementation. The abstraction does not expose
+  them automatically.
+
+- **Free-tier limits are external and not enforced by the runtime.** Gemini
+  and OpenRouter free-tier quotas are enforced by the provider, not by
+  LemmingsOS. Operators hitting free-tier limits will see 429 errors handled
+  by the retry policy, not a clean `budget_exhausted` signal. Explicit token
+  quotas must be configured manually to get early warnings.
+
+## Mitigations
+
+- Adapter failures are isolated by the supervision tree. A crashed Anthropic
+  adapter does not affect the Ollama adapter serving other Departments.
+- The `health_check` callback allows the Provider Registry to surface
+  unhealthy adapters in the control plane before they affect Lemming execution.
+- Provider-specific features can be exposed through the `metadata` field of
+  `ModelRequest` as an escape hatch, allowing adapter extensions without
+  breaking the shared contract.
+
+---
+
+# 16. Non-Goals
+
+The following capabilities are explicitly out of scope for v1:
+
+- fine-tuning or model training integration
+- embedding generation (deferred to a dedicated ADR when RAG is introduced)
+- multi-modal inputs (images, audio, documents)
+- model performance benchmarking
+- automatic provider failover
+- prompt caching (provider-specific optimization, deferred to future adapter work)
+- A/B testing between model configurations
+
+---
+
+# 17. Future Extensions
+
+Potential future improvements include:
+
+- embedding provider abstraction for retrieval-augmented workflows
+- automatic provider failover when primary is unavailable
+- prompt caching support for providers that expose it
+- multi-modal input support
+- per-Lemming type prompt templates registered in the control plane
+- model performance metrics and latency tracking in the observability dashboard
+
+These extensions can build on the provider abstraction and policy inheritance
+model defined in this ADR without changing the core execution contract.
+
+---
+
+# 18. Rationale
+
+LemmingsOS already treats Tools as the controlled boundary for all external
+side effects. Model inference is not a side effect in the same sense — it is
+the primary reasoning engine for every Lemming. However, it shares the same
+governance requirements: it generates cost, requires credential management,
+must be auditable, and must operate under hierarchical policy.
+
+A dedicated Model Runtime keeps these concerns centralized and makes the
+provider abstraction a first-class contract rather than an implementation
+detail buried in individual Lemmings.
+
+The provider tier design follows directly from the accessibility principle.
+The abstraction layer means a developer with no API keys runs Ollama locally
+at zero cost. The same installation, with a single configuration change,
+upgrades to a free-tier cloud provider or a paid API as the team and
+requirements grow. No Lemming code changes. No architecture changes.
+Only configuration.
+
+This is the correct separation of concerns: Lemming definitions describe
+*what* an agent does; model policy describes *with what capability and at
+what cost* it reasons. Those are operationally independent decisions and
+should be independently configurable.

--- a/docs/adr/0020-hierarchical-configuration-model.md
+++ b/docs/adr/0020-hierarchical-configuration-model.md
@@ -1,0 +1,617 @@
+# ADR-0020 — Hierarchical Configuration Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: LemmingsOS maintainers
+
+---
+
+# 1. Context
+
+LemmingsOS organizes execution and governance around a strict hierarchy:
+
+```
+World → City → Department → Lemming
+```
+
+Every subsystem that enforces runtime behavior — tool authorization (ADR-0012),
+cost governance (ADR-0015), model routing (ADR-0019), risk classification
+(ADR-0013) — requires configuration that is scope-aware, deterministically
+resolved, and safe to override at lower levels.
+
+Prior ADRs assumed configuration inheritance but did not define:
+
+- where configuration is stored
+- how inheritance is resolved at each hierarchy level
+- whether child scopes may override governance-critical keys such as tool denials or budget caps
+- how changes propagate across a distributed cluster
+- how the runtime observes configuration updates without restarting
+
+Without a canonical configuration model, each subsystem risks implementing its
+own resolution strategy with conflicting semantics. Most critically, an
+unspecified merge strategy creates a security gap: a naïve "child overrides
+parent" rule applied uniformly would allow a Department-level administrator to
+re-enable a tool that a World-level administrator has explicitly denied, or to
+increase a budget cap above a World-level ceiling. ADR-0012 and ADR-0015 both
+assume this cannot happen. This ADR defines the model that enforces that
+assumption.
+
+---
+
+# 2. Decision Drivers
+
+1. **Deterministic resolution** — Every runtime component reading a configuration
+   key must obtain the same effective value regardless of which node or process
+   performs the resolution. Non-deterministic configuration is a correctness hazard.
+
+2. **Deny dominance for governance keys** — Tool denials and budget ceilings set at
+   a higher scope must not be overridable by a lower scope. A World-level tool deny
+   is a hard constraint; it cannot be re-enabled at City, Department, or Lemming
+   level. A budget cap set at World level defines an absolute ceiling; a child scope
+   may set a tighter cap but never a looser one.
+
+3. **Override semantics for operational keys** — Most configuration keys represent
+   operational preferences, not governance constraints. For these, lower scopes
+   should be able to customize behavior without restriction (e.g., a Department
+   configuring a different default model, or a Lemming reducing its parallel tool
+   limit).
+
+4. **Distributed consistency without coordination** — A City node must be able to
+   resolve effective configuration locally without real-time RPC to sibling nodes.
+   The resolution model must tolerate eventual consistency in cache state while
+   remaining deterministic.
+
+5. **Auditability** — Changes to configuration must produce audit events so that
+   the history of effective configuration at any scope can be reconstructed after
+   the fact. The database stores current state; the audit log stores history.
+
+6. **Safe update propagation** — A configuration change at World level should
+   propagate to runtime components without forcing restarts. Long-running Lemmings
+   must not silently continue with stale governance configuration indefinitely.
+
+---
+
+# 3. Considered Options
+
+## Option A — Flat global configuration with runtime overrides
+
+All configuration lives in a single global table. Individual components read the
+global config and apply their own local overrides through application-level code.
+
+**Pros:**
+- trivial to implement in v1
+- no hierarchy-aware resolution logic required
+
+**Cons:**
+- does not reflect the system hierarchy; organizational scope boundaries are not
+  modeled
+- local overrides applied in application code cannot be audited or validated
+  centrally
+- deny-dominant semantics cannot be enforced consistently; every component would
+  need to implement its own deny propagation logic
+- configuration drift between components becomes likely
+
+Rejected. Flat global configuration cannot enforce hierarchy-aligned governance
+constraints and conflicts with the foundational isolation model of ADR-0003.
+
+---
+
+## Option B — Fully versioned configuration tables with event sourcing
+
+Configuration is stored append-only as a sequence of change events per scope.
+Effective configuration is derived by replaying the event sequence.
+
+**Pros:**
+- complete auditability; full history is the source of truth, not derived
+- rollback to any prior configuration state is deterministic
+- no separate audit event emission required; the storage model is the audit trail
+
+**Cons:**
+- query complexity for effective configuration resolution is high; every read
+  requires a projection over potentially large event sequences
+- cache invalidation and consistency reasoning become significantly harder
+- schema migration against an event-sourced config store is operationally complex
+- disproportionate to the v1 deployment target; self-hosted operators gain little
+  from full event sourcing for configuration
+
+Rejected for v1. The audit requirement is satisfied by emitting change events to
+the existing audit log (ADR-0018) rather than making the storage model itself an
+event log. Full event sourcing for configuration is a future extension.
+
+---
+
+## Option C — File-based configuration with environment variable overrides
+
+Configuration is managed through files (YAML, TOML, or similar) bundled with the
+application, with environment variables providing runtime overrides.
+
+**Pros:**
+- familiar operational model for many self-hosted operators
+- no database dependency for configuration access at startup
+
+**Cons:**
+- hierarchy-scoped configuration (World, City, Department) cannot be represented
+  in static files without per-scope file sets, which creates operational complexity
+- changes to World or Department configuration require file changes and container
+  redeployment, eliminating the ability to update configuration at runtime
+- deny-dominant governance semantics cannot be enforced when configuration lives
+  in files managed by different operators at different scopes
+- distributed runtime nodes would require synchronized file state across containers
+
+Rejected. File-based configuration cannot support runtime-mutable hierarchy-
+scoped governance without reintroducing the coordination problems it attempts
+to avoid.
+
+---
+
+## Option D — Hierarchical JSONB configuration with dual merge semantics (chosen)
+
+Each hierarchy entity (`worlds`, `cities`, `departments`, `lemming_instances`)
+stores a partial JSONB configuration document containing only the keys it defines.
+Effective configuration is resolved by a centralized resolver using two distinct
+merge semantics applied in a single deterministic pipeline.
+
+**Pros:**
+- maps directly to the runtime hierarchy; every configuration value has an explicit
+  scope owner
+- dual merge semantics (override-dominant and deny-dominant) enforce both
+  operational flexibility and governance correctness in a single resolution pass
+- partial documents avoid full-copy-on-write; each scope only stores what it
+  explicitly configures
+- resolver is a single canonical codepath; all subsystems share the same semantics
+- ETS-backed caching makes per-Lemming config resolution effectively O(1) at scale
+
+**Cons:**
+- dual merge semantics add implementation surface that must be maintained and
+  tested carefully
+- JSONB partial documents require discipline to prevent unbounded key accumulation
+- cache invalidation across a distributed cluster is eventual; there is a brief
+  window after a World-level deny change where in-flight operations may proceed
+  under the previous effective config
+
+Chosen. See section 4 and rationale for full justification.
+
+---
+
+# 4. Decision
+
+LemmingsOS uses a **hierarchical configuration model with dual merge semantics**.
+
+Configuration is stored as partial JSONB documents at each hierarchy scope.
+Effective configuration is resolved through a single deterministic pipeline that
+applies two merge strategies in sequence:
+
+1. **Override-dominant merge** — for operational configuration keys, child values
+   replace parent values.
+
+2. **Deny-dominant constraints** — applied as a post-merge pass over governance
+   namespaces. These constraints are ceiling-only: a child scope may only tighten a
+   restriction, never loosen one established by an ancestor.
+
+The two governance namespaces subject to deny-dominant constraints are:
+
+- **`tools.deny`** — tool deny lists; union of all ancestor denials is the floor
+- **`cost.budget`** — budget caps; minimum across all ancestor caps is the ceiling
+
+All other namespaces use override-dominant semantics.
+
+---
+
+# 5. Configuration Storage
+
+Each hierarchy entity stores a partial configuration document in its `config_jsonb`
+column. A document contains only the keys that scope explicitly configures;
+unset keys are resolved from the parent.
+
+Storage schema (abbreviated):
+
+```
+worlds        → config_jsonb
+cities        → config_jsonb
+departments   → config_jsonb
+lemming_types → config_jsonb
+```
+
+Configuration is partial by design. The World document typically contains the
+authoritative defaults. City, Department, and Lemming Type documents contain only
+the keys they override or extend.
+
+Example World configuration:
+
+```json
+{
+  "models": { "default": "qwen3" },
+  "tools": {
+    "max_parallel": 4,
+    "deny": ["shell_exec", "file_write"]
+  },
+  "cost": {
+    "budget": { "cap_usd": 50.00, "window": "monthly" }
+  }
+}
+```
+
+Example Department override:
+
+```json
+{
+  "tools": {
+    "max_parallel": 2,
+    "deny": ["web_search"]
+  },
+  "cost": {
+    "budget": { "cap_usd": 10.00 }
+  }
+}
+```
+
+---
+
+# 6. Merge Semantics
+
+## 6.1 Override-dominant merge (default)
+
+For all configuration namespaces not subject to deny-dominant constraints, child
+values replace parent values recursively. This is a standard `deep_merge`.
+
+```
+models.default: "qwen3" (world) → unchanged if Department does not set it
+tools.max_parallel: 4 (world) → 2 (department wins)
+```
+
+## 6.2 Deny-dominant merge (governance namespaces)
+
+For governance namespaces, the merge rule is inverted: the most restrictive value
+across all ancestor scopes always wins. A child can only add restrictions; it
+cannot remove them.
+
+**`tools.deny` — union semantics**
+
+The effective tool deny list is the union of all deny lists across all ancestor
+scopes. No descendant can remove a tool from an ancestor's deny list.
+
+```
+world:      deny = [shell_exec, file_write]
+department: deny = [web_search]
+effective:  deny = [shell_exec, file_write, web_search]
+```
+
+If World denies `shell_exec`, no Department, City, or Lemming type can re-enable
+`shell_exec`. The ADR-0012 deny-dominance guarantee is structurally enforced by
+the resolution algorithm, not by downstream policy checks.
+
+**`cost.budget.cap_usd` — minimum semantics**
+
+The effective budget cap is the minimum cap across all ancestor scopes. A child
+scope may set a tighter cap (a sub-budget) but cannot exceed the parent ceiling.
+
+```
+world:      cap_usd = 50.00
+department: cap_usd = 10.00
+effective:  cap_usd = 10.00 (tighter wins)
+
+world:      cap_usd = 50.00
+department: cap_usd = 100.00  ← attempts to exceed parent
+effective:  cap_usd = 50.00   ← parent ceiling enforced
+```
+
+---
+
+# 7. Configuration Resolver
+
+All runtime components access configuration exclusively through the resolver. Direct
+database access is forbidden.
+
+```
+LemmingsOs.Config.Resolver
+```
+
+Interface:
+
+```elixir
+Config.Resolver.effective(world_id)
+Config.Resolver.effective(world_id, city_id)
+Config.Resolver.effective(world_id, city_id, department_id)
+Config.Resolver.effective(world_id, city_id, department_id, lemming_type_id)
+```
+
+Each call returns an immutable effective configuration map for the given scope.
+
+Resolution algorithm:
+
+```elixir
+def effective(world_id, city_id \\ nil, dept_id \\ nil, lemming_type_id \\ nil) do
+  layers =
+    [
+      load_config(:world, world_id),
+      load_config(:city, city_id),
+      load_config(:department, dept_id),
+      load_config(:lemming_type, lemming_type_id)
+    ]
+    |> Enum.reject(&is_nil/1)
+
+  layers
+  |> Enum.reduce(%{}, &deep_merge(&2, &1))   # step 1: override-dominant
+  |> enforce_deny_dominant(layers)            # step 2: governance constraints
+end
+
+# Union of all ancestor tool deny lists — no ancestor denial can be removed
+defp enforce_deny_dominant(config, layers) do
+  all_tool_denials =
+    layers
+    |> Enum.flat_map(&(get_in(&1, [:tools, :deny]) || []))
+    |> MapSet.new()
+
+  min_budget_cap =
+    layers
+    |> Enum.map(&get_in(&1, [:cost, :budget, :cap_usd]))
+    |> Enum.reject(&is_nil/1)
+    |> case do
+      [] -> nil
+      caps -> Enum.min(caps)
+    end
+
+  config
+  |> put_in_if_present([:tools, :deny], MapSet.to_list(all_tool_denials))
+  |> put_in_if_present([:cost, :budget, :cap_usd], min_budget_cap)
+end
+```
+
+The resolver is the only location in the codebase where merge semantics are
+implemented. Subsystems must not re-implement merge logic.
+
+---
+
+# 8. Runtime Caching
+
+Resolved configuration is cached per node in ETS.
+
+```
+LemmingsOs.Config.Cache
+```
+
+Cache key: `{world_id, city_id, department_id, lemming_type_id}`
+
+Properties:
+
+- ETS-backed, read-optimized
+- lazily populated on first resolver call for a given scope tuple
+- invalidated on configuration change events
+- rebuilt lazily on cache miss or node restart
+
+Cluster-wide cache invalidation:
+
+When a configuration change is persisted, the control plane emits a
+`config.updated` audit event (ADR-0018). All City nodes observe this event and
+drop the affected cache entries. The next resolver call for that scope reloads
+from PostgreSQL and repopulates the cache.
+
+---
+
+# 9. Configuration Propagation
+
+```
+Admin UI or API call
+        │
+        ▼
+  Config.Validator validates structure and deny-dominant constraints
+        │
+        ▼
+  PostgreSQL update (config_jsonb on the hierarchy entity)
+        │
+        ▼
+  config.updated audit event emitted (ADR-0018)
+        │
+        ▼
+  All City nodes receive event and invalidate affected cache entries
+        │
+        ▼
+  Next resolver call for that scope reloads from DB
+```
+
+Propagation model: **eventual consistency with deterministic resolution**.
+
+There is a brief window between a change being persisted and all City nodes
+invalidating their caches. For most operational keys this is acceptable. For
+governance-critical changes (e.g., a World-level tool denial), operators who
+require immediate enforcement may restart affected City nodes, which forces a
+full cache rebuild.
+
+Long-running Lemmings apply new configuration on their next execution cycle
+boundary, not mid-task.
+
+---
+
+# 10. Configuration Scope Matrix
+
+Not all keys are settable at all hierarchy levels. This table defines which
+namespaces are valid at each scope.
+
+| Namespace | World | City | Department | Lemming Type | Notes |
+|---|---|---|---|---|---|
+| `models.*` | ✅ | ⚠️ | ⚠️ | ❌ | Model routing is typically global |
+| `tools.max_parallel` | ✅ | ✅ | ✅ | ❌ | Concurrency limit, override-dominant |
+| `tools.deny` | ✅ | ✅ | ✅ | ❌ | **Deny-dominant; union of all ancestors** |
+| `tools.risk.*` | ✅ | ❌ | ❌ | ❌ | Risk classification is global (ADR-0013) |
+| `cost.budget.cap_usd` | ✅ | ✅ | ✅ | ❌ | **Deny-dominant; minimum of all ancestors** |
+| `cost.budget.window` | ✅ | ❌ | ❌ | ❌ | Budget window is World-level only |
+| `runtime.*` | ✅ | ✅ | ✅ | ✅ | Execution limits may vary |
+| `security.*` | ✅ | ⚠️ | ❌ | ❌ | Security policies are mostly global |
+| `observability.*` | ✅ | ✅ | ❌ | ❌ | Logging and metric scope |
+
+Legend:
+
+```
+✅ allowed
+⚠️ discouraged / exceptional override
+❌ not allowed; resolver rejects if present
+```
+
+---
+
+# 11. Configuration Versioning
+
+The database stores only the current configuration state at each scope.
+
+History is tracked through the audit event system (ADR-0018). Every successful
+configuration change emits:
+
+```
+event_type: config.updated
+metadata:
+  scope_type: world | city | department | lemming_type
+  scope_id: <uuid>
+  actor: <user or system identity>
+  previous_hash: <sha256 of previous config_jsonb>
+  new_hash: <sha256 of new config_jsonb>
+  changed_keys: [...]
+```
+
+This gives operators a complete audit trail for governance changes without
+requiring event-sourced configuration storage.
+
+---
+
+# 12. Failure Model
+
+| Condition | Behavior |
+|---|---|
+| Invalid configuration submitted | Rejected by `Config.Validator` before persistence; no change written |
+| Child attempts to remove ancestor tool denial | Rejected by validator; `config.updated` is not emitted |
+| Child attempts to exceed parent budget cap | Validator rejects; if bypassed, resolver enforces minimum semantics |
+| Cache miss | Resolver reloads from PostgreSQL and repopulates cache |
+| Node restart | Cache rebuilt lazily on first resolver call per scope |
+| DB unreachable during resolver call | Returns `{:error, :config_unavailable}`; callers must handle gracefully |
+
+---
+
+# 13. Implementation Notes
+
+Key modules:
+
+```
+LemmingsOs.Config.Resolver   — effective config resolution and dual merge
+LemmingsOs.Config.Cache      — ETS-backed per-node cache
+LemmingsOs.Config.Validator  — schema and governance constraint validation
+```
+
+Configuration namespace ownership by ADR:
+
+- `tools.*` — ADR-0012 (Tool Policy and Authorization)
+- `tools.risk.*` — ADR-0013 (Tool Risk Classification)
+- `cost.*` — ADR-0015 (Runtime Cost Governance)
+- `models.*` — ADR-0019 (LLM Model Provider Execution)
+- `runtime.*` — ADR-0004 (Lemming Execution Model)
+
+Subsystems must:
+
+- define the configuration keys they own and their valid scopes
+- validate their namespace keys through `Config.Validator`
+- read configuration exclusively through `Config.Resolver`
+- never apply their own inheritance logic
+
+---
+
+# 14. Considered Options
+
+See section 3 above. Options A (flat global), B (fully versioned tables), and C
+(file-based) were evaluated and rejected before arriving at Option D (hierarchical
+JSONB with dual merge semantics).
+
+---
+
+# 15. Consequences
+
+## Positive
+
+- Deny-dominant merge semantics make the ADR-0012 and ADR-0015 governance
+  guarantees structurally enforceable at the configuration layer, rather than
+  relying on each subsystem to implement its own deny-propagation logic.
+- Effective configuration is always deterministic regardless of which node or
+  process evaluates it.
+- Partial JSONB documents avoid full config duplication across scopes; each scope
+  stores only what it explicitly overrides.
+- A single canonical resolver codepath means governance semantics are auditable
+  and testable in isolation, independent of the subsystems that consume them.
+- ETS caching makes per-Lemming config resolution effectively constant-time at scale.
+
+## Negative
+
+- Dual merge semantics add implementation surface. The distinction between
+  override-dominant and deny-dominant namespaces must be documented and enforced
+  consistently; an incorrect classification of a governance key as override-dominant
+  would be a silent security gap.
+- Cache invalidation is eventual. For governance-critical changes (World-level tool
+  denials), there is a propagation window during which cached effective configs may
+  not yet reflect the new denial.
+- JSONB partial documents require discipline from operators and tooling; keys that
+  do not belong at a given scope must be caught by the validator.
+
+## Mitigations
+
+- The governance namespace list (`tools.deny`, `cost.budget.*`) is small and
+  explicitly enumerated in the resolver. Adding a new deny-dominant namespace
+  requires a deliberate code change, not a configuration value.
+- For operators who require immediate enforcement of a governance change, restarting
+  affected City nodes flushes the cache and forces an immediate reload.
+- `Config.Validator` is a mandatory gateway before persistence; it rejects both
+  invalid configuration and attempts to set keys at disallowed scope levels.
+
+---
+
+# 16. Non-Goals
+
+This ADR intentionally does not define:
+
+- the schema or semantics of individual configuration keys within each namespace
+  (owned by the respective subsystem ADRs)
+- configuration import/export tooling
+- environment-variable-based configuration override for local development
+  (handled by `runtime.exs` at the Mix release level)
+- multi-tenancy where different World operators have independent configuration
+  namespaces (future extension)
+- full event-sourced configuration history with rollback (future extension)
+
+---
+
+# 17. Future Extensions
+
+- **Configuration rollback**: store full JSONB snapshots alongside audit events to
+  allow one-click rollback to a prior configuration state via the control plane.
+- **Dry-run evaluation**: a resolver mode that previews the effective configuration
+  for a proposed change before it is committed to the database.
+- **Per-operator namespace isolation**: for multi-tenant deployments where different
+  World operators should not observe each other's configuration keys.
+- **Signed configuration documents**: cryptographic signatures over config_jsonb
+  to detect tampering in high-security deployments.
+
+---
+
+# 18. Rationale
+
+The core design tension in hierarchical configuration is between operational
+flexibility and governance correctness. A uniform "child overrides parent" rule
+maximizes flexibility but creates a governance gap: any lower-scope administrator
+can nullify a higher-scope security decision. A uniform "parent always wins" rule
+preserves governance but makes the configuration system too rigid for legitimate
+operational customization.
+
+Dual merge semantics resolve this tension by being explicit about which keys
+belong to each category. Governance keys — tool denials and budget ceilings — use
+deny-dominant semantics because their entire purpose is to establish hard
+constraints that cannot be circumvented. All other operational keys use
+override-dominant semantics because customization at lower scopes is a legitimate
+and expected behavior.
+
+This approach also makes the security guarantees of ADR-0012 and ADR-0015
+structurally enforced rather than conventionally enforced. A World administrator
+who denies `shell_exec` does not need to trust that every Department administrator
+will respect that denial in their own configuration. The resolver guarantees it
+algorithmically.
+
+The choice of PostgreSQL JSONB with partial documents, rather than fully-versioned
+tables or event sourcing, reflects the v1 operational target: self-hosted operators
+running on a single VPS do not benefit from the complexity of append-only config
+tables. The audit trail requirement is satisfied by emitting `config.updated`
+events to the existing audit log infrastructure rather than reimplementing event
+sourcing specifically for configuration.

--- a/docs/adr/0021-core-domain-schema.md
+++ b/docs/adr/0021-core-domain-schema.md
@@ -1,0 +1,778 @@
+# ADR-0021 — Core Domain Schema
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: LemmingsOS maintainers
+
+---
+
+# Decision Drivers
+
+1. **Canonical persistence model** — The runtime hierarchy must be represented in the database with a stable, explicit schema. Without a canonical domain model, different subsystems will invent incompatible representations of the same concepts.
+
+2. **Stable identifiers across subsystems** — Routing, persistence, audit logging, authorization, tool governance, and runtime supervision all depend on durable identifiers for Worlds, Cities, Departments, Lemming types, Lemming instances, and Tools.
+
+3. **Hierarchy-aligned architecture** — LemmingsOS is intentionally built around the hierarchy `World → City → Department → Lemming`. The database model must mirror that hierarchy directly so that operational reasoning, control-plane behavior, and runtime state all share the same structure.
+
+4. **Implementation consistency** — Multiple ADRs already reference entities such as `worlds`, `cities`, `departments`, `lemming_types`, `lemming_instances`, and `tool_registry`, but no ADR currently defines them centrally. This creates drift risk across contexts, migrations, and runtime modules.
+
+5. **Foundation for dependent subsystems** — Persistence, audit events, routing, policy evaluation, approval workflows, and runtime observability all need a common domain schema. Without it, downstream implementation remains ambiguous and fragile.
+
+6. **Developer readiness** — The schema definition must be clear enough that a developer can immediately begin implementing Ecto schemas, foreign keys, indexes, and migrations without making architectural guesses.
+
+---
+
+# Context
+
+LemmingsOS operates on a **hierarchical domain model**.
+
+At runtime, the system organizes execution and governance through:
+
+```text
+World → City → Department → Lemming
+```
+
+Previous ADRs already define key architectural behavior around execution, routing, persistence, tools, authorization, approvals, cost governance, audit events, and runtime topology. However, those ADRs rely on a set of shared domain entities that have not yet been defined in one canonical schema.
+
+Core entities already referenced across the architecture include:
+
+- `worlds`
+- `cities`
+- `departments`
+- `lemming_types`
+- `lemming_instances`
+- `tool_registry`
+
+These entities are implicitly required by several subsystems, including:
+
+- routing
+- persistence
+- audit events
+- tool execution
+- configuration
+- runtime supervision
+- policy evaluation
+- cost governance
+- approval workflows
+
+Without a formal domain schema:
+
+- identifiers may drift between subsystems
+- relationship ownership becomes ambiguous
+- migrations risk encoding inconsistent assumptions
+- runtime and control-plane code may model the same concepts differently
+
+This ADR defines the **canonical core domain schema** for LemmingsOS.
+
+---
+
+# Decision
+
+LemmingsOS adopts a canonical relational core domain schema centered on the following persistent entities:
+
+- `worlds`
+- `cities`
+- `departments`
+- `lemming_types`
+- `lemming_instances`
+- `tool_registry`
+- `tool_policies` *(recommended for v1 even if implemented incrementally)*
+
+These entities form the stable foundation for runtime execution, control-plane management, routing, auditability, and policy enforcement.
+
+The schema is intentionally **relational, hierarchy-aware, and identity-first**.
+
+The model distinguishes clearly between:
+
+- **structural entities** — `worlds`, `cities`, `departments`
+- **definition entities** — `lemming_types`, `tool_registry`
+- **runtime entities** — `lemming_instances`
+- **governance entities** — `tool_policies`
+
+This separation is intentional:
+
+- hierarchy structure must remain stable even when runtime instances come and go
+- type definitions must exist independently from currently running instances
+- policy must be attachable to scope and capability definitions without overloading runtime rows
+
+---
+
+# Domain Model Diagram
+
+```text
+World
+  ├── Cities
+  │     └── Departments
+  │           └── Lemming Instances
+  └── Lemming Types
+
+Tool Registry
+  └── Tool Policies
+        └── Applied across World / City / Department / Lemming Type scope
+```
+
+A second view showing relationships more explicitly:
+
+```text
+World
+ ├── City
+ │    ├── Department
+ │    │     ├── Lemming Instance ──────► Lemming Type
+ │    │     └── Tool Policy
+ │    └── Department
+ └── Lemming Types
+
+Tool Registry ──────► Tool Policy
+```
+
+---
+
+# Database Schema
+
+The canonical relational structure of the core domain is shown below.
+
+```mermaid
+erDiagram
+
+    WORLDS ||--o{ CITIES : contains
+    WORLDS ||--o{ DEPARTMENTS : contains
+    WORLDS ||--o{ LEMMING_INSTANCES : scopes
+    WORLDS ||--o{ LEMMING_TYPES : defines
+
+    CITIES ||--o{ DEPARTMENTS : contains
+    CITIES ||--o{ LEMMING_INSTANCES : hosts
+
+    DEPARTMENTS ||--o{ LEMMING_INSTANCES : runs
+
+    LEMMING_TYPES ||--o{ LEMMING_INSTANCES : defines
+
+    TOOL_REGISTRY ||--o{ TOOL_POLICIES : governed_by
+
+    WORLDS {
+        uuid id
+        string name
+        string slug
+        string status
+        jsonb config_jsonb
+    }
+
+    CITIES {
+        uuid id
+        uuid world_id
+        string name
+        string slug
+        string node_name
+        string status
+        jsonb config_jsonb
+        timestamp last_heartbeat_at
+    }
+
+    DEPARTMENTS {
+        uuid id
+        uuid world_id
+        uuid city_id
+        string name
+        string slug
+        string status
+        jsonb config_jsonb
+    }
+
+    LEMMING_TYPES {
+        uuid id
+        uuid world_id
+        string name
+        string slug
+        string module
+        jsonb default_config_jsonb
+        jsonb capabilities_jsonb
+        string status
+        string version
+    }
+
+    LEMMING_INSTANCES {
+        uuid id
+        uuid lemming_type_id
+        uuid world_id
+        uuid city_id
+        uuid department_id
+        uuid parent_instance_id
+        string instance_ref
+        string status
+        jsonb config_jsonb
+        timestamp started_at
+        timestamp stopped_at
+        timestamp last_checkpoint_at
+    }
+
+    TOOL_REGISTRY {
+        uuid id
+        string name
+        string slug
+        string module
+        string package_name
+        string version
+        string risk_level
+        string status
+        jsonb metadata_jsonb
+    }
+
+    TOOL_POLICIES {
+        uuid id
+        uuid tool_registry_id
+        string scope_type
+        uuid scope_id
+        string effect
+        jsonb policy_jsonb
+    }
+```
+
+The Mermaid diagram above represents the **canonical relational model** for the runtime domain.
+
+Actual database migrations may include additional operational columns such as:
+
+- `inserted_at`
+- `updated_at`
+- additional status fields
+- operational metadata
+
+However, the entities and relationships defined in the diagram form the **stable domain contract** used by the rest of the system.
+
+---
+
+# Entity Responsibilities
+
+
+## World
+
+The World is the **top-level isolation boundary**.
+
+Responsibilities:
+
+- defines the outermost durable scope
+- anchors data partitioning and access boundaries
+- scopes Cities and all descendant runtime objects
+- provides the minimum required scope tag for system-wide records
+
+A World is not merely a label. It is a foundational identity boundary for persistence, routing, audit events, and authorization.
+
+---
+
+## City
+
+A City is a **runtime node**.
+
+Responsibilities:
+
+- represents an Elixir / OTP node boundary
+- owns local runtime execution locality
+- contains Departments
+- provides placement identity for Lemming instances
+- supports node-level liveness and operational status
+
+A City is therefore both a domain entity and an operational entity.
+
+---
+
+## Department
+
+A Department is a **logical grouping of agents** inside a City.
+
+Responsibilities:
+
+- groups runtime executions by purpose or ownership
+- acts as a major policy and governance scope
+- provides the immediate structural parent for Lemming instances
+- simplifies operational navigation and observability
+
+Departments exist to organize and constrain agent execution below the City level.
+
+---
+
+## Lemming Type
+
+A Lemming Type is an **agent definition scoped to a World**.
+
+Responsibilities:
+
+- defines reusable agent behavior within its World
+- identifies the implementation module
+- stores default configuration and declared capabilities
+- acts as the template from which Lemming instances are created
+
+A Lemming Type is World-scoped. A Type defined in World A cannot be instantiated in World B, preserving the World isolation boundary established in ADR-0003. Two different Worlds may define Types with identical behavior, but they are distinct records with distinct identities.
+
+A Lemming Type is not itself a runtime process.
+
+---
+
+## Lemming Instance
+
+A Lemming Instance is a **running or historical agent execution**.
+
+Responsibilities:
+
+- records a concrete execution lifecycle
+- binds a Lemming Type to a specific hierarchy scope
+- provides the stable identity used by routing and persistence
+- stores runtime status and execution timestamps
+- enables auditability and observability of execution history
+
+This is the runtime unit most downstream subsystems operate on.
+
+---
+
+## Tool Registry
+
+The Tool Registry is the **catalog of installed tools**.
+
+Responsibilities:
+
+- records which tools exist in the platform
+- stores tool metadata such as module, version, and risk level
+- anchors tool discovery, enablement, authorization, and governance
+- separates tool definition from specific runtime invocation events
+
+A Tool Registry row defines a capability known to the system, not a specific invocation.
+
+---
+
+# Identity Model
+
+LemmingsOS adopts a durable identity model for the core domain schema.
+
+## Primary Key Expectations
+
+All primary entities should use **UUIDs** as primary keys in v1.
+
+Recommended:
+
+- `Ecto.UUID` for schema identifiers
+- generated at the application boundary or database boundary consistently
+
+Rationale:
+
+- UUIDs are stable across distributed nodes
+- they avoid coordination issues associated with integer sequences in multi-node thinking
+- they are well-supported by Ecto and PostgreSQL
+- they work well for public-facing opaque identifiers
+
+## Stable Runtime Identity
+
+For runtime-facing entities, especially `lemming_instances`, stable identity must survive across the runtime lifecycle.
+
+Recommendations:
+
+- database `id` remains the durable primary key
+- `instance_ref` may also be stored as a stable opaque logical execution reference
+- runtime PIDs or node-local process identifiers must never be treated as canonical durable identity
+
+## Hierarchy References Always Stored
+
+Hierarchy references should be stored explicitly on runtime entities.
+
+For example, `lemming_instances` should always store:
+
+- `world_id`
+- `city_id`
+- `department_id`
+- `lemming_type_id`
+
+Rationale:
+
+- avoids ambiguous joins during audit and observability queries
+- makes authorization and scope filtering cheaper and clearer
+- reduces accidental mis-scoping in downstream code
+- reflects that scope is part of the semantic identity of a runtime instance, not merely a derived property
+
+## Human-Readable Identifiers
+
+In addition to UUID primary keys, entities that appear frequently in the UI or configuration should also have a stable human-readable identifier such as `slug`.
+
+This improves:
+
+- operator ergonomics
+- CLI references
+- control-plane URLs
+- configuration readability
+
+These slugs are supplementary and must not replace UUID primary keys internally.
+
+---
+
+# Runtime Relationships
+
+The core runtime relationships are:
+
+- `cities` belong to `worlds`
+- `departments` belong to `cities`
+- `departments` also belong to `worlds`
+- `lemming_types` belong to `worlds`
+- `lemming_instances` belong to `departments`
+- `lemming_instances` belong to `cities`
+- `lemming_instances` belong to `worlds`
+- `lemming_instances` reference `lemming_types`
+- `tool_policies` reference `tool_registry`
+- `tool_policies` attach to hierarchy scopes and optionally to `lemming_types`
+
+Relationship diagram (Mermaid):
+
+```mermaid
+erDiagram
+    WORLDS ||--o{ CITIES : contains
+    WORLDS ||--o{ DEPARTMENTS : contains
+    WORLDS ||--o{ LEMMING_INSTANCES : scopes
+    WORLDS ||--o{ LEMMING_TYPES : defines
+
+    CITIES ||--o{ DEPARTMENTS : contains
+    CITIES ||--o{ LEMMING_INSTANCES : hosts
+
+    DEPARTMENTS ||--o{ LEMMING_INSTANCES : runs
+
+    LEMMING_TYPES ||--o{ LEMMING_INSTANCES : defines
+
+    TOOL_REGISTRY ||--o{ TOOL_POLICIES : governed_by
+
+    WORLDS {
+        uuid id
+    }
+
+    CITIES {
+        uuid id
+        uuid world_id
+    }
+
+    DEPARTMENTS {
+        uuid id
+        uuid world_id
+        uuid city_id
+    }
+
+    LEMMING_TYPES {
+        uuid id
+        uuid world_id
+    }
+
+    LEMMING_INSTANCES {
+        uuid id
+        uuid lemming_type_id
+        uuid world_id
+        uuid city_id
+        uuid department_id
+    }
+
+    TOOL_REGISTRY {
+        uuid id
+    }
+
+    TOOL_POLICIES {
+        uuid id
+        uuid tool_registry_id
+    }
+```
+
+## Relationship Principles
+
+### 1. Downward hierarchy must be explicit
+
+Every descendant entity stores explicit references upward.
+
+### 2. Runtime and definition entities are fully scoped
+
+A `lemming_instance` is never "floating." It must always belong to a World, City, Department, and Lemming Type.
+
+A `lemming_type` is also World-scoped. It must always belong to a World. A Lemming Instance may only reference a Lemming Type within the same World.
+
+### 3. Definitions and executions are separate
+
+A `lemming_type` may exist even if there are no active `lemming_instances`.
+
+### 4. Tools and policy are separate concerns
+
+`tool_registry` describes what a Tool is.
+`tool_policies` describe where and how it may be used.
+
+---
+
+# Indexing Strategy
+
+The schema should be indexed according to common runtime, audit, routing, and control-plane query patterns.
+
+## Required or Strongly Recommended Indexes
+
+### Hierarchy indexes
+
+- `cities(world_id)`
+- `departments(world_id)`
+- `departments(city_id)`
+- `lemming_types(world_id)`
+- `lemming_instances(world_id)`
+- `lemming_instances(city_id)`
+- `lemming_instances(department_id)`
+- `lemming_instances(lemming_type_id)`
+
+### Runtime state indexes
+
+- `lemming_instances(status)`
+- `cities(status)`
+- `departments(status)`
+
+### Identity and lookup indexes
+
+- unique index on `worlds.slug`
+- unique composite index on `cities(world_id, slug)`
+- unique composite index on `departments(city_id, slug)`
+- unique composite index on `lemming_types(world_id, slug)`
+- unique index on `lemming_instances(instance_ref)`
+- unique index on `tool_registry.slug`
+
+### Policy indexes
+
+`tool_policies` uses a polymorphic scope pattern (`scope_type` + `scope_id`)
+rather than dedicated FK columns per hierarchy level. Indexes follow accordingly:
+
+- `tool_policies(tool_registry_id)` — look up all policies for a given tool
+- `tool_policies(scope_type, scope_id)` — resolve effective policies for a
+  given scope (e.g., `scope_type = 'world' AND scope_id = <world_id>`)
+
+A partial index per scope type may be added if query profiling shows it is
+beneficial:
+
+```sql
+CREATE INDEX ON tool_policies (scope_id) WHERE scope_type = 'world';
+CREATE INDEX ON tool_policies (scope_id) WHERE scope_type = 'department';
+```
+
+These are optional optimizations, not required at v1 schema definition time.
+
+## Why These Queries Matter
+
+These indexes support the most common expected operations:
+
+- list all Cities in a World
+- list all Departments in a City
+- list all Lemming instances in a Department
+- find active or waiting instances by status
+- resolve a runtime instance by `instance_ref`
+- filter runtime state by hierarchy scope in the control plane
+- resolve effective tool policy for a specific scope or Lemming Type
+- support audit/event producers that need fast scope resolution
+
+The indexing strategy is therefore driven by **operational query patterns**, not only by relational purity.
+
+---
+
+# Operational Characteristics
+
+## Supports distributed nodes
+
+The schema is designed to support a multi-City distributed topology.
+
+Why:
+
+- Cities map to runtime nodes
+- instance placement must be queryable durably
+- operational state such as heartbeat and status must be visible outside the running process tree
+
+## Entities are scoped by World
+
+World scope is first-class across the schema.
+
+Implications:
+
+- every major hierarchy row is world-aware
+- filtering by world is cheap and explicit
+- access control, routing, and audit systems have a consistent top-level scope
+
+## Designed for runtime observability
+
+The schema supports direct operational inspection.
+
+Examples:
+
+- which City is unhealthy
+- which Departments exist under a City
+- which instances are waiting, failed, or running
+- which Lemming Type a given instance belongs to
+- which Tools exist and what risk level they carry
+
+This observability is not accidental. It is part of the schema design.
+
+## Compatible with append-only audit/event model
+
+The domain schema does not replace audit tables, but it gives them stable foreign keys and scope references.
+
+Examples:
+
+- `events.world_id` can align with `worlds.id`
+- `events.city_id` can align with `cities.id`
+- `events.department_id` can align with `departments.id`
+- `events.lemming_id` can align with `lemming_instances.id`
+
+This reduces drift across the event model and the domain model.
+
+---
+
+# Implementation Notes
+
+Expected Ecto schema modules include:
+
+```elixir
+LemmingsOs.Schema.World
+LemmingsOs.Schema.City
+LemmingsOs.Schema.Department
+LemmingsOs.Schema.LemmingType
+LemmingsOs.Schema.LemmingInstance
+LemmingsOs.Schema.ToolRegistry
+LemmingsOs.Schema.ToolPolicy
+```
+
+Implementation expectations:
+
+- use standard Ecto schemas
+- model hierarchy references with explicit `belongs_to`
+- define matching `has_many` relations where useful for navigation
+- use `:binary_id` / UUID primary keys consistently
+- validate required hierarchy foreign keys at the schema level
+- add explicit unique constraints for slugs and runtime identifiers
+- use `embeds_one` or JSONB-backed map fields only where the data is genuinely flexible
+
+Recommended design style:
+
+- keep the core hierarchy relational and explicit
+- use JSONB only for bounded flexible configuration, not for entity identity or relationship modeling
+- align Ecto context boundaries with domain concepts rather than creating one giant persistence context
+
+Example relationship expectations:
+
+- `World has_many :cities`
+- `World has_many :lemming_types`
+- `City belongs_to :world`
+- `City has_many :departments`
+- `Department belongs_to :city`
+- `Department has_many :lemming_instances`
+- `LemmingType belongs_to :world`
+- `LemmingInstance belongs_to :lemming_type`
+- `ToolPolicy belongs_to :tool_registry`
+
+This ADR does not force a specific context module layout, but it does require that the database model and Ecto schemas follow the canonical structure defined here.
+
+---
+
+# Considered Options
+
+## Option A — Flat entity model
+
+All rows exist in a largely flat structure with minimal explicit hierarchy, relying on conventions or ad hoc metadata to reconstruct scope.
+
+**Rejected.**
+
+Why:
+
+- weakens hierarchy guarantees
+- makes authorization and routing harder to reason about
+- encourages ambiguous ownership of runtime objects
+- does not reflect the architecture’s core World → City → Department model
+
+## Option B — Event-only model
+
+Represent the domain primarily through append-only events and reconstruct current state through projections.
+
+**Rejected for v1.**
+
+Why:
+
+- adds substantial implementation complexity too early
+- makes basic control-plane CRUD and runtime queries harder to implement
+- is disproportionate to the current self-hosted v1 scope
+- the platform already benefits from an event model, but not as the only source of operational truth
+
+## Option C — Document-only storage
+
+Store major entities as JSON documents rather than explicit relational tables.
+
+**Rejected.**
+
+Why:
+
+- weakens foreign key integrity
+- makes hierarchical joins and scoped queries less reliable
+- increases migration ambiguity
+- conflicts with the need for precise indexing, stable references, and predictable relational semantics
+
+## Option D — Relational hierarchy with explicit runtime and definition entities
+
+**Chosen.**
+
+Why:
+
+- matches the architecture directly
+- supports stable identifiers and relationships
+- makes Ecto implementation straightforward
+- works cleanly with audit, routing, and policy systems
+
+---
+
+# Consequences
+
+## Positive
+
+- establishes a stable domain foundation for the whole platform
+- creates a clear runtime identity model
+- provides a consistent persistence layer across subsystems
+- makes routing, audit, policy, and observability implementations materially easier
+- reduces schema drift risk between ADRs and implementation
+- enables immediate implementation of Ecto schemas and migrations with low ambiguity
+
+## Negative / Trade-offs
+
+- explicit hierarchy references create some denormalization, especially on runtime rows such as `lemming_instances`
+- the schema introduces several core tables early, which may feel heavier than a more ad hoc prototype
+- JSONB configuration fields require discipline to avoid becoming a dumping ground for undefined behavior
+
+## Mitigations
+
+- treat denormalized scope fields as an intentional operational optimization
+- keep the entity set small and focused in v1
+- add dedicated tables only when a configuration shape stabilizes beyond what JSONB should hold
+- enforce schema discipline through Ecto validations, foreign keys, and unique constraints
+
+---
+
+# Rationale
+
+LemmingsOS already has a strong architectural hierarchy and a growing set of ADRs that depend on shared entities.
+
+Without a canonical domain schema, implementation will drift:
+
+- routing will invent one representation of instance identity
+- persistence will invent another
+- audit and policy systems will attach to partially overlapping concepts
+
+That is exactly the kind of architectural ambiguity a staff-level ADR set should eliminate.
+
+The chosen schema makes the core model explicit:
+
+- Worlds define isolation
+- Cities define runtime nodes
+- Departments define logical groupings
+- Lemming Types define reusable behavior
+- Lemming Instances define concrete execution
+- Tool Registry defines platform capabilities
+- Tool Policies define durable governance attachments
+
+This is sufficient to begin implementation immediately while leaving room for future specialization.
+
+---
+
+# Implementation Readiness Summary
+
+A developer should be able to begin implementation directly from this ADR by creating:
+
+1. Ecto schemas for the seven core entities
+2. migrations with UUID primary keys and explicit foreign keys
+3. uniqueness constraints for slugs and runtime identifiers
+4. hierarchy and runtime indexes described above
+5. context modules that expose CRUD and lookup operations aligned to the hierarchy
+
+This ADR intentionally defines the domain model at the level needed to start those tasks without architectural guesswork.
+

--- a/docs/adr/0022-deployment-and-packaging-model.md
+++ b/docs/adr/0022-deployment-and-packaging-model.md
@@ -1,0 +1,466 @@
+# ADR-0022 — Deployment and Packaging Model
+
+Status: Accepted  
+Date: 2026-03-14  
+Decision Makers: LemmingsOS maintainers
+
+---
+
+# Decision
+
+LemmingsOS is deployed as a **Mix Release packaged as an OCI-compatible container image**.
+
+Reference deployment stack:
+
+- Elixir Mix Release
+- OCI container image (Docker-compatible)
+- PostgreSQL database
+- Phoenix web interface
+- Distributed Erlang clustering
+
+Each **City corresponds to one runtime node**, and each runtime node typically runs inside **one container**.
+
+Multiple Cities form a **World cluster**.
+
+The container includes the compiled OTP release and runtime configuration but relies on **external PostgreSQL storage**.
+
+Docker is the **reference container runtime**, but any OCI-compatible runtime (such as **Podman**) is supported.
+
+Running a Mix Release directly on the host system is also technically possible, but container packaging is the **canonical operational model**.
+
+This model provides:
+
+- reproducible builds
+- consistent runtime environments
+- simple self-hosting
+- compatibility with container orchestration platforms
+
+---
+
+# Deployment Architecture
+
+```
+           ┌─────────────────────────────┐
+           │           World             │
+           │        (cluster scope)      │
+           └─────────────┬───────────────┘
+                         │
+       ┌─────────────────┴─────────────────┐
+       │                                   │
+  ┌────┴─────┐                       ┌─────┴─────┐
+  │ City A   │                       │ City B    │
+  │ Docker   │                       │ Docker    │
+  │ OTP Node │                       │ OTP Node  │
+  └────┬─────┘                       └─────┬─────┘
+       │                                   │
+  Departments                         Departments
+       │                                   │
+  Lemmings                            Lemmings
+```
+
+Key properties:
+
+- **World** is a logical cluster boundary
+- **City** is a running OTP node
+- Each City executes inside its own container
+- Departments and Lemmings run inside the node supervision tree
+
+Cities join the World cluster using **Erlang distribution**.
+
+---
+
+# Packaging Model
+
+Packaging is composed of two layers.
+
+## Application Package
+
+The application is built as a standard **Mix project** that produces a compiled OTP release.
+
+Release artifacts are produced with:
+
+```
+mix release
+```
+
+The compiled release is located at:
+
+```
+_build/prod/rel/lemmings_os
+```
+
+This release contains:
+
+- compiled BEAM bytecode
+- supervision tree configuration
+- runtime configuration loader
+- Phoenix endpoint
+
+
+## Container Image
+
+The release is embedded inside a Docker image.
+
+The Docker image contains:
+
+- compiled Mix release
+- runtime configuration files
+- entrypoint script
+- minimal runtime OS environment
+
+The container is the primary distribution artifact used for deployment.
+
+---
+
+# Runtime Components in the Container
+
+Each container runs the full runtime stack for a City node.
+
+Processes running inside the container include:
+
+- Phoenix HTTP server
+- runtime supervision tree
+- Lemming execution engine
+- tool runtime
+- telemetry emitters
+- configuration resolver
+
+Persistent storage is externalized.
+
+The PostgreSQL database runs **outside the container**.
+
+The DETS idle-snapshot store (ADR-0008) writes to the local filesystem and **must be backed by a persistent volume**. Without a mounted volume, container restarts destroy all idle Lemming snapshots and defeat the rehydration guarantee.
+
+---
+
+# Clustering Model
+
+Cities form a **distributed Erlang cluster**.
+
+Each runtime node:
+
+- has a unique Erlang node name
+- connects to peer nodes via Erlang distribution
+- participates in cluster membership
+
+Clustering enables:
+
+- inter-city communication
+- distributed Lemming execution
+- cluster-wide coordination
+
+Cities may dynamically join or leave the cluster.
+
+World isolation guarantees that nodes belonging to different Worlds never cluster together.
+
+---
+
+# Installation Modes
+
+The system supports multiple deployment modes.
+
+## Local Development
+
+Developers run a single node locally using:
+
+```
+mix phx.server
+```
+
+This runs:
+
+- Phoenix server
+- runtime supervisors
+- local PostgreSQL database
+
+This mode prioritizes fast feedback during development.
+
+---
+
+## Single-Node Production
+
+A single container runs the entire runtime.
+
+Components:
+
+- Phoenix
+- runtime engine
+- one City node
+
+Suitable for:
+
+- small teams
+- experimentation
+- staging environments
+
+---
+
+## Multi-City Deployment
+
+Multiple containers form a distributed cluster.
+
+Example topology:
+
+```
+World
+ ├─ City A (node)
+ ├─ City B (node)
+ └─ City C (node)
+```
+
+Each container runs a single City node.
+
+This model allows horizontal scaling of runtime capacity.
+
+---
+
+# Operational Characteristics
+
+The deployment model prioritizes the following properties:
+
+- **simple self-hosting**
+- **container-native deployment**
+- **reproducible builds**
+- **predictable node topology**
+- **horizontal scalability through Cities**
+
+Operators can scale the system by adding or removing City containers.
+
+---
+
+# Security Boundaries
+
+Containerization also provides an important **security boundary** for the runtime.
+
+Running LemmingsOS inside a container restricts the default filesystem and process visibility of the application. The runtime only sees the files and system resources available inside the container image and its configured mounts.
+
+This design reduces the risk of agents or tools accidentally accessing sensitive parts of the host system.
+
+External directories may still be shared intentionally using **container volumes**. For example:
+
+- mounting a project repository for analysis
+- exposing a data directory
+- sharing artifacts produced by tools
+
+Example conceptually:
+
+```
+-v ./project:/workspace/project
+```
+
+However, this access is **explicit and operator-controlled**.
+
+This model allows LemmingsOS to run safely on a personal workstation or development machine while maintaining strict boundaries around what agents can access.
+
+This contrasts with systems that allow unrestricted shell access to the host environment, which can create significant security risks when running autonomous agents.
+
+Container isolation therefore provides:
+
+- controlled filesystem exposure
+- predictable execution environments
+- safer local self-hosting
+
+Conceptual isolation model:
+
+```
+Host OS
+   │
+   ├── Docker / Podman Runtime
+   │       │
+   │       └── LemmingsOS Container
+   │              │
+   │              ├── Phoenix Server
+   │              ├── Runtime Supervisors
+   │              ├── Lemming Execution Engine
+   │              └── Tool Runtime
+   │
+   ├── Mandatory Persistent Volume
+   │       └── lemmings_dets_data → /app/data/dets  (idle snapshots)
+   │
+   └── Optional Mounted Volumes
+           ├── /workspace/project
+           └── /data/artifacts
+```
+
+Only explicitly mounted directories become visible inside the container. The host filesystem remains inaccessible by default.
+
+The DETS volume is mandatory: its absence does not cause a startup error but will silently break idle Lemming rehydration after any container restart.
+
+# Persistent Volume Requirements
+
+Container deployments have one mandatory persistent volume and one optional persistent volume.
+
+## DETS Snapshot Directory (mandatory)
+
+The DETS idle-snapshot store (ADR-0008) must be backed by a persistent volume. The runtime writes idle Lemming snapshots to a configurable path on the local filesystem. OCI containers destroy their ephemeral filesystem layer on restart; without a persistent volume, all idle snapshots are lost on container restart and the rehydration guarantee described in ADR-0008 cannot be fulfilled.
+
+Required volume mount:
+
+```
+-v lemmings_dets_data:/app/data/dets
+```
+
+The path inside the container is configurable via the `DETS_DATA_DIR` environment variable and defaults to `/app/data/dets`.
+
+This volume must be configured before the first container start. Operators who omit it will experience silent rehydration failures after any container restart; there is no startup error.
+
+## Workspace / Artifact Directories (optional)
+
+External directories may be mounted to give tools access to project files or artifact output:
+
+```
+-v ./project:/workspace/project
+```
+
+These mounts are operator-controlled and optional.
+
+---
+
+# Configuration
+
+Runtime configuration is provided at startup.
+
+Configuration sources:
+
+- environment variables
+- `runtime.exs`
+
+Typical environment variables include:
+
+```
+DATABASE_URL
+NODE_NAME
+WORLD_ID
+SECRET_KEY_BASE
+DETS_DATA_DIR
+```
+
+Configuration resolution occurs during release boot.
+
+---
+
+# Implementation Notes
+
+Deployment requires the following artifacts:
+
+```
+Dockerfile
+mix release
+runtime.exs
+```
+
+The project will also distribute a **reference docker-compose configuration** to simplify self-hosted installations.
+
+Example stack provided by the compose file:
+
+- PostgreSQL database
+- LemmingsOS runtime container with DETS persistent volume pre-configured
+- optional supporting services (future telemetry / observability components)
+
+The compose file is provided **for convenience only**.
+
+Operators may instead use:
+
+- externally managed PostgreSQL databases
+- existing container orchestration platforms
+- manual container deployment
+
+Key runtime modules involved in bootstrapping include:
+
+```
+LemmingsOs.Application
+LemmingsOs.World.Registry
+LemmingsOs.City.Supervisor
+```
+
+These modules initialize the runtime hierarchy during application startup.
+
+---
+
+# Considered Options
+
+## Running directly with `mix phx.server` in production
+
+Rejected.
+
+Running the development server in production provides poor operational guarantees and lacks reproducible builds.
+
+---
+
+## Non-container deployment
+
+Rejected.
+
+While technically possible, bare-metal deployments introduce environment drift and reduce reproducibility.
+
+Container packaging provides a stable runtime environment.
+
+---
+
+## Kubernetes-only deployment
+
+Rejected.
+
+Mandating Kubernetes would significantly increase operational complexity and exclude smaller self-hosted installations.
+
+Kubernetes can still be supported later as an optional deployment target.
+
+---
+
+# Consequences
+
+## Positive
+
+- Predictable runtime topology: each City maps to exactly one container, making
+  the relationship between architecture and infrastructure unambiguous.
+- Reproducible builds: the Mix Release + OCI image pipeline produces identical
+  artifacts across environments.
+- Simplified self-hosting: a reference `docker-compose.yml` gives operators a
+  working stack without infrastructure expertise.
+- Container filesystem isolation reduces the blast radius if a tool process
+  escapes its sandbox; the host filesystem remains inaccessible by default.
+
+## Negative / Trade-offs
+
+- **Erlang distribution security**: Erlang distribution is unauthenticated by
+  default (shared cookie only) and unencrypted. A World cluster exposed on a
+  public or shared network is vulnerable to node impersonation and traffic
+  interception. Distribution TLS and strict cookie management are required for
+  any production deployment outside a trusted private network.
+- **External PostgreSQL dependency**: the container does not bundle a database.
+  Operators must provision and maintain a PostgreSQL instance independently.
+  This is standard for production but adds setup friction for first-time
+  self-hosters.
+- **Mandatory DETS persistent volume**: idle Lemming snapshots require a
+  persistent volume mount (see Persistent Volume Requirements). Omitting it
+  causes silent rehydration failures after container restart with no startup
+  error.
+- **Container image size**: bundling the full OTP release and a minimal OS
+  environment produces a non-trivial image. Unmanaged image growth as
+  dependencies accumulate can slow CI and increase registry storage costs.
+- **Node startup time**: OTP release boot, supervision tree initialization, and
+  lazy cache population add startup latency compared to direct `mix phx.server`
+  usage. This is most noticeable in development iteration cycles.
+
+## Mitigations
+
+- Distribution TLS should be configured using `:inet_tls_dist` with operator-
+  managed certificates, and the Erlang cookie must be treated as a secret
+  (injected via `RELEASE_COOKIE` env var, not committed to the repository).
+  The reference `docker-compose.yml` will document this as a required step for
+  any non-localhost deployment.
+- The reference compose file bundles PostgreSQL for convenience. Operators who
+  need managed Postgres (RDS, Supabase, etc.) substitute the `DATABASE_URL`
+  environment variable without other changes.
+- The DETS volume is pre-configured in the reference compose file. Operators
+  deploying without compose are warned in the Persistent Volume Requirements
+  section above.
+- Multi-stage Dockerfiles (builder + runtime image) keep the final image small
+  by discarding build tooling. Image size discipline should be enforced in CI.
+
+## Future Extensions
+
+- Kubernetes deployment model and Helm chart.
+- Multi-world gateway nodes.
+- Autoscaling strategies for City containers.
+

--- a/docs/adr/0023-error-handling-and-degradation-model.md
+++ b/docs/adr/0023-error-handling-and-degradation-model.md
@@ -1,0 +1,462 @@
+# ADR-0023 — Error Handling and Graceful Degradation Model
+
+- **Status:** Accepted
+- **Date:** 2026-03-14
+- **Decision Makers:** LemmingsOS maintainers
+
+---
+
+# 1. Decision Drivers
+
+LemmingsOS needs a single cross-cutting failure philosophy because failure is not exceptional in an agent runtime; it is a normal operating condition.
+
+Agents may run for minutes or hours. During that time, model providers may rate limit or become unavailable, tool executions may crash or time out, nodes may restart, and runtime dependencies may temporarily fail. Without an explicit architecture-level model, local retry logic tends to become inconsistent, failures become difficult to contain, and independent subsystems can amplify each other into cascading failure.
+
+The runtime must therefore provide a consistent model for:
+
+- containing failures within the smallest possible scope
+- preventing retry storms and feedback loops
+- preserving system stability under partial outage
+- avoiding unbounded queue growth and resource exhaustion
+- remaining operationally simple for self-hosted deployments
+
+This is especially important for LemmingsOS because the project is intentionally designed to be:
+
+- self-hosted
+- accessible to small teams
+- inexpensive to run
+- operable without complex distributed infrastructure
+
+The system must remain usable during partial failures, but it must not attempt to hide hard dependency failures with expensive coordination layers or complicated control planes.
+
+---
+
+# 2. Context
+
+Previous ADRs already define local aspects of failure handling:
+
+- the Lemming execution lifecycle and state transitions
+- the Tool Runtime execution model
+- the Model Runtime abstraction and provider routing
+- runtime cost governance and hard budget stops
+- runtime topology and deployment assumptions
+
+Those ADRs establish where failures can happen, but they do not yet define a global philosophy for how failures should be contained, retried, surfaced, or degraded across the runtime as a whole.
+
+The system must handle, at minimum, the following classes of failure:
+
+- model API outages, timeouts, and rate limits
+- tool crashes, timeouts, and sandbox failures
+- temporary database failures
+- overloaded nodes or saturated runtimes
+- runaway agents repeatedly consuming compute without making progress
+- node restart or process crash during active work
+
+LemmingsOS must address these cases without introducing heavy resilience infrastructure such as service meshes, distributed breaker clusters, or centralized failure orchestration planes.
+
+---
+
+# 3. Decision
+
+LemmingsOS adopts a simple OTP-native failure and degradation model based on:
+
+- supervision trees for containment and restart
+- bounded retries with exponential backoff
+- explicit backpressure and concurrency limits
+- fail-fast handling for non-recoverable errors
+- local circuit breakers for repeatedly failing dependencies
+- hierarchical model-provider fallback from day 0
+
+The runtime prioritizes:
+
+- stability over throughput
+- predictable behavior over aggressive retries
+- local containment over global coordination
+- simple operational semantics over infrastructure-heavy resilience patterns
+
+Failure handling is intentionally local-first. The runtime should recover common transient failures automatically when safe to do so, degrade in a visible and bounded way when necessary, and stop work explicitly when a dependency is hard-required and unavailable.
+
+---
+
+# 4. Failure Containment Model
+
+Failures must remain contained within the lowest practical boundary of the hierarchy.
+
+```text
+World
+  └─ City
+       └─ Department
+            └─ Lemming
+```
+
+The containment model is:
+
+- a tool execution failure affects the current Lemming execution path, not the Department
+- a Lemming crash does not terminate the Department supervisor tree
+- a Department overload or crash does not terminate the City
+- a City-level failure does not corrupt World-level configuration or control-plane state
+
+This behavior is implemented with OTP supervision trees, restart intensity limits, and explicit ownership boundaries between runtime processes.
+
+The architecture does not attempt to make every failure invisible. Instead, it ensures that failures are isolated, observable, and recoverable at the correct scope.
+
+---
+
+# 5. Failure Classification
+
+For runtime behavior, failures are classified into three broad categories:
+
+## 1. Transient failures
+
+Examples:
+
+- provider timeout
+- HTTP 429 rate limit
+- short-lived network interruption
+- temporary database connectivity issue
+- temporary node overload
+
+These failures may be retried using bounded retry rules.
+
+## 2. Persistent or semi-persistent failures
+
+Examples:
+
+- provider outage lasting several minutes
+- a tool consistently crashing because of environment issues
+- local sandbox misconfiguration
+- database unavailable until operator intervention
+
+These failures should trigger local degradation behavior such as breaker open state, queue slowdown, or explicit pause of new work.
+
+## 3. Permanent or non-recoverable failures
+
+Examples:
+
+- invalid tool input
+- policy denial
+- authorization failure
+- budget exhaustion
+- missing required configuration
+- unsupported model or tool capability
+
+These failures must fail fast and must not be retried automatically.
+
+---
+
+# 6. Retry Strategy
+
+Retries must always be bounded.
+
+Unbounded retries are forbidden.
+
+The default retry philosophy is:
+
+- retry only for clearly transient failures
+- use exponential backoff
+- optionally add jitter to avoid synchronized retry spikes
+- stop retrying once the retry budget is exhausted
+- surface the failure explicitly to the owning process
+
+Illustrative policy:
+
+```text
+attempt 1  -> immediate failure handling
+attempt 2  -> backoff 1s
+attempt 3  -> backoff 5s
+attempt 4  -> backoff 30s
+then fail
+```
+
+Subsystem guidance:
+
+- **Model Runtime:** bounded retries for timeouts, 429s, and selected 5xx failures
+- **Tool Runtime:** bounded retries only when the tool contract declares the action retry-safe
+- **Persistence / database operations:** bounded retries for transient connectivity or lock-related failures
+- **Policy, auth, approval, and budget failures:** no automatic retry
+
+Retry policy remains local to the subsystem, but all subsystem policies must follow the same architectural rule: bounded, explicit, and classified.
+
+---
+
+# 7. Backpressure Philosophy
+
+LemmingsOS must protect the host and runtime before it protects throughput.
+
+Backpressure is mandatory and is implemented with local limits such as:
+
+- maximum active Lemmings per Department
+- maximum queued work per Department
+- maximum concurrent tool executions
+- maximum concurrent model requests per provider
+- maximum retries in flight for a given failure domain
+- cost and budget hard stops as defined in ADR-0015
+
+When limits are reached, the runtime may:
+
+- queue work for later execution
+- reject new work explicitly
+- transition work into a waiting state
+- slow or pause scheduling within the local scope
+
+The architecture does not require distributed queue coordination. Local concurrency limits and bounded queues are sufficient for v1 and consistent with the deployment model.
+
+---
+
+# 8. Circuit Breakers (Minimal and Local)
+
+Circuit breakers are allowed, but only as simple local runtime mechanisms.
+
+Examples:
+
+- the Tool Runtime temporarily disables a repeatedly failing tool within the local node scope
+- the Model Runtime opens a breaker for a failing provider or model route
+
+Illustrative behavior:
+
+```text
+provider fails repeatedly
+-> breaker opens for 60 seconds
+-> no new requests sent during cooldown
+-> one probe request allowed after cooldown
+-> success closes breaker, failure reopens it
+```
+
+The architecture explicitly rejects:
+
+- globally coordinated breaker state
+- distributed resilience clusters
+- service-mesh-based breaker behavior
+
+Breaker state is intentionally local because LemmingsOS is designed for simple self-hosted deployments and because local containment is sufficient to prevent retry storms in the intended operating model.
+
+---
+
+# 9. Model Provider Fallback
+
+Hierarchical model-provider fallback is a required capability from v1.
+
+LemmingsOS supports a primary model route and a fallback model route. Fallback can be configured hierarchically:
+
+- World may define a default fallback provider/model
+- City may override the World fallback
+- Department may override the City fallback
+- Lemming type or instance policy may select from the allowed effective configuration
+
+Fallback is used only when failure classification indicates that the primary model route is temporarily unavailable or unhealthy, such as:
+
+- timeout
+- provider outage
+- rate-limit saturation
+- repeated transient transport failure
+
+Fallback is not used to bypass policy denial, budget exhaustion, or authorization failure.
+
+The runtime must preserve the same policy and budget checks when switching to fallback. A fallback provider is not an escape hatch around governance.
+
+If both primary and fallback routes are unavailable, the Lemming transitions into a waiting or failed state according to its execution policy.
+
+---
+
+# 10. Database Failure Semantics
+
+PostgreSQL is a required system dependency.
+
+If PostgreSQL becomes temporarily unavailable, the runtime should not panic, crash-loop uncontrollably, or amplify the failure through aggressive retry behavior. Instead:
+
+- database-dependent operations may retry with bounded backoff
+- supervisors remain alive where possible
+- new work may be slowed, queued, or rejected
+- affected processes move into safe waiting or failed states
+- operators should receive explicit degraded-state signals through logs and audit events where applicable
+
+However, LemmingsOS does **not** define an offline operating mode.
+
+If PostgreSQL is unavailable for longer than the local retry window, the system should be treated as degraded or unavailable, not as partially offline-capable. The architecture prefers honest dependency failure over hidden split-brain behavior, local shadow persistence, or ad hoc offline execution semantics.
+
+In short:
+
+- temporary DB loss -> bounded retry and controlled degradation
+- prolonged DB loss -> system unavailable for normal operation
+- no offline mode
+
+---
+
+# 11. Graceful Degradation Model
+
+Graceful degradation means the runtime continues operating in a reduced but controlled manner when some capabilities are unavailable.
+
+It does **not** mean pretending that hard dependencies are optional.
+
+| Failure | Runtime behavior |
+| --- | --- |
+| Primary model provider unavailable | Retry with backoff, then route to configured fallback provider if allowed |
+| Primary and fallback model unavailable | Lemming waits or fails according to execution policy |
+| Tool execution crash | Current execution path fails, retry only if tool contract allows |
+| Tool repeatedly failing | Local breaker opens and new calls are paused during cooldown |
+| Node restart | Supervisors restore runtime processes according to restart strategy and persisted state |
+| Temporary PostgreSQL failure | Operations retry with backoff and runtime enters controlled degraded mode |
+| Prolonged PostgreSQL failure | System becomes unavailable for normal operation; no offline fallback mode |
+| Budget exhausted | Hard stop; no degradation path that continues spending |
+| Department overload | Scheduling slows, queues fill up to limit, then new work is rejected or deferred |
+
+---
+
+# 12. Operational Characteristics
+
+This decision deliberately favors:
+
+- low infrastructure complexity
+- low operational cost
+- single-node and small-cluster operability
+- straightforward operator mental models
+- OTP-native recovery mechanisms
+
+The runtime should remain reliable on:
+
+- a laptop
+- a single server
+- a small cluster of nodes
+
+without requiring:
+
+- service meshes
+- distributed queue coordinators
+- centralized resilience control planes
+- expensive observability or traffic-management systems
+
+The architecture assumes that many LemmingsOS deployments will be run by small teams with limited infrastructure budgets. Simplicity is therefore an explicit resilience feature, not merely a convenience.
+
+---
+
+# 13. Implementation Notes
+
+Failure handling should be implemented with standard OTP patterns and small local runtime components.
+
+Illustrative modules include:
+
+```elixir
+LemmingsOs.Lemming.Executor
+LemmingsOs.Lemming.Supervisor
+LemmingsOs.Tool.Runtime
+LemmingsOs.Tool.Breaker
+LemmingsOs.Model.Runtime
+LemmingsOs.Model.Breaker
+LemmingsOs.Department.Manager
+LemmingsOs.Runtime.Scheduler
+```
+
+Implementation guidance:
+
+- supervisors define restart boundaries and intensity limits
+- retry metadata should be explicit in runtime state, not hidden in recursive loops
+- breaker state should remain local and lightweight
+- queue sizes and concurrency limits should be configurable by scope where appropriate
+- fallback model routing should reuse the same policy, budget, and audit hooks as primary routing
+- degraded-state transitions should be visible in logs and audit events
+
+---
+
+# 14. Considered Options
+
+## Full distributed circuit breaker systems
+
+Rejected.
+
+This adds coordination overhead and operational complexity that do not fit the project's self-hosted and low-cost philosophy.
+
+## Service-mesh-based resilience
+
+Rejected.
+
+This shifts core runtime behavior into infrastructure that many intended deployments will not have and should not need.
+
+## Complex centralized failure orchestration layers
+
+Rejected.
+
+This conflicts with the OTP-first design of the runtime and creates an unnecessary control-plane dependency for common failure handling.
+
+## Offline execution mode for database loss
+
+Rejected.
+
+This would require shadow persistence, reconciliation semantics, and significantly more complexity. For v1, PostgreSQL remains a required dependency.
+
+---
+
+# 15. Consequences
+
+## Positive
+
+- failure behavior becomes consistent across runtime subsystems
+- cascading failures are less likely
+- retry storms and resource blowups are reduced
+- the system remains simple to operate for small teams
+- the deployment model stays compatible with self-hosted, low-cost environments
+- model fallback provides practical resilience from day 0 without adding heavy infrastructure
+
+## Negative
+
+- prolonged database failure makes the system unavailable rather than partially offline-capable
+- local breakers do not coordinate globally across nodes
+- throughput may be reduced under load because stability is preferred over aggressive scheduling
+- some failures remain visible to users and operators instead of being hidden behind heavy recovery machinery
+
+---
+
+# 16. Future Extensions
+
+Future ADRs may refine:
+
+- exact retry classification tables per subsystem
+- breaker thresholds and cooldown defaults
+- operator-facing degraded-state visibility and health reporting
+- persistence recovery semantics after node restart
+- optional larger-scale deployment patterns
+
+Those future refinements must remain compatible with this ADR's central principle: simple, OTP-native, bounded, and operationally accessible resilience.
+
+---
+
+# 17. Rationale
+
+The core design tension in an agent runtime's failure model is between recovery
+ambition and operational simplicity. Distributed systems literature offers many
+heavy patterns — globally coordinated circuit breakers, service meshes, offline
+execution modes, saga orchestration — that are technically sophisticated but
+operationally demanding. LemmingsOS is explicitly designed for small teams,
+self-hosted VPS deployments, and operators who are not running a site reliability
+engineering function. Importing heavy resilience infrastructure for that context
+would make the system harder to operate without making it meaningfully more
+reliable for its intended scale.
+
+OTP is the right foundation because Elixir supervision trees already implement
+the containment model the architecture needs. A Lemming crash is contained by its
+supervisor. A Department overload does not propagate upward to the City because
+OTP restart intensity limits and process isolation provide the boundary. The
+framework's failure model aligns directly with the runtime hierarchy; there is no
+need to recreate it with application-level coordination layers.
+
+Bounded retries with exponential backoff are the correct default because transient
+failures — rate limits, short provider outages, brief network interruptions — are
+the common case in autonomous agent workloads. But unbounded retries are the
+common path to retry storms and resource exhaustion in the same context. The
+distinction between retryable and non-retryable failures must be made explicit at
+the classification level, not left to individual subsystems to discover
+inconsistently.
+
+Honesty about hard dependencies is a deliberate choice. Defining an offline
+execution mode for PostgreSQL loss would require shadow persistence, reconciliation
+semantics, and the kind of split-brain complexity that is disproportionate to both
+v1 scope and the intended deployment target. A system that fails visibly and
+honestly when its required dependency is unavailable is easier to operate and
+debug than one that appears to continue while silently accumulating divergent
+state. The architecture prefers explicit degraded-state signals over hidden partial
+operation.
+
+Local circuit breakers rather than globally coordinated ones follows the same
+principle. A breaker that opens for a failing tool on a single City node is
+sufficient to prevent retry storms locally. A globally synchronized breaker adds
+coordination overhead and a new failure mode (the coordination channel itself) for
+a benefit that does not materialize at the intended deployment scale.

--- a/docs/adr/0024-observability-and-monitoring-model.md
+++ b/docs/adr/0024-observability-and-monitoring-model.md
@@ -1,0 +1,333 @@
+# ADR-0024 — Observability and Monitoring Model
+
+- Status: Accepted
+- Date: 2026-03-14
+- Decision Makers: Maintainer(s)
+
+---
+
+# 1. Context
+
+LemmingsOS operates as a runtime for long‑running autonomous agents organized in a hierarchical topology:
+
+World → City → Department → Lemming
+
+Previous ADRs define multiple runtime subsystems that generate operational signals:
+
+- ADR‑0004 — Lemming Execution Model
+- ADR‑0015 — Runtime Cost Governance
+- ADR‑0018 — Audit Event Model
+- ADR‑0023 — Error Handling and Degradation Model
+
+ADR‑0018 introduces an **append‑only audit event system** that records significant runtime actions. However, audit events alone are not sufficient for operators to determine the **current operational state of the runtime**.
+
+Operators must be able to answer practical operational questions such as:
+
+- Is the runtime currently running?
+- Which City nodes are healthy?
+- Are Lemmings executing tasks normally?
+- Are tool executions failing?
+- Are model calls succeeding?
+- Are queues backing up or stalled?
+
+Because LemmingsOS targets **self‑hosted deployments for small teams**, the observability model must avoid operational complexity typically associated with enterprise monitoring stacks.
+
+The system must remain observable in environments such as:
+
+- a single VPS
+- a local workstation
+- small on‑premise servers
+
+Therefore the observability model must prioritize:
+
+- simplicity
+- low operational overhead
+- minimal infrastructure dependencies
+
+---
+
+# 2. Decision Drivers
+
+Several constraints shape the observability approach.
+
+1. **Operators must understand runtime health** — If agents execute for long periods, operators need clear signals that the runtime remains healthy.
+
+2. **Distributed nodes require visibility** — Multiple City nodes may exist in a single World. Operators must quickly determine which nodes are reachable and operational.
+
+3. **Failures must be diagnosable** — Runtime failures, tool crashes, or model errors must produce sufficient logs and signals for investigation.
+
+4. **Stuck systems must be detectable** — Long‑running tasks or queue backlogs must be visible so operators can intervene.
+
+5. **Self‑hosted constraint** — Observability must not require large external systems such as SaaS monitoring platforms or distributed tracing clusters.
+
+6. **Cost sensitivity** — The observability model must remain inexpensive and compatible with minimal infrastructure.
+
+---
+
+# 3. Considered Options
+
+## Option A — Full distributed observability stack
+
+Adopt a full enterprise monitoring stack including distributed tracing, metrics aggregation, and centralized log ingestion.
+
+Examples:
+
+- OpenTelemetry tracing pipelines
+- distributed trace collectors
+- centralized logging clusters
+
+**Pros**
+
+- deep visibility across distributed systems
+- advanced diagnostics
+
+**Cons**
+
+- operational complexity
+- high infrastructure requirements
+- unsuitable for small self‑hosted deployments
+
+Rejected. This model conflicts with the goal of simple self‑hosted installations.
+
+---
+
+## Option B — Logs only
+
+Expose runtime state purely through application logs.
+
+**Pros**
+
+- extremely simple
+- no infrastructure dependencies
+
+**Cons**
+
+- difficult to determine real‑time system health
+- operators must manually interpret log streams
+- no standardized liveness signal
+
+Rejected. Logs alone are insufficient to quickly determine runtime health.
+
+---
+
+## Option C — Layered observability model (chosen)
+
+Adopt a **three‑layer observability model** combining:
+
+- health checks
+- structured event logging
+- optional metrics
+
+Each layer provides a different class of operational insight while keeping the system simple to operate.
+
+Chosen. This approach balances operational visibility with minimal infrastructure requirements.
+
+---
+
+# 4. Decision
+
+LemmingsOS adopts a **three‑layer observability architecture**.
+
+```
+1. Health checks
+2. Structured event logging
+3. Optional metrics
+```
+
+The runtime prioritizes **logs and health endpoints** as the primary operational signals.
+
+Metrics export and external monitoring integrations are **optional extensions**, not mandatory infrastructure.
+
+This ensures that a minimal installation remains observable without requiring external monitoring systems.
+
+---
+
+# 5. Health Checks
+
+Every City runtime exposes a **health endpoint**.
+
+Example endpoint:
+
+```
+/health
+```
+
+The endpoint returns basic runtime status information.
+
+Example response:
+
+```json
+{
+  "status": "ok",
+  "node": "city_a@host",
+  "database": "connected",
+  "runtime": "healthy"
+}
+```
+
+Health checks provide a **fast liveness signal** that operators and orchestration tools can use to determine whether the runtime is operational.
+
+---
+
+# 6. Node Health Model
+
+Each City node exposes a small set of runtime health indicators.
+
+Typical values include:
+
+- node name
+- uptime
+- number of active Lemmings
+- number of active tool executions
+- queue depth
+
+These values may be retrieved via the administrative API or a runtime dashboard.
+
+The goal is not to provide deep system introspection but to expose **clear operational signals** for operators.
+
+---
+
+# 7. Event Logging
+
+The primary observability mechanism in LemmingsOS is **structured event logging**.
+
+All important runtime actions emit events defined by **ADR‑0018 (Audit Event Model)**.
+
+Event type names must match the canonical catalog in ADR-0018 exactly. Examples
+of catalog-compliant event types relevant to observability:
+
+- `lemming.started`
+- `lemming.failed`
+- `tool.invocation_requested`
+- `tool.invocation_denied`
+- `tool.invocation_failed`
+- `model.request_started`
+- `model.request_failed`
+- `model.usage`
+- `config.updated`
+
+Example structured log event:
+
+```json
+{
+  "event": "model.request_failed",
+  "model": "qwen3",
+  "lemming_id": "abc123",
+  "error": "timeout",
+  "attempt": 3
+}
+```
+
+Structured logs allow operators to reconstruct runtime behavior and diagnose failures.
+
+---
+
+# 8. Error Reporting
+
+The runtime may optionally forward errors to external reporting systems.
+
+Examples include:
+
+- Sentry
+- OpenTelemetry exporters
+- centralized log collectors
+
+These integrations are **optional** and disabled by default.
+
+The runtime must remain fully functional without them.
+
+---
+
+# 9. Metrics (Optional)
+
+LemmingsOS may expose runtime metrics using **Elixir Telemetry**.
+
+Possible metrics include:
+
+- active Lemming count
+- tool execution latency
+- model request latency
+- queue depth
+- failure rates
+
+Operators may export these metrics to systems such as:
+
+- Prometheus
+- Grafana
+
+Metrics are optional and not required for normal operation.
+
+---
+
+# 10. Observability Architecture
+
+Conceptual signal flow:
+
+```
+Runtime Event
+     │
+     ▼
+Structured Log
+     │
+     ├─ Operator log inspection
+     ├─ Optional metrics export
+     └─ Optional error reporting
+```
+
+Health endpoints provide the **runtime liveness signal**.
+
+Logs provide **diagnostic visibility**.
+
+Metrics provide **optional operational insight**.
+
+---
+
+# 11. Operational Characteristics
+
+The observability design prioritizes:
+
+- simplicity
+- low operational overhead
+- compatibility with single‑node installations
+- compatibility with distributed deployments
+
+A minimal deployment should remain fully observable using only:
+
+- application logs
+- health endpoints
+
+This keeps operational requirements aligned with the project's self‑hosted philosophy.
+
+---
+
+# 12. Implementation Notes
+
+Possible runtime modules include:
+
+```
+LemmingsOs.Observability
+LemmingsOs.Health.Endpoint
+LemmingsOs.Event.Logger
+```
+
+Telemetry hooks may emit metrics and integrate with Phoenix LiveDashboard when available.
+
+---
+
+# 13. Consequences
+
+## Positive
+
+- Operators gain immediate visibility into runtime health.
+- Failures can be reconstructed from structured event logs.
+- Observability remains compatible with very small deployments.
+
+## Negative / Trade‑offs
+
+- Without external monitoring systems, long‑term metrics analysis may be limited.
+- Operators relying solely on logs must interpret system behavior manually.
+
+## Mitigations
+
+Optional telemetry exporters and log collectors can be integrated when deeper observability is required without modifying the core runtime architecture.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ must be captured here as an ADR.
 
 ## Suggested naming
 
-Use `NNNN-short-title.md`, for example: `0004-lemming-identity-model.md`.
+Use `NNNN-short-title.md`, for example: `0004-lemming-execution-model.md`.
 
 ## ADR format
 


### PR DESCRIPTION
## Summary

Architecture review pass over the initial ADR set (ADR-0004 through ADR-0024).
No implementation code changed   this PR exclusively refines the decision records
before development begins against them.

The most significant change is a full rewrite of ADR-0020 to introduce
**deny-dominant merge semantics**: the configuration resolver now defines that
`tools.deny` and `cost.budget` keys propagate downward as hard constraints  
a child scope can only tighten them, never loosen them. ADR-0012 and ADR-0015
both depended on this guarantee being defined; it was not.

Other changes resolve cross-ADR contradictions, fill structural gaps, and bring
weaker ADRs up to the quality bar set by the rest of the set.

## Scope

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Linked Issues

Related #

## Technical Notes

- **Key implementation details:**
- ADR-0020 defines `deny_dominant_merge/2` as a two-step resolver: first a
    standard `deep_merge`, then a post-pass that unions all `tools.deny` lists
    and takes the minimum `cost.budget.cap_usd` across all ancestor scopes.
- ADR-0021 adds `world_id` to `lemming_types` (FK + index + unique composite
    slug constraint). Any future migration creating `lemming_types` must include
    this column.
- ADR-0016 introduces a trust gradient for tool isolation: trusted first-party
    tools may run in-process; third-party tools require an external OS process.
    The trust tier is an explicit field in the Tool Registry row.
- ADR-0022 documents a mandatory persistent volume for DETS snapshots
    (`lemmings_dets_data   /app/data/dets`). The reference docker-compose must
    include this volume or idle Lemming rehydration silently breaks on container
    restart.

- **Data model / migration impact:**
- `lemming_types` table gains a non-nullable `world_id UUID` column with FK
    to `worlds.id`. Slug uniqueness constraint changes from global to
    `(world_id, slug)`.
- `tool_policies` index strategy changes: the four per-column indexes
    (`world_id`, `city_id`, `department_id`, `lemming_type_id`) are replaced by
    `(scope_type, scope_id)` composite index to match the polymorphic schema.

- **Config/env var changes:**
- `DETS_DATA_DIR` added as a documented env var for the DETS snapshot path
    (defaults to `/app/data/dets`).
- `RELEASE_COOKIE` should be treated as a secret for any non-localhost
    Erlang cluster (documented in ADR-0022 Consequences).

- **Security/privacy considerations:**
- ADR-0022 now explicitly requires Erlang distribution TLS (`:inet_tls_dist`)
    for any production deployment outside a trusted private network. Cookie
    management is called out as a deployment requirement.
- ADR-0016 trust gradient ensures third-party tools cannot opt into in-process
    execution by self-declaring   it is a platform-side registry classification.

## Validation

- [ ] `mix format`
- [ ] `mix test`
- [ ] `mix precommit`
- [ ] Manual validation completed

### Manual validation notes

Documentation-only PR. Validation is a review of the ADR set for internal
consistency, correct cross-references, and architectural soundness. No runtime
behavior changed.

Reviewers should pay particular attention to:
1. ADR-0020 deny-dominant pseudocode   does the two-step merge algorithm match
    the intent of ADR-0012 and ADR-0015?
2. ADR-0021 `lemming_types(world_id)`   does this scoping decision hold given
    the World isolation model in ADR-0003?
3. ADR-0022 persistent volume requirement   is the DETS path default acceptable
    or should it be configurable from day one?

## Screenshots / Recordings (if UI changes)

N/A

## Rollout / Rollback

- **Rollout notes:** Documentation only. No deploy required.
- **Rollback notes:** Revert the PR. No data or config to undo.

## Checklist

- [ ] Tests added/updated for changed behavior
- [x] Docs updated (README/docs/ADR/runbook) when needed
- [x] No secrets or sensitive data committed
- [x] Backward compatibility considered

