### PR TITLE
Refactor context architecture for consistency

### DIFF
--- a/lib/lemmings_os/cities.ex
+++ b/lib/lemmings_os/cities.ex
@@ -16,79 +16,25 @@ defmodule LemmingsOs.Cities do
   Returns persisted cities for the given World scope.
 
   Accepts an optional keyword list for filtering and explicit preloads.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> LemmingsOs.Factory.insert(:city, world: world, status: "active")
-      iex> cities = LemmingsOs.Cities.list_cities(world)
-      iex> length(cities)
-      1
   """
-  @spec list_cities(World.t() | Ecto.UUID.t(), keyword()) :: [City.t()]
-  def list_cities(world_or_world_id, opts \\ [])
-
-  def list_cities(%World{} = world, opts) do
-    world
-    |> list_cities_query(opts)
-    |> Repo.all()
-  end
-
-  def list_cities(world_id, opts) when is_binary(world_id) do
-    world_id
-    |> list_cities_query(opts)
-    |> Repo.all()
-  end
-
-  @doc """
-  Returns the base City query for the given World scope.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> LemmingsOs.Cities.list_cities_query(world) |> Ecto.Query.exclude(:preload) |> Map.has_key?(:from)
-      true
-  """
-  @spec list_cities_query(World.t() | Ecto.UUID.t(), keyword()) :: Ecto.Query.t()
-  def list_cities_query(%World{id: world_id}, opts), do: list_cities_query(world_id, opts)
-
-  def list_cities_query(world_id, opts) when is_binary(world_id) do
+  @spec list_cities(World.t(), keyword()) :: [City.t()]
+  def list_cities(%World{id: world_id}, opts \\ []) do
     City
     |> where([city], city.world_id == ^world_id)
     |> filter_query(opts)
     |> order_by([city], asc: city.inserted_at, asc: city.id)
+    |> Repo.all()
   end
 
   @doc """
-  Returns the City for the given World-scoped persisted ID.
-
-  Raises `Ecto.NoResultsError` if no City exists in that World.
+  Returns the City for the given World-scoped persisted ID, or `nil`.
   """
-  @spec get_city!(World.t(), Ecto.UUID.t()) :: City.t()
-  def get_city!(%World{} = world, id) do
-    case fetch_city(world, id) do
-      {:ok, city} -> city
-      {:error, :not_found} -> raise Ecto.NoResultsError, queryable: City
-    end
-  end
-
-  @doc """
-  Fetches a City by World-scoped persisted ID.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> {:ok, fetched_city} = LemmingsOs.Cities.fetch_city(world, city.id)
-      iex> fetched_city.id == city.id
-      true
-  """
-  @spec fetch_city(World.t(), Ecto.UUID.t()) :: {:ok, City.t()} | {:error, :not_found}
-  def fetch_city(%World{id: world_id}, id) when is_binary(id) do
+  @spec get_city(World.t(), Ecto.UUID.t(), keyword()) :: City.t() | nil
+  def get_city(%World{id: world_id}, id, opts \\ []) when is_binary(id) do
     City
     |> where([city], city.world_id == ^world_id and city.id == ^id)
+    |> filter_query(opts)
     |> Repo.one()
-    |> fetch_city_result()
   end
 
   @doc """
@@ -101,13 +47,6 @@ defmodule LemmingsOs.Cities do
 
   @doc """
   Creates a City scoped to the given World.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> {:ok, city} = LemmingsOs.Cities.create_city(world, %{slug: "ops", name: "Ops", node_name: "ops@localhost", status: "active"})
-      iex> city.world_id == world.id
-      true
   """
   @spec create_city(World.t(), map()) :: {:ok, City.t()} | {:error, Ecto.Changeset.t()}
   def create_city(%World{id: world_id}, attrs) when is_map(attrs) do
@@ -135,8 +74,7 @@ defmodule LemmingsOs.Cities do
   @doc """
   Creates or updates the runtime-owned City row for the given World.
 
-  Lookup prefers persisted `id`, then `node_name`, then `slug`. This keeps the
-  runtime presence contract narrow without reshaping the normal CRUD API.
+  Lookup prefers persisted `id`, then `node_name`, then `slug`.
   """
   @spec upsert_runtime_city(World.t(), map()) :: {:ok, City.t()} | {:error, Ecto.Changeset.t()}
   def upsert_runtime_city(%World{} = world, attrs) when is_map(attrs) do
@@ -148,15 +86,6 @@ defmodule LemmingsOs.Cities do
 
   @doc """
   Persists the latest heartbeat timestamp for a City.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> seen_at = DateTime.utc_now() |> DateTime.truncate(:second)
-      iex> {:ok, updated_city} = LemmingsOs.Cities.heartbeat_city(city, seen_at)
-      iex> updated_city.last_seen_at == seen_at
-      true
   """
   @spec heartbeat_city(City.t(), DateTime.t()) :: {:ok, City.t()} | {:error, Ecto.Changeset.t()}
   def heartbeat_city(%City{} = city, seen_at \\ DateTime.utc_now()) do
@@ -176,9 +105,6 @@ defmodule LemmingsOs.Cities do
     |> order_by([city], asc: city.last_seen_at, asc: city.id)
     |> Repo.all()
   end
-
-  defp fetch_city_result(%City{} = city), do: {:ok, city}
-  defp fetch_city_result(nil), do: {:error, :not_found}
 
   defp runtime_lookup_target(%World{id: world_id}, attrs) do
     lookup_runtime_city_by_id(world_id, attr_value(attrs, :id)) ||

--- a/lib/lemmings_os/cities/runtime.ex
+++ b/lib/lemmings_os/cities/runtime.ex
@@ -63,12 +63,12 @@ defmodule LemmingsOs.Cities.Runtime do
           {:ok, City.t()} | {:error, :default_world_not_found | Changeset.t()}
   def sync_runtime_city(opts \\ []) do
     case Worlds.get_default_world() do
-      {:ok, %World{} = world} ->
+      %World{} = world ->
         world
         |> Cities.upsert_runtime_city(runtime_city_attrs(opts))
         |> log_sync_result(world)
 
-      {:error, :not_found} ->
+      nil ->
         {:error, :default_world_not_found}
     end
   end
@@ -104,13 +104,13 @@ defmodule LemmingsOs.Cities.Runtime do
     runtime_city_attrs = runtime_city_attrs(opts)
 
     case Worlds.get_default_world() do
-      {:ok, %World{} = world} ->
+      %World{} = world ->
         case Cities.list_cities(world, node_name: runtime_city_attrs.node_name) do
           [%City{} = city] -> {:ok, city}
           [] -> {:error, :runtime_city_not_found}
         end
 
-      {:error, :not_found} ->
+      nil ->
         {:error, :default_world_not_found}
     end
   end

--- a/lib/lemmings_os/departments.ex
+++ b/lib/lemmings_os/departments.ex
@@ -2,8 +2,8 @@ defmodule LemmingsOs.Departments do
   @moduledoc """
   Department domain boundary.
 
-  This context owns persisted Department retrieval, explicit World/City-scoped
-  collection CRUD APIs, and lifecycle transitions.
+  This context owns persisted Department retrieval, scope-based list APIs, and
+  lifecycle transitions.
   """
 
   import Ecto.Query, warn: false
@@ -15,160 +15,59 @@ defmodule LemmingsOs.Departments do
   alias LemmingsOs.Worlds.World
 
   @doc """
-  Returns persisted departments for the given World and City scope.
+  Returns persisted departments scoped by World or City.
 
   Accepts an optional keyword list for filtering and explicit preloads.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> LemmingsOs.Factory.insert(:department, world: world, city: city, status: "active")
-      iex> [%LemmingsOs.Departments.Department{}] = LemmingsOs.Departments.list_departments(world, city)
   """
-  @spec list_departments(World.t() | Ecto.UUID.t(), City.t() | Ecto.UUID.t(), keyword()) :: [
-          Department.t()
-        ]
-  def list_departments(world_or_world_id, city_or_city_id, opts \\ []) do
-    world_or_world_id
-    |> departments_query(city_or_city_id, opts)
+  @spec list_departments(World.t() | City.t(), keyword()) :: [Department.t()]
+  def list_departments(scope, opts \\ [])
+
+  def list_departments(%World{id: world_id}, opts) do
+    Department
+    |> filter_query([world_id: world_id | opts])
+    |> order_by([department], asc: department.inserted_at, asc: department.id)
+    |> Repo.all()
+  end
+
+  def list_departments(%City{id: city_id}, opts) do
+    Department
+    |> filter_query([city_id: city_id | opts])
+    |> order_by([department], asc: department.inserted_at, asc: department.id)
     |> Repo.all()
   end
 
   @doc """
-  Fetches a Department by persisted ID.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
-      iex> {:ok, %LemmingsOs.Departments.Department{id: id}} =
-      ...>   LemmingsOs.Departments.fetch_department(department.id)
-      iex> id
-      department.id
+  Returns the Department for the given persisted ID, or `nil`.
   """
-  @spec fetch_department(Ecto.UUID.t(), keyword()) ::
-          {:ok, Department.t()} | {:error, :not_found}
-  def fetch_department(id, opts \\ [])
-
-  def fetch_department(id, opts) when is_binary(id) and is_list(opts) do
+  @spec get_department(Ecto.UUID.t(), keyword()) :: Department.t() | nil
+  def get_department(id, opts \\ []) when is_binary(id) do
     Department
-    |> where([department], department.id == ^id)
-    |> filter_query(opts)
+    |> filter_query([id: id | opts])
     |> Repo.one()
-    |> fetch_department_result()
   end
 
   @doc """
-  Returns the Department for the given persisted ID.
-
-  Raises `Ecto.NoResultsError` if no Department exists for the given ID.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
-      iex> %LemmingsOs.Departments.Department{id: id} =
-      ...>   LemmingsOs.Departments.get_department!(department.id)
-      iex> id
-      department.id
+  Returns the Department for the given City-scoped slug, or `nil`.
   """
-  @spec get_department!(Ecto.UUID.t(), keyword()) :: Department.t()
-  def get_department!(id, opts \\ []) do
-    case fetch_department(id, opts) do
-      {:ok, department} -> department
-      {:error, :not_found} -> raise Ecto.NoResultsError, queryable: Department
-    end
-  end
-
-  @doc """
-  Fetches a Department by City-scoped slug.
-
-  ## Examples
-
-      iex> city = LemmingsOs.Factory.insert(:city)
-      iex> department = LemmingsOs.Factory.insert(:department, world: city.world, city: city, slug: "support")
-      iex> {:ok, %LemmingsOs.Departments.Department{slug: "support", id: id}} =
-      ...>   LemmingsOs.Departments.fetch_department_by_slug(city, "support")
-      iex> id
-      department.id
-  """
-  @spec fetch_department_by_slug(City.t() | Ecto.UUID.t(), String.t()) ::
-          {:ok, Department.t()} | {:error, :not_found}
-  def fetch_department_by_slug(city_or_city_id, slug)
-
-  def fetch_department_by_slug(%City{id: city_id}, slug),
-    do: fetch_department_by_slug(city_id, slug)
-
-  def fetch_department_by_slug(city_id, slug) when is_binary(city_id) and is_binary(slug) do
+  @spec get_department_by_slug(City.t(), String.t(), keyword()) :: Department.t() | nil
+  def get_department_by_slug(%City{id: city_id}, slug, opts \\ []) when is_binary(slug) do
     Department
-    |> where([department], department.city_id == ^city_id and department.slug == ^slug)
+    |> filter_query([city_id: city_id, slug: slug | opts])
     |> Repo.one()
-    |> fetch_department_result()
   end
 
   @doc """
-  Returns the Department for the given City-scoped slug.
-
-  Raises `Ecto.NoResultsError` if no Department exists in that City scope.
-
-  ## Examples
-
-      iex> city = LemmingsOs.Factory.insert(:city)
-      iex> department = LemmingsOs.Factory.insert(:department, world: city.world, city: city, slug: "support")
-      iex> %LemmingsOs.Departments.Department{slug: "support", id: id} =
-      ...>   LemmingsOs.Departments.get_department_by_slug!(city, "support")
-      iex> id
-      department.id
+  Creates a Department scoped to the given City.
   """
-  @spec get_department_by_slug!(City.t() | Ecto.UUID.t(), String.t()) :: Department.t()
-  def get_department_by_slug!(city_or_city_id, slug) do
-    case fetch_department_by_slug(city_or_city_id, slug) do
-      {:ok, department} -> department
-      {:error, :not_found} -> raise Ecto.NoResultsError, queryable: Department
-    end
-  end
-
-  @doc """
-  Creates a Department scoped to the given World and City.
-
-  Returns `{:error, :city_not_in_world}` when the supplied City does not belong
-  to the supplied World scope.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> {:ok, %LemmingsOs.Departments.Department{slug: "support", world_id: world_id, city_id: city_id}} =
-      ...>   LemmingsOs.Departments.create_department(world, city, %{slug: "support", name: "Support", status: "active"})
-      iex> {world_id, city_id}
-      {world.id, city.id}
-  """
-  @spec create_department(World.t() | Ecto.UUID.t(), City.t() | Ecto.UUID.t(), map()) ::
-          {:ok, Department.t()} | {:error, Ecto.Changeset.t() | :city_not_in_world}
-  def create_department(world_or_world_id, city_or_city_id, attrs) when is_map(attrs) do
-    with {:ok, world_id} <- normalize_world_id(world_or_world_id),
-         {:ok, %City{id: city_id}} <- fetch_city_in_world(world_id, city_or_city_id) do
-      %Department{world_id: world_id, city_id: city_id}
-      |> Department.changeset(attrs)
-      |> Repo.insert()
-    end
+  @spec create_department(City.t(), map()) :: {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
+  def create_department(%City{id: city_id, world_id: world_id}, attrs) when is_map(attrs) do
+    %Department{world_id: world_id, city_id: city_id}
+    |> Department.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
   Updates a persisted Department through the operator-facing CRUD contract.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, name: "Before")
-      iex> {:ok, %LemmingsOs.Departments.Department{name: name}} =
-      ...>   LemmingsOs.Departments.update_department(department, %{name: "After"})
-      iex> name
-      "After"
   """
   @spec update_department(Department.t(), map()) ::
           {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
@@ -180,27 +79,12 @@ defmodule LemmingsOs.Departments do
 
   @doc """
   Returns aggregate persisted Department counts for a World.
-
-  The summary is intentionally narrow and query-efficient for operator-facing
-  topology cards.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> LemmingsOs.Factory.insert(:department, world: world, city: city, status: "active")
-      iex> summary = LemmingsOs.Departments.topology_summary(world)
-      iex> summary.department_count
-      1
   """
-  @spec topology_summary(World.t() | Ecto.UUID.t()) :: %{
+  @spec topology_summary(World.t()) :: %{
           department_count: non_neg_integer(),
           active_department_count: non_neg_integer()
         }
-  def topology_summary(%World{id: world_id}) when is_binary(world_id),
-    do: topology_summary(world_id)
-
-  def topology_summary(world_id) when is_binary(world_id) do
+  def topology_summary(%World{id: world_id}) do
     Department
     |> where([department], department.world_id == ^world_id)
     |> select([department], %{
@@ -227,16 +111,6 @@ defmodule LemmingsOs.Departments do
 
   @doc """
   Transitions a Department to a new administrative status.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, status: "disabled")
-      iex> {:ok, %LemmingsOs.Departments.Department{status: status}} =
-      ...>   LemmingsOs.Departments.set_department_status(department, "active")
-      iex> status
-      "active"
   """
   @spec set_department_status(Department.t(), String.t()) ::
           {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
@@ -245,72 +119,7 @@ defmodule LemmingsOs.Departments do
   end
 
   @doc """
-  Transitions a Department to `active`.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, status: "disabled")
-      iex> {:ok, %LemmingsOs.Departments.Department{status: status}} =
-      ...>   LemmingsOs.Departments.activate_department(department)
-      iex> status
-      "active"
-  """
-  @spec activate_department(Department.t()) ::
-          {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
-  def activate_department(%Department{} = department),
-    do: set_department_status(department, "active")
-
-  @doc """
-  Transitions a Department to `draining`.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, status: "active")
-      iex> {:ok, %LemmingsOs.Departments.Department{status: status}} =
-      ...>   LemmingsOs.Departments.drain_department(department)
-      iex> status
-      "draining"
-  """
-  @spec drain_department(Department.t()) :: {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
-  def drain_department(%Department{} = department),
-    do: set_department_status(department, "draining")
-
-  @doc """
-  Transitions a Department to `disabled`.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, status: "draining")
-      iex> {:ok, %LemmingsOs.Departments.Department{status: status}} =
-      ...>   LemmingsOs.Departments.disable_department(department)
-      iex> status
-      "disabled"
-  """
-  @spec disable_department(Department.t()) :: {:ok, Department.t()} | {:error, Ecto.Changeset.t()}
-  def disable_department(%Department{} = department),
-    do: set_department_status(department, "disabled")
-
-  @doc """
   Deletes a persisted Department record when safe removal can be proven.
-
-  This implementation is intentionally conservative. In the current project
-  slice there is no runtime-backed signal that can prove the Department has no
-  active work, so hard deletion remains denied even after the Department is
-  administratively disabled.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> city = LemmingsOs.Factory.insert(:city, world: world)
-      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city, status: "disabled")
-      iex> {:error, %LemmingsOs.Departments.DeleteDeniedError{reason: :safety_indeterminate}} =
-      ...>   LemmingsOs.Departments.delete_department(department)
   """
   @spec delete_department(Department.t()) ::
           {:ok, Department.t()} | {:error, DeleteDeniedError.t()}
@@ -320,46 +129,6 @@ defmodule LemmingsOs.Departments do
       Repo.delete(department)
     end
   end
-
-  defp departments_query(%World{id: world_id}, %City{id: city_id}, opts),
-    do: departments_query(world_id, city_id, opts)
-
-  defp departments_query(%World{id: world_id}, city_id, opts) when is_binary(city_id),
-    do: departments_query(world_id, city_id, opts)
-
-  defp departments_query(world_id, %City{id: city_id}, opts) when is_binary(world_id),
-    do: departments_query(world_id, city_id, opts)
-
-  defp departments_query(world_id, city_id, opts)
-       when is_binary(world_id) and is_binary(city_id) do
-    Department
-    |> where([department], department.world_id == ^world_id and department.city_id == ^city_id)
-    |> filter_query(opts)
-    |> order_by([department], asc: department.inserted_at, asc: department.id)
-  end
-
-  defp fetch_department_result(%Department{} = department), do: {:ok, department}
-  defp fetch_department_result(nil), do: {:error, :not_found}
-
-  defp normalize_world_id(%World{id: world_id}) when is_binary(world_id), do: {:ok, world_id}
-  defp normalize_world_id(world_id) when is_binary(world_id), do: {:ok, world_id}
-
-  defp fetch_city_in_world(world_id, %City{id: city_id, world_id: world_id} = city)
-       when is_binary(city_id),
-       do: {:ok, city}
-
-  defp fetch_city_in_world(_world_id, %City{}), do: {:error, :city_not_in_world}
-
-  defp fetch_city_in_world(world_id, city_id)
-       when is_binary(world_id) and is_binary(city_id) do
-    City
-    |> where([city], city.world_id == ^world_id and city.id == ^city_id)
-    |> Repo.one()
-    |> fetch_scoped_city_result()
-  end
-
-  defp fetch_scoped_city_result(%City{} = city), do: {:ok, city}
-  defp fetch_scoped_city_result(nil), do: {:error, :city_not_in_world}
 
   defp normalize_topology_summary(nil), do: %{department_count: 0, active_department_count: 0}
 
@@ -379,6 +148,15 @@ defmodule LemmingsOs.Departments do
   defp ensure_department_safe_to_delete(%Department{id: id}) do
     {:error, %DeleteDeniedError{department_id: id, reason: :safety_indeterminate}}
   end
+
+  defp filter_query(query, [{:id, id} | rest]),
+    do: filter_query(from(department in query, where: department.id == ^id), rest)
+
+  defp filter_query(query, [{:world_id, world_id} | rest]),
+    do: filter_query(from(department in query, where: department.world_id == ^world_id), rest)
+
+  defp filter_query(query, [{:city_id, city_id} | rest]),
+    do: filter_query(from(department in query, where: department.city_id == ^city_id), rest)
 
   defp filter_query(query, [{:status, status} | rest]),
     do: filter_query(from(department in query, where: department.status == ^status), rest)

--- a/lib/lemmings_os/departments.ex
+++ b/lib/lemmings_os/departments.ex
@@ -24,14 +24,14 @@ defmodule LemmingsOs.Departments do
 
   def list_departments(%World{id: world_id}, opts) do
     Department
-    |> filter_query([world_id: world_id | opts])
+    |> filter_query(Keyword.merge([world_id: world_id], opts))
     |> order_by([department], asc: department.inserted_at, asc: department.id)
     |> Repo.all()
   end
 
   def list_departments(%City{id: city_id}, opts) do
     Department
-    |> filter_query([city_id: city_id | opts])
+    |> filter_query(Keyword.merge([city_id: city_id], opts))
     |> order_by([department], asc: department.inserted_at, asc: department.id)
     |> Repo.all()
   end
@@ -42,7 +42,7 @@ defmodule LemmingsOs.Departments do
   @spec get_department(Ecto.UUID.t(), keyword()) :: Department.t() | nil
   def get_department(id, opts \\ []) when is_binary(id) do
     Department
-    |> filter_query([id: id | opts])
+    |> filter_query(Keyword.merge([id: id], opts))
     |> Repo.one()
   end
 
@@ -52,7 +52,7 @@ defmodule LemmingsOs.Departments do
   @spec get_department_by_slug(City.t(), String.t(), keyword()) :: Department.t() | nil
   def get_department_by_slug(%City{id: city_id}, slug, opts \\ []) when is_binary(slug) do
     Department
-    |> filter_query([city_id: city_id, slug: slug | opts])
+    |> filter_query(Keyword.merge([city_id: city_id, slug: slug], opts))
     |> Repo.one()
   end
 

--- a/lib/lemmings_os/worlds.ex
+++ b/lib/lemmings_os/worlds.ex
@@ -16,22 +16,6 @@ defmodule LemmingsOs.Worlds do
   Returns all persisted worlds.
 
   Accepts an optional keyword list for filtering.
-
-  ## Examples
-
-      iex> LemmingsOs.Repo.delete_all(LemmingsOs.Worlds.World)
-      iex> LemmingsOs.Factory.insert(:world, status: "ok")
-      iex> LemmingsOs.Factory.insert(:world, status: "degraded")
-      iex> worlds = LemmingsOs.Worlds.list_worlds()
-      iex> length(worlds)
-      2
-
-      iex> LemmingsOs.Repo.delete_all(LemmingsOs.Worlds.World)
-      iex> LemmingsOs.Factory.insert(:world, status: "ok")
-      iex> LemmingsOs.Factory.insert(:world, status: "degraded")
-      iex> worlds = LemmingsOs.Worlds.list_worlds(status: "ok")
-      iex> Enum.all?(worlds, &(&1.status == "ok"))
-      true
   """
   @spec list_worlds(keyword()) :: [World.t()]
   def list_worlds(opts \\ []) do
@@ -42,100 +26,47 @@ defmodule LemmingsOs.Worlds do
   end
 
   @doc """
-  Returns the world for the given persisted ID. Raises `Ecto.NoResultsError` if not found.
+  Returns the world for the given persisted ID, or `nil` when missing.
 
-  Results are served from the `Worlds.Cache`. The cache is invalidated automatically
-  on upsert, so callers may receive a cached value until the next write or explicit
-  `Worlds.Cache.invalidate_world/1` call.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> fetched_world = LemmingsOs.Worlds.get_world!(world.id)
-      iex> fetched_world.id == world.id
-      true
+  Results are served from `Worlds.Cache`. The cache is invalidated automatically
+  on upsert, so callers may receive a cached value until the next write or
+  explicit `Worlds.Cache.invalidate_world/1` call.
   """
-  @spec get_world!(Ecto.UUID.t()) :: World.t()
-  def get_world!(id) do
-    case fetch_world(id) do
+  @spec get_world(Ecto.UUID.t()) :: World.t() | nil
+  def get_world(id) do
+    case Cache.fetch_world(id, fn -> Repo.get(World, id) |> normalize_world_result() end) do
       {:ok, world} -> world
-      {:error, :not_found} -> raise Ecto.NoResultsError, queryable: World
+      {:error, :not_found} -> nil
     end
   end
 
   @doc """
-  Fetches a world by persisted ID.
+  Returns the default world for the current node, or `nil` when none exists.
 
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> {:ok, fetched_world} = LemmingsOs.Worlds.fetch_world(world.id)
-      iex> fetched_world.slug == world.slug
-      true
-
-      iex> LemmingsOs.Worlds.fetch_world(Ecto.UUID.generate())
-      {:error, :not_found}
-  """
-  @spec fetch_world(Ecto.UUID.t()) :: {:ok, World.t()} | {:error, :not_found}
-  def fetch_world(id) do
-    Cache.fetch_world(id, fn ->
-      fetch_world_result(Repo.get(World, id))
-    end)
-  end
-
-  @doc """
-  Returns the default world for the current node.
-
-  This task keeps the default-world contract minimal by selecting the oldest
+  This keeps the default-world contract minimal by selecting the oldest
   persisted world when one exists.
-
-  ## Examples
-
-      iex> LemmingsOs.Repo.delete_all(LemmingsOs.Worlds.World)
-      iex> LemmingsOs.Worlds.Cache.invalidate_all()
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> {:ok, default_world} = LemmingsOs.Worlds.get_default_world()
-      iex> default_world.id == world.id
-      true
   """
-  @spec get_default_world() :: {:ok, World.t()} | {:error, :not_found}
+  @spec get_default_world() :: World.t() | nil
   def get_default_world do
-    Cache.fetch_default_world(fn ->
-      query =
-        World
-        |> order_by([world], asc: world.inserted_at, asc: world.id)
-        |> limit(1)
+    case Cache.fetch_default_world(fn ->
+           query =
+             World
+             |> order_by([world], asc: world.inserted_at, asc: world.id)
+             |> limit(1)
 
-      query
-      |> Repo.one()
-      |> fetch_world_result()
-    end)
+           query
+           |> Repo.one()
+           |> normalize_world_result()
+         end) do
+      {:ok, world} -> world
+      {:error, :not_found} -> nil
+    end
   end
 
   @doc """
   Creates or updates a world from persisted or bootstrap-facing attributes.
 
   Upsert matching prefers persisted `id`, then `bootstrap_path`, then `slug`.
-  That keeps bootstrap sync idempotent without treating the bootstrap payload
-  as the persisted source of truth.
-
-  ## Examples
-
-      iex> attrs = LemmingsOs.Factory.params_for(:world, name: "Doc World")
-      iex> {:ok, world} = LemmingsOs.Worlds.upsert_world(attrs)
-      iex> {world.name, world.status, world.last_import_status}
-      {"Doc World", "unknown", "unknown"}
-
-      iex> attrs = LemmingsOs.Factory.params_for(:world, name: "Before")
-      iex> {:ok, world} = LemmingsOs.Worlds.upsert_world(attrs)
-      iex> {:ok, updated_world} =
-      ...>   LemmingsOs.Worlds.upsert_world(%{
-      ...>     "slug" => world.slug,
-      ...>     "bootstrap_path" => world.bootstrap_path,
-      ...>     "name" => "After"
-      ...>   })
-      iex> updated_world.id == world.id and updated_world.name == "After"
-      true
   """
   @spec upsert_world(map()) :: {:ok, World.t()} | {:error, Ecto.Changeset.t()}
   def upsert_world(attrs) when is_map(attrs) do
@@ -148,13 +79,6 @@ defmodule LemmingsOs.Worlds do
 
   @doc """
   Creates or updates a world using the bootstrap sync contract.
-
-  ## Examples
-
-      iex> attrs = LemmingsOs.Factory.params_for(:world, name: "Bootstrap World")
-      iex> {:ok, world} = LemmingsOs.Worlds.upsert_bootstrap_world(attrs)
-      iex> world.name
-      "Bootstrap World"
   """
   @spec upsert_bootstrap_world(map()) :: {:ok, World.t()} | {:error, Ecto.Changeset.t()}
   def upsert_bootstrap_world(attrs), do: upsert_world(attrs)
@@ -162,22 +86,7 @@ defmodule LemmingsOs.Worlds do
   @doc """
   Updates an existing world located by the bootstrap lookup chain.
 
-  Unlike `upsert_world/1`, this function never inserts a new record. It is
-  intended for failure-path bootstrap sync where the YAML file is missing or
-  invalid and no slug or name is available to create a valid world row. If no
-  existing world can be found via the lookup chain, `{:error, :not_found}` is
-  returned and no write is attempted.
-
-  ## Examples
-
-      iex> world = LemmingsOs.Factory.insert(:world)
-      iex> attrs = %{slug: world.slug, status: "unavailable", last_import_status: "unavailable"}
-      iex> {:ok, updated} = LemmingsOs.Worlds.update_existing_world(attrs)
-      iex> updated.status
-      "unavailable"
-
-      iex> LemmingsOs.Worlds.update_existing_world(%{slug: "does-not-exist"})
-      {:error, :not_found}
+  Unlike `upsert_world/1`, this function never inserts a new record.
   """
   @spec update_existing_world(map()) ::
           {:ok, World.t()} | {:error, :not_found} | {:error, Ecto.Changeset.t()}
@@ -204,8 +113,8 @@ defmodule LemmingsOs.Worlds do
 
   defp invalidate_cached_reads({:error, _changeset} = error), do: error
 
-  defp fetch_world_result(%World{} = world), do: {:ok, world}
-  defp fetch_world_result(nil), do: {:error, :not_found}
+  defp normalize_world_result(%World{} = world), do: {:ok, world}
+  defp normalize_world_result(nil), do: {:error, :not_found}
 
   defp lookup_world(attrs), do: lookup_world_by_id(attr_value(attrs, :id), attrs)
 

--- a/lib/lemmings_os_web/controllers/health_controller.ex
+++ b/lib/lemmings_os_web/controllers/health_controller.ex
@@ -42,7 +42,7 @@ defmodule LemmingsOsWeb.HealthController do
   defp city_liveness_summary do
     try do
       case Worlds.get_default_world() do
-        {:ok, world} ->
+        %{} = world ->
           cities =
             world
             |> Cities.list_cities()
@@ -57,7 +57,7 @@ defmodule LemmingsOsWeb.HealthController do
 
           {:ok, cities}
 
-        {:error, :not_found} ->
+        nil ->
           {:ok, []}
       end
     rescue

--- a/lib/lemmings_os_web/controllers/health_controller.ex
+++ b/lib/lemmings_os_web/controllers/health_controller.ex
@@ -44,8 +44,7 @@ defmodule LemmingsOsWeb.HealthController do
       case Worlds.get_default_world() do
         %{} = world ->
           cities =
-            world
-            |> Cities.list_cities()
+            Cities.list_cities(world)
             |> Enum.map(fn city ->
               %{
                 node_name: city.node_name,

--- a/lib/lemmings_os_web/live/cities_live.ex
+++ b/lib/lemmings_os_web/live/cities_live.ex
@@ -66,7 +66,7 @@ defmodule LemmingsOsWeb.CitiesLive do
   def handle_event("edit_city", %{"id" => city_id}, socket) do
     with %{snapshot: %{} = snapshot} <- socket.assigns,
          {:ok, world} <- fetch_snapshot_world(snapshot),
-         {:ok, city} <- Cities.fetch_city(world, city_id) do
+         %City{} = city <- Cities.get_city(world, city_id) do
       changeset = City.changeset(city, %{})
       form = to_form(changeset, as: :city)
 
@@ -113,7 +113,7 @@ defmodule LemmingsOsWeb.CitiesLive do
   def handle_event("delete_city", %{"id" => city_id}, socket) do
     with %{snapshot: %{} = snapshot} <- socket.assigns,
          {:ok, world} <- fetch_snapshot_world(snapshot),
-         {:ok, city} <- Cities.fetch_city(world, city_id),
+         %City{} = city <- Cities.get_city(world, city_id),
          {:ok, _city} <- Cities.delete_city(city) do
       socket =
         socket
@@ -156,7 +156,10 @@ defmodule LemmingsOsWeb.CitiesLive do
     do: [shell_item(:cities, "/cities"), shell_item(name || id, "/cities?city=#{id}")]
 
   defp fetch_snapshot_world(%{world: %{id: world_id}}) do
-    Worlds.fetch_world(world_id)
+    case Worlds.get_world(world_id) do
+      %{} = world -> {:ok, world}
+      nil -> {:error, :not_found}
+    end
   end
 
   defp fetch_snapshot_world(_snapshot), do: {:error, :not_found}

--- a/lib/lemmings_os_web/live/create_lemming_live.ex
+++ b/lib/lemmings_os_web/live/create_lemming_live.ex
@@ -74,45 +74,47 @@ defmodule LemmingsOsWeb.CreateLemmingLive do
   end
 
   defp load_page(socket, %{"dept" => department_id}) when is_binary(department_id) do
-    department = Departments.get_department!(department_id, preload: [:city, :world])
-    cities = Cities.list_cities(department.world)
-    departments = Departments.list_departments(department.world, department.city)
+    case Departments.get_department(department_id, preload: [:city, :world]) do
+      nil ->
+        load_page(socket, %{})
 
-    socket
-    |> assign(:world, department.world)
-    |> assign(:city, department.city)
-    |> assign(:department, department)
-    |> assign(:cities, cities)
-    |> assign(:departments, departments)
-    |> assign(
-      :scope_form,
-      build_scope_form(%{"city_id" => department.city.id, "department_id" => department.id})
-    )
-    |> assign(:form, build_form(base_changeset(form_params(socket.assigns.form))))
-    |> put_shell_breadcrumb([
-      shell_item(:cities, "/cities"),
-      shell_item(
-        department.city.name || department.city.id,
-        "/cities?city=#{department.city.id}"
-      ),
-      shell_item(:departments, "/departments?city=#{department.city.id}"),
-      shell_item(
-        department.name || department.id,
-        "/departments?city=#{department.city.id}&dept=#{department.id}"
-      ),
-      shell_item("new", "/lemmings/new?dept=#{department.id}")
-    ])
-  rescue
-    Ecto.NoResultsError ->
-      load_page(socket, %{})
+      department ->
+        cities = Cities.list_cities(department.world)
+        departments = Departments.list_departments(department.city)
+
+        socket
+        |> assign(:world, department.world)
+        |> assign(:city, department.city)
+        |> assign(:department, department)
+        |> assign(:cities, cities)
+        |> assign(:departments, departments)
+        |> assign(
+          :scope_form,
+          build_scope_form(%{"city_id" => department.city.id, "department_id" => department.id})
+        )
+        |> assign(:form, build_form(base_changeset(form_params(socket.assigns.form))))
+        |> put_shell_breadcrumb([
+          shell_item(:cities, "/cities"),
+          shell_item(
+            department.city.name || department.city.id,
+            "/cities?city=#{department.city.id}"
+          ),
+          shell_item(:departments, "/departments?city=#{department.city.id}"),
+          shell_item(
+            department.name || department.id,
+            "/departments?city=#{department.city.id}&dept=#{department.id}"
+          ),
+          shell_item("new", "/lemmings/new?dept=#{department.id}")
+        ])
+    end
   end
 
   defp load_page(socket, %{"city" => city_id}) when is_binary(city_id) do
     case Worlds.get_default_world() do
-      {:ok, world} ->
+      %Worlds.World{} = world ->
         cities = Cities.list_cities(world)
         city = Enum.find(cities, &(&1.id == city_id))
-        departments = if city, do: Departments.list_departments(world, city), else: []
+        departments = if city, do: Departments.list_departments(city), else: []
 
         socket
         |> assign(:world, world)
@@ -131,14 +133,14 @@ defmodule LemmingsOsWeb.CreateLemmingLive do
           shell_item("new", "/lemmings/new")
         ])
 
-      {:error, :not_found} ->
+      nil ->
         load_page_without_scope(socket)
     end
   end
 
   defp load_page(socket, _params) do
     case Worlds.get_default_world() do
-      {:ok, world} ->
+      %Worlds.World{} = world ->
         socket
         |> assign(:world, world)
         |> assign(:city, nil)
@@ -153,7 +155,7 @@ defmodule LemmingsOsWeb.CreateLemmingLive do
           shell_item("new", "/lemmings/new")
         ])
 
-      {:error, :not_found} ->
+      nil ->
         load_page_without_scope(socket)
     end
   end

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -3,10 +3,14 @@ defmodule LemmingsOsWeb.DepartmentsLive do
 
   import LemmingsOsWeb.MockShell
 
+  alias LemmingsOs.Cities
+  alias LemmingsOs.Cities.City
   alias LemmingsOs.Config.Resolver
   alias LemmingsOs.Departments
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.MockData
+  alias LemmingsOs.Worlds
+  alias LemmingsOs.Worlds.World
   alias LemmingsOsWeb.PageData.CitiesPageSnapshot
 
   @detail_tabs ~w(overview lemmings settings)
@@ -172,9 +176,17 @@ defmodule LemmingsOsWeb.DepartmentsLive do
 
   defp load_departments(_snapshot, nil), do: []
 
-  defp load_departments(snapshot, selected_city) do
-    Departments.list_departments(selected_city, preload: [:city, :world])
+  defp load_departments(%{world: %{id: world_id}}, %{id: city_id})
+       when is_binary(world_id) and is_binary(city_id) do
+    with %World{} = world <- Worlds.get_world(world_id),
+         %City{} = city <- Cities.get_city(world, city_id) do
+      Departments.list_departments(city, preload: [:city, :world])
+    else
+      _ -> []
+    end
   end
+
+  defp load_departments(_, _), do: []
 
   defp select_department([], _department_id), do: nil
   defp select_department(_departments, nil), do: nil

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -8,7 +8,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   alias LemmingsOs.Config.Resolver
   alias LemmingsOs.Departments
   alias LemmingsOs.Departments.Department
-  alias LemmingsOs.MockData
+  alias LemmingsOs.Lemmings
   alias LemmingsOs.Worlds
   alias LemmingsOs.Worlds.World
   alias LemmingsOsWeb.PageData.CitiesPageSnapshot
@@ -29,7 +29,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
      |> assign(:department_settings_form, nil)
      |> assign(:department_effective_config, nil)
      |> assign(:department_local_overrides, nil)
-     |> assign(:department_lemming_preview, [])}
+     |> assign(:department_lemmings, [])}
   end
 
   def handle_params(params, _uri, socket) do
@@ -169,7 +169,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
         |> assign(:department_settings_form, nil)
         |> assign(:department_effective_config, nil)
         |> assign(:department_local_overrides, nil)
-        |> assign(:department_lemming_preview, [])
+        |> assign(:department_lemmings, [])
         |> put_shell_breadcrumb(default_shell_breadcrumb(:departments))
     end
   end
@@ -210,7 +210,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_settings_form, nil)
     |> assign(:department_effective_config, nil)
     |> assign(:department_local_overrides, nil)
-    |> assign(:department_lemming_preview, [])
+    |> assign(:department_lemmings, [])
   end
 
   defp assign_department_detail(socket, %Department{} = department, requested_tab) do
@@ -220,7 +220,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_settings_form, build_department_settings_form(department))
     |> assign(:department_effective_config, Resolver.resolve(department))
     |> assign(:department_local_overrides, department_local_overrides(department))
-    |> assign(:department_lemming_preview, department_lemming_preview(department))
+    |> assign(:department_lemmings, Lemmings.list_lemmings(department))
   end
 
   defp build_department_settings_form(%Department{} = department) do
@@ -291,25 +291,6 @@ defmodule LemmingsOsWeb.DepartmentsLive do
       {key, value}, acc ->
         Map.put(acc, key, value)
     end)
-  end
-
-  defp department_lemming_preview(%Department{} = department) do
-    direct_preview = MockData.lemmings_for_department(department.slug)
-
-    if direct_preview == [] do
-      department.id
-      |> :erlang.phash2()
-      |> rem(max(length(MockData.lemmings()), 1))
-      |> rotated_mock_lemmings()
-    else
-      direct_preview
-    end
-  end
-
-  defp rotated_mock_lemmings(seed) do
-    lemmings = MockData.lemmings()
-    {head, tail} = Enum.split(lemmings, seed)
-    Enum.take(tail ++ head, 4)
   end
 
   defp apply_lifecycle_action(department, "activate"),

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -6,7 +6,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   alias LemmingsOs.Config.Resolver
   alias LemmingsOs.Departments
   alias LemmingsOs.Departments.Department
-  alias LemmingsOs.Lemmings
+  alias LemmingsOs.MockData
   alias LemmingsOsWeb.PageData.CitiesPageSnapshot
 
   @detail_tabs ~w(overview lemmings settings)
@@ -25,7 +25,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
      |> assign(:department_settings_form, nil)
      |> assign(:department_effective_config, nil)
      |> assign(:department_local_overrides, nil)
-     |> assign(:department_lemmings, [])}
+     |> assign(:department_lemming_preview, [])}
   end
 
   def handle_params(params, _uri, socket) do
@@ -165,7 +165,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
         |> assign(:department_settings_form, nil)
         |> assign(:department_effective_config, nil)
         |> assign(:department_local_overrides, nil)
-        |> assign(:department_lemmings, [])
+        |> assign(:department_lemming_preview, [])
         |> put_shell_breadcrumb(default_shell_breadcrumb(:departments))
     end
   end
@@ -173,14 +173,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   defp load_departments(_snapshot, nil), do: []
 
   defp load_departments(snapshot, selected_city) do
-    lemming_counts =
-      Lemmings.lemming_counts_by_department(%LemmingsOs.Cities.City{id: selected_city.id})
-
-    snapshot.world.id
-    |> Departments.list_departments(selected_city.id, preload: [:city, :world])
-    |> Enum.map(fn department ->
-      Map.put(department, :lemming_count, Map.get(lemming_counts, department.id, 0))
-    end)
+    Departments.list_departments(selected_city, preload: [:city, :world])
   end
 
   defp select_department([], _department_id), do: nil
@@ -195,7 +188,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   defp reload_department_detail(nil), do: nil
 
   defp reload_department_detail(%Department{} = department) do
-    Departments.get_department!(department.id, preload: [:world, :city])
+    Departments.get_department(department.id, preload: [:world, :city])
   end
 
   defp assign_department_detail(socket, nil, _requested_tab) do
@@ -205,7 +198,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_settings_form, nil)
     |> assign(:department_effective_config, nil)
     |> assign(:department_local_overrides, nil)
-    |> assign(:department_lemmings, [])
+    |> assign(:department_lemming_preview, [])
   end
 
   defp assign_department_detail(socket, %Department{} = department, requested_tab) do
@@ -215,7 +208,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_settings_form, build_department_settings_form(department))
     |> assign(:department_effective_config, Resolver.resolve(department))
     |> assign(:department_local_overrides, department_local_overrides(department))
-    |> assign(:department_lemmings, department_lemmings(department))
+    |> assign(:department_lemming_preview, department_lemming_preview(department))
   end
 
   defp build_department_settings_form(%Department{} = department) do
@@ -288,15 +281,33 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     end)
   end
 
-  defp department_lemmings(%Department{} = department), do: Lemmings.list_lemmings(department)
+  defp department_lemming_preview(%Department{} = department) do
+    direct_preview = MockData.lemmings_for_department(department.slug)
+
+    if direct_preview == [] do
+      department.id
+      |> :erlang.phash2()
+      |> rem(max(length(MockData.lemmings()), 1))
+      |> rotated_mock_lemmings()
+    else
+      direct_preview
+    end
+  end
+
+  defp rotated_mock_lemmings(seed) do
+    lemmings = MockData.lemmings()
+    {head, tail} = Enum.split(lemmings, seed)
+    Enum.take(tail ++ head, 4)
+  end
 
   defp apply_lifecycle_action(department, "activate"),
-    do: Departments.activate_department(department)
+    do: Departments.set_department_status(department, "active")
 
-  defp apply_lifecycle_action(department, "drain"), do: Departments.drain_department(department)
+  defp apply_lifecycle_action(department, "drain"),
+    do: Departments.set_department_status(department, "draining")
 
   defp apply_lifecycle_action(department, "disable"),
-    do: Departments.disable_department(department)
+    do: Departments.set_department_status(department, "disabled")
 
   defp apply_lifecycle_action(department, "delete"), do: Departments.delete_department(department)
 

--- a/lib/lemmings_os_web/live/import_lemming_live.ex
+++ b/lib/lemmings_os_web/live/import_lemming_live.ex
@@ -146,30 +146,31 @@ defmodule LemmingsOsWeb.ImportLemmingLive do
   end
 
   defp load_page(socket, %{"dept" => department_id}) when is_binary(department_id) do
-    department = Departments.get_department!(department_id, preload: [:city, :world])
+    case Departments.get_department(department_id, preload: [:city, :world]) do
+      nil ->
+        socket
+        |> put_flash(:error, dgettext("lemmings", ".flash_create_scope_invalid"))
+        |> push_navigate(to: ~p"/lemmings")
 
-    socket
-    |> assign(:world, department.world)
-    |> assign(:city, department.city)
-    |> assign(:department, department)
-    |> put_shell_breadcrumb([
-      shell_item(:cities, "/cities"),
-      shell_item(
-        department.city.name || department.city.id,
-        "/cities?city=#{department.city.id}"
-      ),
-      shell_item(:departments, "/departments?city=#{department.city.id}"),
-      shell_item(
-        department.name || department.id,
-        "/departments?city=#{department.city.id}&dept=#{department.id}&tab=lemmings"
-      ),
-      shell_item("import", "/lemmings/import?dept=#{department.id}")
-    ])
-  rescue
-    Ecto.NoResultsError ->
-      socket
-      |> put_flash(:error, dgettext("lemmings", ".flash_create_scope_invalid"))
-      |> push_navigate(to: ~p"/lemmings")
+      department ->
+        socket
+        |> assign(:world, department.world)
+        |> assign(:city, department.city)
+        |> assign(:department, department)
+        |> put_shell_breadcrumb([
+          shell_item(:cities, "/cities"),
+          shell_item(
+            department.city.name || department.city.id,
+            "/cities?city=#{department.city.id}"
+          ),
+          shell_item(:departments, "/departments?city=#{department.city.id}"),
+          shell_item(
+            department.name || department.id,
+            "/departments?city=#{department.city.id}&dept=#{department.id}&tab=lemmings"
+          ),
+          shell_item("import", "/lemmings/import?dept=#{department.id}")
+        ])
+    end
   end
 
   defp load_page(socket, _params) do

--- a/lib/lemmings_os_web/live/lemmings_live.ex
+++ b/lib/lemmings_os_web/live/lemmings_live.ex
@@ -115,7 +115,7 @@ defmodule LemmingsOsWeb.LemmingsLive do
 
   defp load_page(socket, params) do
     case Worlds.get_default_world() do
-      {:ok, world} ->
+      %World{} = world ->
         selected_lemming = load_selected_lemming(lemming_id_param(socket, params))
         cities = Cities.list_cities(world)
         selected_city = selected_city(cities, params["city"], selected_lemming)
@@ -139,7 +139,7 @@ defmodule LemmingsOsWeb.LemmingsLive do
           build_shell_breadcrumb(world, selected_city, selected_department, selected_lemming)
         )
 
-      {:error, :not_found} ->
+      nil ->
         socket
         |> assign(:world, nil)
         |> assign(:cities, [])
@@ -228,8 +228,8 @@ defmodule LemmingsOsWeb.LemmingsLive do
 
   defp load_departments(_world, nil), do: []
 
-  defp load_departments(%World{} = world, %City{} = city) do
-    Departments.list_departments(world, city, preload: [:city, :world])
+  defp load_departments(%World{}, %City{} = city) do
+    Departments.list_departments(city, preload: [:city, :world])
   end
 
   defp load_lemmings(_world, _city, %Department{} = department) do

--- a/lib/lemmings_os_web/live/world_live.ex
+++ b/lib/lemmings_os_web/live/world_live.ex
@@ -61,8 +61,7 @@ defmodule LemmingsOsWeb.WorldLive do
     freshness = freshness_threshold_seconds()
     world = %World{id: world_id}
 
-    world
-    |> Cities.list_cities()
+    Cities.list_cities(world)
     |> Enum.map(&to_city_summary(&1, now, freshness))
   end
 

--- a/lib/lemmings_os_web/live/world_live.ex
+++ b/lib/lemmings_os_web/live/world_live.ex
@@ -5,11 +5,9 @@ defmodule LemmingsOsWeb.WorldLive do
 
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
-  alias LemmingsOs.Departments
   alias LemmingsOs.Helpers
-  alias LemmingsOs.Lemmings
   alias LemmingsOs.WorldBootstrap.Importer
-  alias LemmingsOs.Worlds
+  alias LemmingsOs.Worlds.World
   alias LemmingsOsWeb.PageData.WorldPageSnapshot
 
   def mount(_params, _session, socket) do
@@ -61,22 +59,14 @@ defmodule LemmingsOsWeb.WorldLive do
   defp load_world_cities(world_id) when is_binary(world_id) do
     now = DateTime.utc_now() |> DateTime.truncate(:second)
     freshness = freshness_threshold_seconds()
+    world = %World{id: world_id}
 
-    case Worlds.fetch_world(world_id) do
-      {:ok, world} ->
-        department_counts = Departments.department_counts_by_city(world)
-        lemming_counts = Lemmings.lemming_counts_by_city(world)
-
-        world
-        |> Cities.list_cities()
-        |> Enum.map(&to_city_summary(&1, now, freshness, department_counts, lemming_counts))
-
-      {:error, :not_found} ->
-        []
-    end
+    world
+    |> Cities.list_cities()
+    |> Enum.map(&to_city_summary(&1, now, freshness))
   end
 
-  defp to_city_summary(%City{} = city, now, freshness, department_counts, lemming_counts) do
+  defp to_city_summary(%City{} = city, now, freshness) do
     liveness = City.liveness(city, now, freshness)
 
     %{
@@ -86,8 +76,6 @@ defmodule LemmingsOsWeb.WorldLive do
       node_name: city.node_name,
       status: city.status,
       liveness: liveness,
-      department_count: Map.get(department_counts, city.id, 0),
-      lemming_count: Map.get(lemming_counts, city.id, 0),
       last_seen_at: city.last_seen_at,
       last_seen_at_label: Helpers.format_datetime(city.last_seen_at)
     }

--- a/lib/lemmings_os_web/page_data/cities_page_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/cities_page_snapshot.ex
@@ -15,7 +15,6 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.Helpers
   alias LemmingsOs.Gettext, as: AppGettext
-  alias LemmingsOs.Lemmings
   alias LemmingsOs.Worlds
   alias LemmingsOs.Worlds.World
 
@@ -44,7 +43,6 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
           name: String.t(),
           status: String.t(),
           status_label: String.t(),
-          lemming_count: non_neg_integer(),
           tags: [String.t()],
           notes_preview: String.t() | nil
         }
@@ -108,10 +106,19 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
   defp fetch_world(nil, opts),
     do: fetch_world_by_id(Keyword.get(opts, :world_id))
 
-  defp fetch_world_by_id(world_id) when is_binary(world_id),
-    do: Worlds.fetch_world(world_id)
+  defp fetch_world_by_id(world_id) when is_binary(world_id) do
+    case Worlds.get_world(world_id) do
+      %World{} = world -> {:ok, world}
+      nil -> {:error, :not_found}
+    end
+  end
 
-  defp fetch_world_by_id(_world_id), do: Worlds.get_default_world()
+  defp fetch_world_by_id(_world_id) do
+    case Worlds.get_default_world() do
+      %World{} = world -> {:ok, world}
+      nil -> {:error, :not_found}
+    end
+  end
 
   defp world_snapshot(%World{} = world, cities) do
     %{
@@ -175,21 +182,17 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
   end
 
   defp city_departments_snapshot(%City{} = city) do
-    lemming_counts = Lemmings.lemming_counts_by_department(city)
-
-    city.world_id
-    |> Departments.list_departments(city.id)
-    |> Enum.map(&department_card(&1, lemming_counts))
+    Departments.list_departments(city)
+    |> Enum.map(&department_card/1)
   end
 
-  defp department_card(%Department{} = department, lemming_counts) when is_map(lemming_counts) do
+  defp department_card(%Department{} = department) do
     %{
       id: department.id,
       path: "/departments?city=#{department.city_id}&dept=#{department.id}",
       name: department.name,
       status: department.status,
       status_label: Department.translate_status(department),
-      lemming_count: Map.get(lemming_counts, department.id, 0),
       tags: department.tags || [],
       notes_preview: truncate_notes(department.notes)
     }

--- a/lib/lemmings_os_web/page_data/cities_page_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/cities_page_snapshot.ex
@@ -15,6 +15,7 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.Helpers
   alias LemmingsOs.Gettext, as: AppGettext
+  alias LemmingsOs.Lemmings
   alias LemmingsOs.Worlds
   alias LemmingsOs.Worlds.World
 
@@ -44,7 +45,8 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
           status: String.t(),
           status_label: String.t(),
           tags: [String.t()],
-          notes_preview: String.t() | nil
+          notes_preview: String.t() | nil,
+          lemming_count: non_neg_integer()
         }
 
   @type t :: %__MODULE__{
@@ -182,11 +184,12 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
   end
 
   defp city_departments_snapshot(%City{} = city) do
-    Departments.list_departments(city)
-    |> Enum.map(&department_card/1)
+    departments = Departments.list_departments(city)
+    counts = Lemmings.lemming_counts_by_department(city)
+    Enum.map(departments, &department_card(&1, counts))
   end
 
-  defp department_card(%Department{} = department) do
+  defp department_card(%Department{} = department, counts) do
     %{
       id: department.id,
       path: "/departments?city=#{department.city_id}&dept=#{department.id}",
@@ -194,7 +197,8 @@ defmodule LemmingsOsWeb.PageData.CitiesPageSnapshot do
       status: department.status,
       status_label: Department.translate_status(department),
       tags: department.tags || [],
-      notes_preview: truncate_notes(department.notes)
+      notes_preview: truncate_notes(department.notes),
+      lemming_count: Map.get(counts, department.id, 0)
     }
   end
 

--- a/lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex
@@ -85,13 +85,15 @@ defmodule LemmingsOsWeb.PageData.HomeDashboardSnapshot do
   def build_topology_card_meta(world_id) when is_binary(world_id) do
     case Ecto.UUID.cast(world_id) do
       {:ok, valid_id} ->
+        world = %World{id: valid_id}
+
         city_count =
-          valid_id
+          world
           |> Cities.list_cities()
           |> length()
 
         %{department_count: department_count, active_department_count: active_department_count} =
-          Departments.topology_summary(valid_id)
+          Departments.topology_summary(world)
 
         %{lemming_count: lemming_count, active_lemming_count: active_lemming_count} =
           Lemmings.topology_summary(%World{id: valid_id})

--- a/lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex
@@ -88,8 +88,7 @@ defmodule LemmingsOsWeb.PageData.HomeDashboardSnapshot do
         world = %World{id: valid_id}
 
         city_count =
-          world
-          |> Cities.list_cities()
+          Cities.list_cities(world)
           |> length()
 
         %{department_count: department_count, active_department_count: active_department_count} =

--- a/lib/lemmings_os_web/page_data/settings_page_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/settings_page_snapshot.ex
@@ -96,7 +96,8 @@ defmodule LemmingsOsWeb.PageData.SettingsPageSnapshot do
   defp city_section(nil, _local_node_name), do: unavailable_city_section()
 
   defp city_section(snapshot, local_node_name) do
-    city = Cities.list_cities(snapshot.world.id, node_name: local_node_name) |> List.first()
+    world = %World{id: snapshot.world.id}
+    city = Cities.list_cities(world, node_name: local_node_name) |> List.first()
     city_section_from_row(city)
   end
 

--- a/lib/lemmings_os_web/page_data/world_page_snapshot.ex
+++ b/lib/lemmings_os_web/page_data/world_page_snapshot.ex
@@ -128,10 +128,19 @@ defmodule LemmingsOsWeb.PageData.WorldPageSnapshot do
   defp fetch_snapshot_world(nil, opts),
     do: fetch_snapshot_world_by_id(Keyword.get(opts, :world_id))
 
-  defp fetch_snapshot_world_by_id(world_id) when is_binary(world_id),
-    do: Worlds.fetch_world(world_id)
+  defp fetch_snapshot_world_by_id(world_id) when is_binary(world_id) do
+    case Worlds.get_world(world_id) do
+      %World{} = world -> {:ok, world}
+      nil -> {:error, :not_found}
+    end
+  end
 
-  defp fetch_snapshot_world_by_id(_world_id), do: Worlds.get_default_world()
+  defp fetch_snapshot_world_by_id(_world_id) do
+    case Worlds.get_default_world() do
+      %World{} = world -> {:ok, world}
+      nil -> {:error, :not_found}
+    end
+  end
 
   defp persisted_world_snapshot(%World{} = world) do
     %{

--- a/llms/agents/dev_backend_elixir_engineer.md
+++ b/llms/agents/dev_backend_elixir_engineer.md
@@ -184,8 +184,15 @@ rg "create index" priv/repo/migrations/ -n | tail -40
 
 #### 2.3 Context APIs
 Use predictable naming:
-- `list_*`, `get_*`, `get_*!`
+
+Do not use over-abstracted APIs:
+- Avoid `world_or_world_id` / `city_or_city_id` / `department_or_department_id` unions
+- Avoid redundant read pairs like `fetch_*` + `get_*!` unless explicitly required
+- Avoid helper indirection like `fetch_city_in_world` when struct matching and direct id checks are enough
+- `list_*` with scope pattern matching (`%World{}`, `%City{}`, `%Department{}`)
+- `get_*` returning `struct | nil` for normal reads
 - `create_*`, `update_*`, `delete_*`
+- `set_*_status/2` for lifecycle transitions instead of one wrapper per status
 - `change_*` for forms
 
 Prefer query helpers:

--- a/llms/coding_styles/elixir.md
+++ b/llms/coding_styles/elixir.md
@@ -104,19 +104,19 @@ end
 
 def list_departments(%City{id: city_id}, opts \\ []) do
   Department
-  |> filter_query([city_id: city_id | opts])
+  |> filter_query(Keyword.merge([city_id: city_id], opts))
   |> Repo.all()
 end
 
 def list_departments(%World{id: world_id}, opts) do
   Department
-  |> filter_query([world_id: world_id | opts])
+  |> filter_query(Keyword.merge([world_id: world_id], opts))
   |> Repo.all()
 end
 
 def get_department(id, opts \\ []) do
   Department
-  |> filter_query([id: id | opts])
+  |> filter_query(Keyword.merge([id: id], opts))
   |> Repo.one()
 end
 ```

--- a/llms/coding_styles/elixir.md
+++ b/llms/coding_styles/elixir.md
@@ -17,7 +17,7 @@
 - **Schemas** live under their context (not a global `Schemas` bucket).
 - **Web** layer only depends on contexts, not vice-versa.
 - Module names: `LemmingsOsWeb.*` (web), `LemmingsOs.*` (core). One module per file.
-- Context APIs for World-scoped resources MUST accept `world_id` or `%World{}` explicitly.
+- Context APIs for domain-scoped operations MUST accept domain structs (for example `%World{}`, `%City{}`, `%Department{}`), not `*_or_*_id` unions.
 
 ```elixir
 # good
@@ -90,22 +90,35 @@ end
 
 - Use `changeset/2` for validation; use `unique_constraint/3` instead of prechecks.
 - Prefer `Ecto.Multi` for multi-step writes; return final typed tuples.
-- Keep queries composable; expose filter functions rather than many `list_by_*` variants.
+- Keep context surfaces small: avoid duplicate variants that encode the same behavior.
+- For entity-scoped operations, pass structs (`%World{}`, `%City{}`, `%Department{}`), not `*_or_*_id` unions.
+- Prefer read APIs that return `struct | nil` for normal lookups; only keep bang reads when there is a strong, consistent reason.
+- For hierarchical collections, use a single `list_*` API differentiated by scope pattern matching in function heads.
+- Use `filter_query/2` with explicit keys (`:world_id`, `:city_id`, `:department_id`, `:status`, `:slug`, `:ids`, `:preload`, ...).
+- Avoid ceremonial private helpers (for example `fetch_*_in_world`) when direct struct matching and simple field checks are enough.
+- Do not duplicate lifecycle wrappers (`activate_*`, `disable_*`, ...) when `set_*_status/2` already expresses the transition.
 - Only preload what you render/use; avoid N+1 with explicit `preload`.
-- All World-scoped tables MUST be filtered by `world_id` in every query.
 
 ```elixir
-# composable World-scoped query
-def list_departments(world_id, opts \\ []) do
-  from(d in Department, where: d.world_id == ^world_id)
-  |> filter_query(opts)
+# composable scope-based query
+
+def list_departments(%City{id: city_id}, opts \\ []) do
+  Department
+  |> filter_query([city_id: city_id | opts])
   |> Repo.all()
 end
 
-defp filter_query(q, [{:city_id, city_id} | rest]),
-  do: filter_query(from(d in q, where: d.city_id == ^city_id), rest)
-defp filter_query(q, [_ | rest]), do: filter_query(q, rest)
-defp filter_query(q, []), do: q
+def list_departments(%World{id: world_id}, opts) do
+  Department
+  |> filter_query([world_id: world_id | opts])
+  |> Repo.all()
+end
+
+def get_department(id, opts \\ []) do
+  Department
+  |> filter_query([id: id | opts])
+  |> Repo.one()
+end
 ```
 
 ## 5) OTP & Process Management

--- a/llms/tasks/0004_implement_lemming_management/01_lemmings_migration_and_indexes.md
+++ b/llms/tasks/0004_implement_lemming_management/01_lemmings_migration_and_indexes.md
@@ -1,8 +1,8 @@
 # Task 01: Lemmings Migration and Indexes
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: PENDING
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: None
 - **Blocks**: Task 03
 - **Estimated Effort**: M
@@ -95,37 +95,32 @@ priv/repo/migrations/20260318120000_create_cities.exs        # Earlier precedent
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added `priv/repo/migrations/20260324120000_create_lemmings.exs` following the `CreateDepartments` migration style.
-- Created the `lemmings` table with explicit `world_id`, `city_id`, and `department_id` ownership columns, metadata fields, and five config buckets.
-- Added the requested foreign-key indexes, the per-department slug uniqueness constraint, and the composite hierarchy/status index.
+- [What was actually done]
 
 ### Outputs Created
-- `priv/repo/migrations/20260324120000_create_lemmings.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| The task’s frozen contract is authoritative for index shape even without a partial `status = 'active'` index. | The plan and task file explicitly require the four-column composite index, so the migration mirrors the approved contract rather than speculating about future query-specific indexes. |
-| `:map` defaults should remain `%{}` for all config buckets, including `tools_config`. | This matches the existing World, City, and Department migration pattern and keeps local overrides empty by default. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Added standalone indexes for all three foreign keys plus the composite `world_id, city_id, department_id, status` index. | Relying only on the composite index for some access paths. | The task explicitly requires FK indexes, and standalone FK indexes protect simpler join/filter shapes that do not constrain the full composite prefix. |
-| Kept status validation out of the database layer. | Adding a check constraint for `draft`, `active`, `archived`. | The task explicitly reserves lifecycle validation for the application layer, preserving flexibility while the feature is still being introduced. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/02_tools_config_shared_embedded_schema.md
+++ b/llms/tasks/0004_implement_lemming_management/02_tools_config_shared_embedded_schema.md
@@ -1,8 +1,8 @@
 # Task 02: ToolsConfig Shared Embedded Schema
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: PENDING
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: None (can run in parallel with Task 01)
 - **Blocks**: Task 03
 - **Estimated Effort**: S
@@ -81,38 +81,32 @@ lib/lemmings_os/config/models_config.ex    # Shows list field pattern
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added `LemmingsOs.Config.ToolsConfig` as a new embedded schema module under `lib/lemmings_os/config/`.
-- Implemented the minimal v1 shape with `allowed_tools` and `denied_tools` array fields, list defaults, and a casting-only `changeset/2`.
-- Added a focused unit test covering both explicit casting and default empty-list behavior.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os/config/tools_config.ex`
-- `test/lemmings_os/config/tools_config_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| `ToolsConfig` should mirror the lightweight casting behavior of the other config embeds and avoid validation in this task. | The task explicitly says to follow the existing config embed pattern and not add validation beyond `cast/3`. |
-| Empty lists are the correct default runtime shape for both tool fields. | The frozen contract defines both fields with default `[]`, which also keeps the embed safe for future upward propagation. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Added a small unit test for the embed changeset. | Leaving the new module untested. | The constitution requires tests for executable logic, and this keeps the task self-contained with minimal overhead. |
-| Kept the moduledoc scoped to Lemmings only. | Describing future Department/City/World propagation in the module docs. | The current shipped behavior is Lemming-only; future propagation is architectural context, not module behavior. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/03_lemming_schema_and_changeset.md
+++ b/llms/tasks/0004_implement_lemming_management/03_lemming_schema_and_changeset.md
@@ -1,8 +1,8 @@
 # Task 03: Lemming Schema and Changeset
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [x] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 01, Task 02
 - **Blocks**: Task 04, Task 05
 - **Estimated Effort**: M
@@ -105,39 +105,32 @@ test/support/factory.ex                      # Factory pattern
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added `LemmingsOs.Lemmings.Lemming` with the persisted schema shape, hierarchy associations, five config embeds, lifecycle status helpers, and the schema changeset rules for this slice.
-- Added a `:lemming` ExMachina factory that derives `world` and `city` from its built `:department` parent and defaults status to `\"draft\"`.
-- Added schema tests covering required fields, status validation, ownership casting boundaries, embed casting, helper translations, database constraints, and the factory shape.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os/lemmings/lemming.ex`
-- `test/lemmings_os/lemmings/lemming_test.exs`
-- Updated `test/support/factory.ex`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| Lemming operator-facing description length should use the same 280-character bound as Department notes. | The task calls for a bounded description similar to Department notes, and reusing that limit keeps the operator metadata constraints aligned. |
-| A nil lemming status should translate to an unknown label for UI safety even though `nil` is not a valid persisted value. | Existing City and Department status helpers provide a nil-safe fallback for rendering code paths, so the Lemming schema follows the same UI-facing pattern. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Kept the activation guard out of the changeset and added a test proving `active` can be set without `instructions` at the schema layer. | Enforcing instructions presence in `changeset/2`. | The task explicitly reserves that business rule for the context lifecycle APIs in Task 04. |
-| Added `description_max_length/0` as a small helper, mirroring `Department.notes_max_length/0`. | Inlining the numeric bound only in the test. | This keeps the bound explicit and testable without scattering a magic number. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/04_lemmings_context_and_lifecycle_apis.md
+++ b/llms/tasks/0004_implement_lemming_management/04_lemmings_context_and_lifecycle_apis.md
@@ -1,8 +1,8 @@
 # Task 04: Lemmings Context and Lifecycle APIs
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [x] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 03
 - **Blocks**: Task 06, Task 07, Task 08, Task 09, Task 10, Task 11, Task 12
 - **Estimated Effort**: L
@@ -121,40 +121,32 @@ test/lemmings_os/departments_test.exs                # Test pattern
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added the `LemmingsOs.Lemmings` context with explicit World- and Department-scoped list APIs, fetch/get helpers, create/update lifecycle APIs, and topology aggregation.
-- Implemented hierarchy validation in `create_lemming/4` so the supplied Department must belong to the supplied City and World scope before insert.
-- Added `LemmingsOs.Lemmings.DeleteDeniedError` and wired `delete_lemming/1` to unconditionally deny hard deletion with `:safety_indeterminate`.
-- Added context tests covering listing, scoping, hierarchy validation, slug conflicts, lifecycle transitions, the instructions activation guard, delete denial, and topology summary behavior.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os/lemmings.ex`
-- `lib/lemmings_os/lemmings/delete_denied_error.ex`
-- `test/lemmings_os/lemmings_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| `create_lemming/4` should return a single hierarchy-mismatch atom for both cross-city and cross-world mismatches. | The task allows `:department_not_in_world` or similar, and a single explicit atom keeps the public error surface stable while still enforcing the full hierarchy contract. |
-| `fetch_lemming/2` remains ID-based and unscoped, while collection APIs own the explicit World/Department boundaries. | This matches the existing Department pattern, where fetch-by-id is a direct lookup and scoped list APIs enforce boundary traversal. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Used `:department_not_in_city_world` as the hierarchy validation error atom. | Returning separate `:department_not_in_world` and `:department_not_in_city` atoms. | The create contract validates the full three-level ownership relationship, so one explicit mismatch atom avoids leaking internal branching into the public API. |
-| Added `list_all_lemmings/2` as a first-class World-scoped query instead of asking callers to iterate departments. | Deferring cross-department listing assembly to the web layer. | The task explicitly requires the context to own the cross-department query for the `/lemmings` page. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/05_config_resolver_lemming_extension.md
+++ b/llms/tasks/0004_implement_lemming_management/05_config_resolver_lemming_extension.md
@@ -1,8 +1,8 @@
 # Task 05: Config Resolver Lemming Extension
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 03
 - **Blocks**: Task 09, Task 10
 - **Estimated Effort**: M
@@ -113,38 +113,32 @@ lib/lemmings_os/config/tools_config.ex          # New embed to support
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Extended `LemmingsOs.Config.Resolver` to support `%Lemming{}` resolution on top of the existing `World -> City -> Department` merge chain.
-- Added `ToolsConfig` support to the resolver so Lemming scope returns a fifth `tools_config` bucket while World, City, and Department results remain unchanged.
-- Added resolver tests for Lemming inheritance, Lemming-level overrides, Lemming-only `tools_config`, and partially loaded parent-chain handling.
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os/config/resolver.ex`
-- Updated `test/lemmings_os/config/resolver_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| `tools_config` should resolve from an empty `%ToolsConfig{}` parent baseline because higher levels do not ship that bucket in this slice. | The frozen contract explicitly keeps `tools_config` Lemming-only for now, so there is no parent merge source above Lemming. |
-| Resolver support for partially loaded Lemming chains should follow the same spirit as the existing Department fallback, even if it requires reconstructing the in-memory chain first. | The task explicitly calls for preload-safe in-memory resolution with no DB access. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Introduced a dedicated `resolved_lemming_config` type instead of widening the existing non-Lemming `resolved_config` shape. | Making `tools_config` optional in one shared type. | Keeping a distinct Lemming result type makes the backward-compatibility boundary explicit and avoids implying `tools_config` exists at other scopes. |
-| Resolved Lemming config by delegating to Department resolution first, then layering Lemming overrides and `tools_config` on top. | Re-implementing the full four-level merge inline inside the Lemming clause. | Reusing Department resolution keeps the merge order clearer and avoids duplicating the existing logic. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/06_import_export_context_functions.md
+++ b/llms/tasks/0004_implement_lemming_management/06_import_export_context_functions.md
@@ -107,38 +107,32 @@ lib/lemmings_os/lemmings.ex    # Add functions here
 ---
 
 ## Execution Summary
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added `export_lemming/1` to `LemmingsOs.Lemmings` to produce a portable JSON-serializable map with `schema_version`, portable fields, and plain-map config buckets only.
-- Added `import_lemmings/4` to `LemmingsOs.Lemmings` to accept a single map or list of maps, validate `schema_version`, prevalidate the full batch, and insert records atomically through `Ecto.Multi`.
-- Added focused import/export coverage for single import, batch import, schema version handling, forward-compatible extra keys, empty-list import, validation failures, slug conflicts, and export/import roundtrip behavior.
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os/lemmings.ex`
-- Added `test/lemmings_os/lemmings_import_export_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| Portable export keys should be string-keyed instead of atom-keyed. | The context is preparing data for JSON serialization, and string keys line up directly with decoded JSON payloads on import. |
-| Empty config buckets should collapse to `%{}` even when the underlying embed struct contains default empty nested fields or lists. | The task explicitly calls for empty buckets to export as empty maps, not verbose default-shaped payloads. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Split import into a prevalidation pass plus an atomic `Ecto.Multi` write phase. | Letting `Ecto.Multi` fail on the first invalid row and returning only one error. | The task requires per-record validation errors while still keeping all-or-nothing semantics. |
-| Parsed `{:lemming, index}` failures from the transaction back into indexed error entries. | Returning a generic transaction failure without record indexing. | This keeps duplicate-slug and DB-backed validation failures attributable to the specific imported record. |
 
 ### Blockers Encountered
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/07_home_topology_summary_lemming_counts.md
+++ b/llms/tasks/0004_implement_lemming_management/07_home_topology_summary_lemming_counts.md
@@ -1,8 +1,8 @@
 # Task 07: Home Topology Summary -- Lemming Counts
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 04
 - **Blocks**: Task 15
 - **Estimated Effort**: S
@@ -75,44 +75,32 @@ test/lemmings_os_web/page_data/home_dashboard_snapshot_test.exs
 ---
 
 ## Execution Summary
-*Completed by the frontend agent*
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Extended `HomeDashboardSnapshot.build_topology_card_meta/1` to merge persisted lemming counts from `Lemmings.topology_summary/1` into the topology card meta.
-- Updated `HomeComponents.card_display/1` so the topology summary card renders `lemming_count` alongside the existing city and department counts, while keeping `active_lemming_count` available only in the snapshot meta.
-- Updated snapshot and LiveView tests to assert the new lemming counts, including the zero-count case.
-- Added the gettext entry for the new topology label in English, Spanish, and the extraction template.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex`
-- `lib/lemmings_os_web/components/home_components.ex`
-- `test/lemmings_os_web/page_data/home_dashboard_snapshot_test.exs`
-- `test/lemmings_os_web/live/home_live_test.exs`
-- `priv/gettext/en/LC_MESSAGES/layout.po`
-- `priv/gettext/es/LC_MESSAGES/layout.po`
-- `priv/gettext/layout.pot`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| The existing Home dashboard template did not need a direct markup change because the topology card already renders through `HomeComponents.dashboard_card/1`. | The requested UI update is fully expressed by the snapshot and card component data contract. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Kept the topology card as counts only, without introducing any lemming status breakdown. | Adding per-status detail. | The task explicitly asked for simple count-only output. |
-| Exposed `active_lemming_count` in snapshot metadata but rendered only `lemming_count` on the card. | Rendering both lemming totals on the card. | The task requires the extra meta field, but the UI should stay count-only without adding a lemming status breakdown. |
 
 ### Blockers Encountered
-- None
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/08_cities_page_department_cards_lemming_counts.md
+++ b/llms/tasks/0004_implement_lemming_management/08_cities_page_department_cards_lemming_counts.md
@@ -1,8 +1,8 @@
 # Task 08: Cities Page Department Cards -- Lemming Counts
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 04
 - **Blocks**: Task 15
 - **Estimated Effort**: S
@@ -78,42 +78,32 @@ test/lemmings_os_web/page_data/cities_page_snapshot_test.exs
 ---
 
 ## Execution Summary
-*Completed by the executing agent*
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added an aggregate `Lemmings.lemming_counts_by_department/1` query that groups persisted lemming counts by department for a selected city without loading full lemming rows.
-- Extended `CitiesPageSnapshot` department cards to include `lemming_count`, defaulting to `0` when a department has no persisted lemmings.
-- Updated the Cities page department list rendering to show the lemming count on each department row.
-- Updated snapshot and LiveView tests to verify the persisted count appears in both the read model and the rendered UI.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os/lemmings.ex`
-- `lib/lemmings_os_web/page_data/cities_page_snapshot.ex`
-- `lib/lemmings_os_web/components/world_components.ex`
-- `test/lemmings_os_web/page_data/cities_page_snapshot_test.exs`
-- `test/lemmings_os_web/live/cities_live_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| The Cities page department rows are rendered through `WorldComponents.city_departments_panel/1`, not directly in `cities_live.html.heex`. | The LiveView template delegates the selected city department card markup to the shared component. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Added a grouped aggregate API in `Lemmings` instead of counting per department row. | Per-row aggregate queries or `length(Lemmings.list_lemmings(...))`. | A grouped query keeps the count path efficient and avoids loading full lemming rows. |
-| Rendered only the total lemming count per department row. | Adding per-status breakdown or previews. | The task explicitly requires a minimal count-only card. |
 
 ### Blockers Encountered
-- None
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/09_department_lemmings_tab_desmoke.md
+++ b/llms/tasks/0004_implement_lemming_management/09_department_lemmings_tab_desmoke.md
@@ -1,8 +1,8 @@
 # Task 09: Department Lemmings Tab Desmoke
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 04, Task 05
 - **Blocks**: Task 10, Task 11
 - **Estimated Effort**: M
@@ -85,45 +85,32 @@ lib/lemmings_os/mock_data.ex                        # MockData to remove depende
 ---
 
 ## Execution Summary
-*Completed by the executing agent*
+*[Filled by executing agent after completion]*
 
 ### Work Performed
-- Replaced the Department Lemmings tab mock path with persisted loading through `Lemmings.list_lemmings/1`.
-- Renamed the LiveView assign from `department_lemming_preview` to `department_lemmings`.
-- Updated the tab UI to render persisted definition fields only: name, slug, status badge, and description preview.
-- Added an honest empty state with a CTA to `/lemmings/new`.
-- Removed the mock banner/copy and regenerated gettext entries for the updated tab copy.
+- [What was actually done]
 
 ### Outputs Created
-- `lib/lemmings_os_web/live/departments_live.ex`
-- `lib/lemmings_os_web/live/departments_live.html.heex`
-- `lib/lemmings_os_web/components/world_components.ex`
-- `test/lemmings_os_web/live/departments_live_test.exs`
-- `priv/gettext/en/LC_MESSAGES/world.po`
-- `priv/gettext/es/LC_MESSAGES/world.po`
-- `priv/gettext/world.pot`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| The existing `Lemmings.list_lemmings/1` contract is the correct persisted read path for a Department-scoped listing. | The context API was already simplified to struct-based scope pattern matching and returns real persisted lemmings in display order. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Kept navigation targets on `/lemmings?lemming=ID` instead of inventing a new route. | Adding a dedicated detail route in this task. | Task 10 owns the real detail view; this task only needs a stable forward link target. |
-| Used the existing `status kind={:lemming}` badge component for lifecycle tones. | Custom badge tone mapping in the tab template. | The status component already centralizes the visual contract for lemming statuses. |
 
 ### Blockers Encountered
-- None
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/10_lemming_detail_view.md
+++ b/llms/tasks/0004_implement_lemming_management/10_lemming_detail_view.md
@@ -1,8 +1,8 @@
 # Task 10: Lemming Detail View
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 09
 - **Blocks**: Task 13, Task 14
 - **Estimated Effort**: M
@@ -118,45 +118,29 @@ The agent should follow whichever approach best matches the existing navigation 
 *[Filled by executing agent after completion]*
 
 ### Work Performed
-- Replaced the mock-backed `/lemmings` page with persisted data from `Lemmings` and the default persisted world.
-- Added real Lemming detail loading with `department.city.world` preload and read-only effective config resolution through `Config.Resolver`.
-- Implemented lifecycle actions for `activate` and `archive`, including the `:instructions_required` activation guard flash path.
-- Reworked the detail panel to show persisted definition fields only: name, slug, description, instructions, status, hierarchy context, and effective config summary.
-- Added honest empty-selection and not-found states.
-- Replaced the mock navigation test with persisted records and added dedicated LiveView coverage for the detail page and lifecycle actions.
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os_web/live/lemmings_live.ex`
-- Updated `lib/lemmings_os_web/live/lemmings_live.html.heex`
-- Updated `lib/lemmings_os_web/components/lemming_components.ex`
-- Updated `lib/lemmings_os_web/components/core_components.ex`
-- Updated `test/lemmings_os_web/live/navigation_live_test.exs`
-- Added `test/lemmings_os_web/live/lemmings_live_test.exs`
-- Updated gettext catalogs via `mix gettext.extract --merge`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-| The existing `/lemmings?lemming=<id>` route should become the persisted detail view | It already existed, is linked from the Department lemmings tab, and avoids introducing another route surface |
-| A compact effective-config summary is sufficient for this task | Task 10 calls for read-only config display; Task 13 owns editing |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Kept the detail view on `/lemmings` rather than embedding a second panel inside Departments | Separate Departments panel, dedicated `/lemmings/:id` route | This preserves the existing deep link used by Task 09 and keeps the detail page focused |
-| Removed mock runtime fields from the detail page instead of trying to preserve the old registry presentation | Partial reuse of runtime fields | Task scope is persisted definition detail, not runtime activity |
-| Added a `muted` badge tone for archived lemmings | Reusing `default` or `warning` | Archived needed an explicitly subdued state without distorting other status tones |
 
 ### Blockers Encountered
-- `archived` used a `muted` status tone that the shared badge component did not support - Resolution: added `muted` tone support in `CoreComponents.badge/1`
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. None
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/11_create_lemming_page_desmoke.md
+++ b/llms/tasks/0004_implement_lemming_management/11_create_lemming_page_desmoke.md
@@ -1,8 +1,8 @@
 # Task 11: Create Lemming Page Desmoke
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 04, Task 09
 - **Blocks**: Task 15
 - **Estimated Effort**: M
@@ -116,48 +116,29 @@ The agent should choose the approach that best fits the existing navigation mode
 *[Filled by executing agent after completion]*
 
 ### Work Performed
-- Replaced the mock-backed `CreateLemmingLive` with a real changeset-backed create flow using `Lemmings.create_lemming/4`.
-- Added Department-scoped create context through `/lemmings/new?dept=<department_id>`.
-- Upgraded the no-context entry at `/lemmings/new` to load the default world plus real city and department selectors, patching into the scoped create flow instead of showing only a dead-end warning.
-- Implemented live validation, auto-slug generation from name, manual slug override preservation, and real persistence.
-- Reworked the create page UI to use existing panel/input/button/stat components instead of the mock tools workflow.
-- Updated the Department Lemmings empty-state CTA to navigate with Department context.
-- Added dedicated LiveView coverage for missing-context, real form rendering, auto-slug, create success, and duplicate slug validation.
-- Updated `en` and `es` translations for the new create flow strings.
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os_web/live/create_lemming_live.ex`
-- Updated `lib/lemmings_os_web/live/create_lemming_live.html.heex`
-- Updated `lib/lemmings_os_web/components/lemming_components.ex`
-- Updated `lib/lemmings_os_web/components/world_components.ex`
-- Added `test/lemmings_os_web/live/create_lemming_live_test.exs`
-- Updated `test/lemmings_os_web/live/navigation_live_test.exs`
-- Updated `priv/gettext/en/LC_MESSAGES/lemmings.po`
-- Updated `priv/gettext/es/LC_MESSAGES/lemmings.po`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-- Using `?dept=` on `/lemmings/new` is acceptable for this task. | It preserves the existing route surface while giving the form the Department context it needs. |
-- Entering `/lemmings/new` without Department context should stay honest instead of crashing. | The sidebar still links to the generic route, so an empty-state guard is safer than implicit fake defaults. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-- Kept the route as `/lemmings/new?dept=ID`. | Department tab inline form; a new nested route. | Lowest-diff option that still gives real Department context and matches current navigation patterns. |
-- Derived World and City from the persisted Department preload instead of trusting query params. | Passing `world` and `city` through params and re-validating them. | Keeps the API simpler and aligned with the domain contract that Department owns its parent scope. |
-- Left the generic `/lemmings/new` route available with a world/city/department scope picker. | Forcing a redirect or removing the route. | Avoids breaking the sidebar entrypoint while still guiding operators toward the correct Department-scoped create flow. |
 
 ### Blockers Encountered
-- The page had no existing dedicated LiveView test coverage. - Resolution: added `test/lemmings_os_web/live/create_lemming_live_test.exs` to lock the new contract.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. The sidebar still links to `/lemmings/new` without Department context. If the product later wants a global creation flow beyond the default world, that route will need a broader world-selection decision.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/12_lemmings_index_page_desmoke.md
+++ b/llms/tasks/0004_implement_lemming_management/12_lemmings_index_page_desmoke.md
@@ -1,8 +1,8 @@
 # Task 12: Lemmings Index Page Desmoke
 
 ## Status
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 04
 - **Blocks**: Task 15
 - **Estimated Effort**: M
@@ -37,7 +37,7 @@ Desmoke `LemmingsLive` by replacing `MockData.lemmings/0` and `MockData.find_lem
 ### Data Source
 - [ ] Page loads Lemmings from real persistence, not `MockData`
 - [ ] No `MockData` calls remain in `LemmingsLive`
-- [ ] Uses `Lemmings.list_lemmings(%World{}, opts \\ [])` to list all Lemmings across all Departments
+- [ ] Uses `Lemmings.list_all_lemmings(world_or_world_id, opts \\ [])` to list all Lemmings across all Departments
 
 ### Display
 - [ ] Each Lemming entry shows: name, slug, status badge, description preview
@@ -73,7 +73,7 @@ lib/lemmings_os/mock_data.ex                         # Mock data source
 
 ### Patterns to Follow
 - Follow the Cities/Departments page pattern: load World, then load entities with preloads
-- Use the official World-scoped context API `Lemmings.list_lemmings(%World{}, opts)`
+- Use the official World-scoped context API `Lemmings.list_all_lemmings/2`
 
 ### Constraints
 - Do NOT create a new snapshot module unless the data loading is complex enough to warrant one
@@ -81,7 +81,7 @@ lib/lemmings_os/mock_data.ex                         # Mock data source
 - The existing `/lemmings?lemming=ID` route pattern for detail selection can be preserved or replaced
 
 ### World-Wide Listing
-The page depends on the official World-scoped context contract `list_lemmings(%World{}, opts)`. The web layer must not assemble the cross-department list ad hoc by iterating departments.
+The current context API `list_lemmings/3` is department-scoped. This page depends on the official World-scoped context contract `list_all_lemmings(world_or_world_id, opts)`, which should be implemented in Task 04 and consumed here. The web layer must not assemble the cross-department list ad hoc by iterating departments.
 
 ## Execution Instructions
 
@@ -99,7 +99,7 @@ The page depends on the official World-scoped context contract `list_lemmings(%W
 2. Verify the rendered fields are definition-oriented, not runtime-oriented.
 3. Verify ancestry context (Department, City) is shown for each Lemming.
 4. Reject if mock runtime fields are still rendered.
-5. Verify the page uses the context-owned `list_lemmings(%World{}, ...)` contract rather than assembling the list ad hoc in the web layer.
+5. Verify the page uses the context-owned `list_all_lemmings/2` contract rather than assembling the list ad hoc in the web layer.
 
 ---
 
@@ -107,40 +107,29 @@ The page depends on the official World-scoped context contract `list_lemmings(%W
 *[Filled by executing agent after completion]*
 
 ### Work Performed
-- Kept the persisted `/lemmings` LiveView and finished the remaining desmoke contract for the index page.
-- Wired the index page to use `Lemmings.list_lemmings(%World{}, ...)` for the cross-department view.
-- Updated the lemming cards to show ancestry context (`Department`, `City`) while staying definition-oriented.
-- Replaced the old mock-sounding header copy and added an honest `World not found` state when no persisted world exists.
-- Extended LiveView coverage for ancestry rendering and the world-unavailable state.
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os_web/live/lemmings_live.ex`
-- Updated `lib/lemmings_os_web/components/lemming_components.ex`
-- Updated `test/lemmings_os_web/live/lemmings_live_test.exs`
-- Updated `priv/gettext/en/LC_MESSAGES/lemmings.po`
-- Updated `priv/gettext/es/LC_MESSAGES/lemmings.po`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 | Assumption | Rationale |
 |------------|-----------|
-- Keeping the current dedicated detail route `/lemmings/:id` is acceptable for this task. | The detail view had already been split out and the index now only needs to navigate into it cleanly. |
 
 ### Decisions Made
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-- Reused `list_lemmings(%World{}, ...)` for the world-wide index. | Adding a dedicated `list_all_lemmings/2`; assembling the cross-department list in the web layer. | Keeps the context API smaller while still preserving the rule that the web layer must not assemble topology ad hoc. |
-- Kept the index cards lightweight but added Department and City ancestry rows. | Repeating full detail data inline; keeping ancestry hidden. | Meets the task contract while preserving the browse-first index layout already in place. |
 
 ### Blockers Encountered
-- The page had already diverged from the original mock-only task shape, so the remaining work was contract alignment rather than a full rewrite. - Resolution: closed the missing context API and UI state gaps without undoing the newer dedicated-detail structure.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. If you want the index cards to show slug too, that would now be a deliberate UX choice rather than a desmoke requirement, since the dedicated detail page already owns the heavier metadata.
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/13_lemming_settings_edit_form.md
+++ b/llms/tasks/0004_implement_lemming_management/13_lemming_settings_edit_form.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 10
 - **Blocks**: Task 15, Task 16
 - **Estimated Effort**: M
@@ -76,48 +76,36 @@ Add the operator-facing edit flow for an existing Lemming so the stored definiti
 *[Filled by executing agent after completion]*
 
 ### Work Performed
-- Added a real `edit` mode to the dedicated lemming detail page, replacing the previous placeholder tab.
-- Implemented a changeset-backed settings form for mutable definition fields: `name`, `slug`, `description`, `instructions`, and `status`.
-- Added editable local override inputs for all five config buckets:
-  - limits
-  - runtime
-  - costs
-  - models
-  - tools
-- Kept `world_id`, `city_id`, and `department_id` read-only and context-owned.
-- Added live validation, persisted save handling, a success flash, and the activation guard when saving `status = active`.
-- Added LiveView coverage for edit mode rendering, save persistence, and the active-without-instructions guard.
+
+- [What was actually done]
 
 ### Outputs Created
-- Updated `lib/lemmings_os_web/live/lemmings_live.ex`
-- Updated `lib/lemmings_os_web/live/lemmings_live.html.heex`
-- Updated `lib/lemmings_os_web/components/lemming_components.ex`
-- Updated `test/lemmings_os_web/live/lemmings_live_test.exs`
-- Updated `priv/gettext/en/LC_MESSAGES/lemmings.po`
-- Updated `priv/gettext/es/LC_MESSAGES/lemmings.po`
+
+- [List of files/artifacts created]
 
 ### Assumptions Made
+
 | Assumption | Rationale |
 |------------|-----------|
-- Using JSON textareas for `models_config.providers` and `models_config.profiles` is acceptable for this task. | Those payloads are already map-backed in the schema, so JSON keeps the edit surface honest without inventing a larger nested map editor. |
-- Using comma-separated inputs for allowed/denied tools is acceptable for this task. | It gives operators a small, practical editing surface while still persisting the real array-backed `tools_config` contract. |
 
 ### Decisions Made
+
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-- Kept settings editing inside the dedicated detail page as an explicit `edit` tab. | Separate route or modal. | Reuses the Task 10 workspace and keeps browse/detail/edit in one coherent place. |
-- Stayed on the `edit` tab after a successful save. | Redirecting back to overview immediately. | Lets operators verify the persisted values and continue editing without extra navigation churn. |
 
 ### Blockers Encountered
-- The schema mixes simple scalar embeds with flexible map-backed config (`models_config`). - Resolution: used normal nested form inputs for scalar embeds and JSON textareas for the map-backed fields.
+
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
-1. If you want a friendlier non-JSON editor for model providers/profiles later, that should probably be a follow-up UX task rather than extending this desmoke/settings slice further.
+
+1. [Question needing human input]
 
 ### Ready for Next Task
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/14_import_export_minimal_ui.md
+++ b/llms/tasks/0004_implement_lemming_management/14_import_export_minimal_ui.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE — pending human sign-off
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 06, Task 10
 - **Blocks**: Task 15, Task 16
 - **Estimated Effort**: M
@@ -41,14 +41,14 @@ This task is intentionally narrow and may be deferred if implementation cost bec
 
 ## Acceptance Criteria
 
-- [x] Lemming detail view exposes an `Export JSON` action
-- [x] Export produces a downloadable `.json` payload backed by `export_lemming/1`
-- [x] Department Lemmings tab exposes an `Import JSON` action
-- [x] Import accepts pasted JSON (file upload deferred — see questions)
-- [x] Import uses `import_lemmings/4` in the web layer after JSON parsing
-- [x] Unknown schema versions surface a clear operator-facing error
-- [x] No wizard, preview, diff view, drag-and-drop, or progress workflow is introduced
-- [x] Defer decision not applicable — implementation completed in full
+- [ ] Lemming detail view exposes an `Export JSON` action
+- [ ] Export produces a downloadable `.json` payload backed by `export_lemming/1`
+- [ ] Department Lemmings tab exposes an `Import JSON` action
+- [ ] Import accepts either pasted JSON or a simple uploaded file
+- [ ] Import uses `import_lemmings/4` in the web layer after JSON parsing
+- [ ] Unknown schema versions surface a clear operator-facing error
+- [ ] No wizard, preview, diff view, drag-and-drop, or progress workflow is introduced
+- [ ] If this task is explicitly deferred during implementation, the defer decision and rationale are recorded in the execution summary
 
 ## Technical Notes
 
@@ -77,71 +77,39 @@ This task is intentionally narrow and may be deferred if implementation cost bec
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-1. Created `DownloadJsonHook` JS hook at `assets/js/hooks/download_json_hook.js` — listens for `"download_json"` push events and triggers a client-side file download via a data URI.
-2. Registered `DownloadJsonHook` in `assets/js/app.js`.
-3. Added `export_lemming` event handler to `lib/lemmings_os_web/live/lemmings_live.ex` — calls `ImportExport.export_lemming/1`, encodes to pretty-printed JSON via `Jason.encode!/2`, then pushes a `"download_json"` event with filename `lemming-{slug}.json`.
-4. Added an `Export JSON` button and the `phx-hook="DownloadJsonHook"` span to the edit tab panel in `lib/lemmings_os_web/components/lemming_components.ex`.
-5. Added `import_lemmings` UI to the Department lemmings tab in `lib/lemmings_os_web/components/world_components.ex` — inline form with a `<textarea>` for pasting JSON, visible only when `@import_open?` is true.
-6. Added `toggle_import_form`, `validate_import`, and `submit_import` event handlers to `lib/lemmings_os_web/live/departments_live.ex`, including structured inline error messages for JSON decode errors, unsupported schema version, and changeset validation failures.
-7. Added `:import_open?`, `:import_form`, and `:import_error` assigns to `departments_live.ex` mount, `assign_department_detail/3`, and all error-path branches.
-8. Threaded new assigns through `lib/lemmings_os_web/live/departments_live.html.heex`.
-9. Added all new i18n keys to `priv/gettext/en/LC_MESSAGES/lemmings.po`, `priv/gettext/es/LC_MESSAGES/lemmings.po`, `priv/gettext/lemmings.pot`, `priv/gettext/en/LC_MESSAGES/world.po`, `priv/gettext/es/LC_MESSAGES/world.po`, and `priv/gettext/world.pot`.
-10. Added export tests to `test/lemmings_os_web/live/lemmings_live_test.exs` and import tests (S15–S21) to `test/lemmings_os_web/live/departments_live_test.exs`.
+- [What was actually done]
 
 ### Outputs Created
 
-| File | Action |
-|------|--------|
-| `assets/js/hooks/download_json_hook.js` | Created |
-| `assets/js/app.js` | Modified — added `DownloadJsonHook` import and registration |
-| `lib/lemmings_os_web/live/lemmings_live.ex` | Modified — `ImportExport` alias, two `export_lemming` event handlers |
-| `lib/lemmings_os_web/components/lemming_components.ex` | Modified — `export_hook_id` attr, hook span, Export JSON button in edit tab |
-| `lib/lemmings_os_web/live/departments_live.ex` | Modified — `ImportExport` alias, import event handlers, import assigns |
-| `lib/lemmings_os_web/live/departments_live.html.heex` | Modified — three new import attrs passed to `department_detail_page` |
-| `lib/lemmings_os_web/components/world_components.ex` | Modified — three new attrs, import inline form panel in lemmings tab |
-| `priv/gettext/en/LC_MESSAGES/lemmings.po` | Modified — 8 new keys |
-| `priv/gettext/es/LC_MESSAGES/lemmings.po` | Modified — 8 new keys (Spanish) |
-| `priv/gettext/lemmings.pot` | Modified — 8 new keys |
-| `priv/gettext/en/LC_MESSAGES/world.po` | Modified — 9 new keys |
-| `priv/gettext/es/LC_MESSAGES/world.po` | Modified — 9 new keys (Spanish) |
-| `priv/gettext/world.pot` | Modified — 9 new keys |
-| `test/lemmings_os_web/live/lemmings_live_test.exs` | Modified — export describe block (2 tests) |
-| `test/lemmings_os_web/live/departments_live_test.exs` | Modified — import describe block (7 tests, S15–S21) |
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| Export button placed in the edit tab panel (`:actions` slot) | The edit tab is the natural surface for "manage this lemming" actions; the overview tab is read-only by convention |
-| `phx-hook` span placed inside the `active_tab == "edit"` conditional | The hook only needs to be mounted when the export button is visible; `push_event` targets all hooks listening to the named event in the current LiveView session |
-| No file upload input added | The task brief explicitly allowed "paste or file upload as alternative" but marked the textarea approach as sufficient; adding a file input in the same form would require JavaScript to read the FileReader API and push to a `phx-change`, adding complexity that the "no wizard" constraint discourages |
-| Import inline form uses a raw `<textarea>` instead of `<.input type="textarea">` | The `<.input>` component is backed by `Phoenix.HTML.FormField`; using a raw textarea with `name="import[json]"` keeps the form binding simpler for a free-form text surface |
-| `validate_import` stores the raw JSON in the form without re-parsing | Eager re-parsing on every keystroke is unnecessary and noisy; the form just updates the textarea value for LiveView patching |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Data URI download via JS hook | Server-side download endpoint with `send_download/3` | No new routes needed; simpler; the JSON is small enough that data URIs are practical |
-| Inline error as a `@import_error` string assign | Flash message | Flash messages disappear on navigation; an inline error stays visible while the user edits the JSON in the same panel |
-| Import state (`@import_open?`, `@import_form`, `@import_error`) cleared on department navigation | Persisting state across navigation | Prevents stale error messages when switching departments |
-| JSON parsing lives in `handle_event("submit_import", ...)` in the LiveView | Context layer | Constitution requires context functions to accept maps; parsing is a web-layer concern |
 
 ### Blockers Encountered
 
-None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. Should a file upload input be added as a parallel alternative to the textarea? The task brief mentioned it but it was treated as optional given the "no wizard" constraint. It can be added as a follow-up without changing the event contract.
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/15_test_scenarios_and_coverage_plan.md
+++ b/llms/tasks/0004_implement_lemming_management/15_test_scenarios_and_coverage_plan.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 09, Task 10, Task 11, Task 12, Task 13, Task 14, Task 19
 - **Blocks**: Task 16
 - **Estimated Effort**: M
@@ -50,19 +50,6 @@ Turn the branch-level acceptance criteria into a concrete, prioritized test plan
 - Keep the plan grounded in what the branch actually ships
 - Prefer stable DOM selectors and deterministic time/data setup
 
-### Methods To Explicitly Cover
-
-- `LemmingsOs.Lemmings.topology_summary/1`
-- `LemmingsOs.Lemmings.lemming_counts_by_department/1`
-- `LemmingsOs.Lemmings.lemming_counts_by_city/1`
-- `LemmingsOs.Departments.topology_summary/1`
-- `LemmingsOs.Departments.department_counts_by_city/1`
-- `LemmingsOs.Config.Resolver.resolve/1` for `%LemmingsOs.Lemmings.Lemming{}`
-- `LemmingsOs.Lemmings.ImportExport.export_lemming/1`
-- `LemmingsOs.Lemmings.ImportExport.import_lemmings/4`
-
-These should be called out in the coverage plan as direct contracts to test, not only indirectly through page snapshots or LiveViews.
-
 ## Execution Instructions
 
 ### For the Agent
@@ -80,49 +67,39 @@ These should be called out in the coverage plan as direct contracts to test, not
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Read all branch source files: schema, context, resolver, import/export, LiveView modules, and HEEx templates.
-- Read all existing test files: `lemming_test.exs`, `lemmings_test.exs`, `lemmings_import_export_test.exs`, `resolver_test.exs`, `lemmings_live_test.exs`, `create_lemming_live_test.exs`, `departments_live_test.exs`, `navigation_live_test.exs`, `home_live_test.exs`, `home_dashboard_snapshot_test.exs`.
-- Catalogued 68 existing test cases across 8 test files.
-- Identified 22 coverage gaps requiring new test implementation in Task 16.
-- Produced the scenario matrix below organized by 6 layers.
+- [What was actually done]
 
 ### Outputs Created
 
-- This file: `llms/tasks/0004_implement_lemming_management/15_test_scenarios_and_coverage_plan.md` with full scenario matrix, regression checklist, and deferred scope section.
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| `Departments.topology_summary/1` and `Departments.department_counts_by_city/1` are tested in existing `departments_test.exs` | Confirmed by grep; tests exist at lines 195+ in that file. New Lemming-specific scenarios for those functions are not needed here. |
-| `ImportLemmingLive` has zero test coverage | Confirmed by glob and grep; no `import_lemming_live_test.exs` file exists on the branch. |
-| `lemming_counts_by_department/1` and `lemming_counts_by_city/1` have zero direct unit coverage | Confirmed by grep across the entire test directory; these functions are only exercised indirectly through LiveView and snapshot tests. |
-| The home dashboard snapshot test already covers Lemming counts in topology card | Confirmed at `home_dashboard_snapshot_test.exs` and `home_live_test.exs` line 98. |
-| Navigation regression tests already exist in `navigation_live_test.exs` covering Lemming routes | Confirmed; the file tests `/lemmings`, `/lemmings/:id`, and `/lemmings/new` routes. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Group scenarios by architectural layer (schema, context, resolver, import/export, read model, liveview) rather than by file | Could group by file or by user story | Layer grouping matches the task's acceptance criteria structure and makes Task 16 implementation ordering natural (unit tests first, integration last). |
-| Mark LiveView import scenarios as P1 rather than P0 | Could mark all import tests as P0 | The context-level import/export functions are already well-tested. The LiveView layer adds UI plumbing but the critical business logic is covered. File upload testing in LiveView is mechanically complex and lower risk. |
-| Do not add scenarios for `Departments.topology_summary/1` or `department_counts_by_city/1` | Could include them for completeness | Those functions predate this branch and already have coverage. The task scope is Lemming management, not Department regression. |
 
 ### Blockers Encountered
 
-- None encountered.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. The `ImportLemmingLive` module has zero test coverage. Should Task 16 implement the full upload-parse-confirm-import flow in LiveView tests, or is context-level import coverage sufficient for this branch?
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 
@@ -146,243 +123,3 @@ These should be called out in the coverage plan as direct contracts to test, not
 ```bash
 # human-only
 ```
-
----
-
-## Risk Areas
-
-1. **World scoping bypass** -- Any context function that omits explicit `world_id` filtering could leak data across worlds. High impact, low likelihood given existing patterns.
-2. **Activation guard** -- Lemmings with blank or nil instructions must never reach `active` status. Both context API and LiveView save paths enforce this independently.
-3. **Scoped slug uniqueness** -- Slug must be unique per department but allowed across departments. DB constraint + changeset validation both participate.
-4. **Delete denial** -- Hard deletion is always denied in this branch slice. Any path that bypasses `delete_lemming/1` is a critical defect.
-5. **Resolver preload requirements** -- `Resolver.resolve/1` for `%Lemming{}` requires a fully preloaded parent chain (`department.city.world`). Partial preloads use fallback patching but missing world data would crash.
-6. **Import atomicity** -- Batch import via `Ecto.Multi` must not partially commit on validation failure.
-7. **Import schema versioning** -- Unknown `schema_version` values must be rejected cleanly.
-8. **Cross-hierarchy create** -- `create_lemming/4` must reject mismatched world/city/department triples.
-
----
-
-## Test Scenario Matrix
-
-### Layer 1 -- Schema & Changeset
-
-Test file: `test/lemmings_os/lemmings/lemming_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S1-01 | Requires `slug`, `name`, and `status` fields | P0 | unit | YES -- `lemming_test.exs` S01 |
-| S1-02 | Rejects statuses outside the frozen lifecycle taxonomy (`draft`, `active`, `archived`) | P0 | unit | YES -- `lemming_test.exs` S02 |
-| S1-03 | Does not cast `world_id`, `city_id`, or `department_id` from attrs (ownership is context-controlled) | P0 | unit | YES -- `lemming_test.exs` S03 |
-| S1-04 | Allows `active` status without instructions at the schema layer (guard lives in context) | P0 | unit | YES -- `lemming_test.exs` S04 |
-| S1-05 | Validates `description` length bounded at `description_max_length()` (280 chars) | P1 | unit | YES -- `lemming_test.exs` S05 |
-| S1-06 | Casts all five config embed buckets (limits, runtime, costs, models, tools) | P0 | unit | YES -- `lemming_test.exs` S06 |
-| S1-07 | Exposes translated status helpers (`statuses/0`, `status_options/0`, `translate_status/1`) | P1 | unit | YES -- `lemming_test.exs` S07 |
-| S1-08 | `translate_status/1` accepts a `%Lemming{}` struct | P2 | unit | YES -- `lemming_test.exs` S08 |
-| S1-09 | Enforces unique slug per department via DB constraint | P0 | unit | YES -- `lemming_test.exs` S09 |
-| S1-10 | Allows same slug in different departments | P0 | unit | YES -- `lemming_test.exs` S10 |
-| S1-11 | Enforces `world` foreign key existence | P0 | unit | YES -- `lemming_test.exs` S11 |
-| S1-12 | Enforces `city` foreign key existence | P0 | unit | YES -- `lemming_test.exs` S12 |
-| S1-13 | Enforces `department` foreign key existence | P0 | unit | YES -- `lemming_test.exs` S13 |
-| S1-14 | Factory builds a valid lemming with inherited hierarchy ownership and `%ToolsConfig{}` | P1 | unit | YES -- `lemming_test.exs` S14 |
-| S1-15 | Accepts valid `instructions` field (nullable text, no max length at schema layer) | P2 | unit | NO -- verify changeset accepts long instructions without error |
-| S1-16 | Accepts boundary description at exactly `description_max_length()` characters | P2 | unit | NO -- boundary value test (S05 only tests max+1) |
-
-### Layer 2 -- Context APIs
-
-Test file: `test/lemmings_os/lemmings_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S2-01 | `list_lemmings/2` scopes by `%World{}` and excludes other worlds | P0 | context | YES -- `lemmings_test.exs` "returns lemmings for a world scope" |
-| S2-02 | `list_lemmings/2` scopes by `%City{}` within a world | P0 | context | YES -- `lemmings_test.exs` "returns lemmings for a city scope" |
-| S2-03 | `list_lemmings/2` scopes by `%Department{}` | P0 | context | YES -- `lemmings_test.exs` "returns lemmings for a department scope" |
-| S2-04 | `list_lemmings/2` supports `status`, `ids`, `slug`, and `preload` filter opts | P0 | context | YES -- `lemmings_test.exs` "supports status, ids, slug, and preload filters" |
-| S2-05 | `list_lemmings/2` orders by name ASC then slug ASC | P1 | context | YES -- `lemmings_test.exs` "orders lemmings by name and slug" |
-| S2-06 | `get_lemming/2` returns lemming by UUID | P0 | context | YES -- `lemmings_test.exs` "get_lemming/2 returns the lemming by id" |
-| S2-07 | `get_lemming/2` returns nil for missing UUID | P0 | context | YES -- `lemmings_test.exs` "get_lemming/2 returns nil when the id is missing" |
-| S2-08 | `get_lemming/2` supports explicit preloads | P1 | context | YES -- `lemmings_test.exs` "get_lemming/2 supports explicit preloads" |
-| S2-09 | `get_lemming_by_slug/2` is department-scoped and returns the correct lemming | P0 | context | YES -- `lemmings_test.exs` "get by slug is department-scoped" |
-| S2-10 | `get_lemming_by_slug/2` returns nil when slug is missing in department | P1 | context | YES -- `lemmings_test.exs` "get_lemming_by_slug/2 returns nil when missing in department scope" |
-| S2-11 | `create_lemming/4` creates with correct world/city/department ownership and tools_config | P0 | context | YES -- `lemmings_test.exs` "creates a lemming scoped to the given world, city, and department" |
-| S2-12 | `create_lemming/4` rejects mismatched world/city/department triple | P0 | context | YES -- `lemmings_test.exs` "rejects creating a lemming when the department does not belong to the city and world" |
-| S2-13 | `create_lemming/4` returns changeset error on duplicate slug within same department | P0 | context | YES -- `lemmings_test.exs` "returns changeset error on duplicate slug within the same department" |
-| S2-14 | `update_lemming/2` persists attribute changes | P0 | context | YES -- `lemmings_test.exs` "updates persisted lemming attributes" |
-| S2-15 | `set_lemming_status/2` activates with valid instructions, archives, and re-activates | P0 | context | YES -- `lemmings_test.exs` "set_lemming_status/2 and archive wrapper delegate through the status path" |
-| S2-16 | `set_lemming_status/2` rejects nil instructions when activating | P0 | context | YES -- `lemmings_test.exs` "set_lemming_status/2 rejects nil instructions when activating" |
-| S2-17 | `set_lemming_status/2` rejects blank/whitespace-only instructions when activating | P0 | context | YES -- `lemmings_test.exs` "set_lemming_status/2 rejects blank instructions when activating" |
-| S2-18 | `delete_lemming/1` always returns `{:error, %DeleteDeniedError{reason: :safety_indeterminate}}` | P0 | context | YES -- `lemmings_test.exs` "rejects deleting lemmings in all statuses" |
-| S2-19 | `create_lemming/4` rejects city not in world (city.world_id != world.id) | P1 | context | NO -- current test only checks department mismatch; add explicit city-world mismatch case |
-| S2-20 | `set_lemming_status/2` rejects empty string instructions when activating | P1 | context | NO -- the empty string (`""`) clause is a distinct code path from nil and blank; add explicit test |
-| S2-21 | `list_lemmings/2` ignores unknown filter keys gracefully | P2 | context | NO -- verify the catch-all `filter_query/2` clause does not raise |
-
-### Layer 3 -- Config Resolver
-
-Test file: `test/lemmings_os/config/resolver_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S3-01 | Resolves full 4-level merge: World -> City -> Department -> Lemming with all 5 buckets | P0 | unit | YES -- `resolver_test.exs` "merges lemming overrides on top of department, city, and world config" |
-| S3-02 | Inherits parent config when lemming has empty config buckets | P0 | unit | YES -- `resolver_test.exs` "keeps inherited values when the lemming has empty config buckets" |
-| S3-03 | Resolves when city/department parent chains are not fully preloaded (uses lemming.world fallback) | P0 | unit | YES -- `resolver_test.exs` "uses lemming.world when city and department parent chains are not fully preloaded" |
-| S3-04 | Does NOT include `tools_config` in World/City/Department resolution (backward compat) | P0 | unit | YES -- `resolver_test.exs` "does not add tools_config to world city or department resolution" |
-| S3-05 | `tools_config` at Lemming level starts from `%ToolsConfig{}` base (no parent inheritance) | P1 | unit | YES -- implied by S3-01 which checks `tools_config` merge from empty base |
-| S3-06 | Resolver handles lemming with `department.city.world: nil` preload variant | P1 | unit | NO -- the resolver has distinct function heads for `world: nil` vs `%NotLoaded{}` on nested city; only the NotLoaded variant is tested. Add test for `city.world: nil` and `department.city.world: nil` paths |
-
-### Layer 4 -- Import/Export
-
-Test file: `test/lemmings_os/lemmings_import_export_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S4-01 | `export_lemming/1` produces portable JSON shape with `schema_version: 1` | P0 | unit | YES -- `lemmings_import_export_test.exs` "exports the portable lemming shape without identity fields" |
-| S4-02 | Export excludes identity fields (`id`, `world_id`, `city_id`, `department_id`, timestamps) | P0 | unit | YES -- same test as S4-01 |
-| S4-03 | Export renders empty config buckets as empty maps (not nil) | P1 | unit | YES -- `lemmings_import_export_test.exs` "exports empty config buckets as empty maps" |
-| S4-04 | `import_lemmings/4` imports valid single record | P0 | context | YES -- `lemmings_import_export_test.exs` "imports a valid single lemming definition" |
-| S4-05 | `import_lemmings/4` imports valid batch atomically | P0 | context | YES -- `lemmings_import_export_test.exs` "imports a valid batch atomically" |
-| S4-06 | Import returns per-record validation errors and does not partially commit | P0 | context | YES -- `lemmings_import_export_test.exs` "returns validation errors per record and does not partially commit on failure" |
-| S4-07 | Import returns error on slug conflict with existing lemming | P0 | context | YES -- `lemmings_import_export_test.exs` "returns validation error on slug conflict" |
-| S4-08 | Import rejects unsupported `schema_version` values | P0 | context | YES -- `lemmings_import_export_test.exs` "rejects unsupported schema_version values" |
-| S4-09 | Import accepts missing `schema_version` (forward tolerance) | P1 | context | YES -- `lemmings_import_export_test.exs` "accepts missing schema_version" |
-| S4-10 | Import ignores unknown extra keys in JSON payload | P1 | context | YES -- `lemmings_import_export_test.exs` "ignores unknown extra keys" |
-| S4-11 | Import returns `{:ok, []}` for empty list | P1 | context | YES -- `lemmings_import_export_test.exs` "returns ok for an empty import list" |
-| S4-12 | Export/import roundtrip preserves all definition fields including tools_config | P0 | context | YES -- `lemmings_import_export_test.exs` "roundtrips through export and import" |
-| S4-13 | `import_lemmings/4` rejects mismatched world/city/department triple | P1 | context | NO -- the import module has its own `validate_city_in_world` and `validate_department_in_city_world` guards; they are untested |
-| S4-14 | `import_lemmings/4` rejects non-map/non-list payloads (e.g., string, integer) | P1 | context | NO -- the `normalize_import_records/1` catch-all returns `{:error, [%{index: nil, error: :invalid_import_payload}]}` but is untested |
-| S4-15 | `import_lemmings/4` rejects list containing non-map entries | P2 | context | NO -- exercises the `Enum.all?(records, &is_map/1)` guard in `normalize_import_records/1` |
-
-### Layer 5 -- Read Models
-
-Test files: `test/lemmings_os/lemmings_test.exs`, `test/lemmings_os/departments_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S5-01 | `Lemmings.topology_summary/1` returns aggregate total and active counts scoped to world | P0 | integration | YES -- `lemmings_test.exs` "returns aggregate lemming counts for the world" |
-| S5-02 | `Lemmings.topology_summary/1` returns zero counts for world without lemmings | P0 | integration | YES -- `lemmings_test.exs` "returns zero counts for worlds without lemmings" |
-| S5-03 | `Lemmings.lemming_counts_by_department/1` returns `%{department_id => count}` map for a city | P0 | integration | NO -- function exists and is called by LiveView but has zero direct unit test |
-| S5-04 | `Lemmings.lemming_counts_by_department/1` omits departments with zero lemmings | P1 | integration | NO -- edge case of the same function |
-| S5-05 | `Lemmings.lemming_counts_by_department/1` returns empty map for city with no lemmings | P1 | integration | NO -- empty-state edge case |
-| S5-06 | `Lemmings.lemming_counts_by_city/1` returns `%{city_id => count}` map for a world | P0 | integration | NO -- function exists and is called by LiveView but has zero direct unit test |
-| S5-07 | `Lemmings.lemming_counts_by_city/1` omits cities with zero lemmings | P1 | integration | NO -- edge case |
-| S5-08 | `Lemmings.lemming_counts_by_city/1` returns empty map for world with no lemmings | P1 | integration | NO -- empty-state edge case |
-
-### Layer 6 -- LiveView Flows
-
-#### 6A: Lemmings Index Page
-
-Test file: `test/lemmings_os_web/live/lemmings_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6A-01 | Renders filter panel, world name, city/department selectors, and cards grid | P0 | liveview | YES -- `lemmings_live_test.exs` "renders filters and browse cards" |
-| S6A-02 | Shows world unavailable state when no persisted world exists | P0 | liveview | YES -- `lemmings_live_test.exs` "shows world unavailable state" |
-| S6A-03 | Changing city filter patches URL and scopes visible cards | P0 | liveview | YES -- `lemmings_live_test.exs` "changing filters scopes the cards" |
-| S6A-04 | Card click navigates to dedicated detail page with scope params | P0 | liveview | YES -- `lemmings_live_test.exs` "card navigates to dedicated detail page" |
-| S6A-05 | Empty state renders when department has no lemmings | P1 | liveview | NO -- no test for empty cards grid on the lemmings index |
-
-#### 6B: Lemming Detail / Overview
-
-Test file: `test/lemmings_os_web/live/lemmings_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6B-01 | Dedicated detail page renders header, hero, detail panel, effective config, instances placeholder | P0 | liveview | YES -- `lemmings_live_test.exs` "dedicated detail page renders workspace" |
-| S6B-02 | Activate succeeds when instructions are present; UI shows active status and archive button | P0 | liveview | YES -- `lemmings_live_test.exs` "activate succeeds when instructions are present" |
-| S6B-03 | Activate fails when instructions are blank; UI shows error flash and retains draft status | P0 | liveview | YES -- `lemmings_live_test.exs` "activate fails when instructions are blank" |
-| S6B-04 | Archive succeeds for active lemming; UI shows archived status and activate button | P0 | liveview | YES -- `lemmings_live_test.exs` "archive succeeds for active lemmings" |
-| S6B-05 | Shows not-found state for invalid lemming UUID | P1 | liveview | YES -- `lemmings_live_test.exs` "shows not found state for invalid lemming id" |
-| S6B-06 | Export button visible on edit tab; triggers `download_json` push event with correct payload | P0 | liveview | YES -- `lemmings_live_test.exs` export describe block |
-
-#### 6C: Lemming Edit / Settings Tab
-
-Test file: `test/lemmings_os_web/live/lemmings_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6C-01 | Edit tab renders settings form with name, slug, limits, runtime config fields | P0 | liveview | YES -- `lemmings_live_test.exs` "edit tab renders a real settings form" |
-| S6C-02 | Settings save persists mutable fields and local config overrides | P0 | liveview | YES -- `lemmings_live_test.exs` "settings save persists mutable fields" |
-| S6C-03 | Settings save blocks activation when instructions are blank (activation guard in UI) | P0 | liveview | YES -- `lemmings_live_test.exs` "settings save keeps activation guard when instructions are blank" |
-| S6C-04 | Settings validate event provides inline feedback without persisting | P1 | liveview | NO -- `validate_lemming_settings` event handler exists but no test exercises the `phx-change` validation path |
-
-#### 6D: Create Lemming Page
-
-Test file: `test/lemmings_os_web/live/create_lemming_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6D-01 | Shows city/department scope selectors when no department context provided | P0 | liveview | YES -- `create_lemming_live_test.exs` "shows city and department selectors" |
-| S6D-02 | Selecting city then department patches URL into create scope | P0 | liveview | YES -- `create_lemming_live_test.exs` "selecting city and department patches" |
-| S6D-03 | Renders real form fields in department scope (name, slug, description, instructions, status) | P0 | liveview | YES -- `create_lemming_live_test.exs` "renders the real create form" |
-| S6D-04 | Auto-generates slug from name until manually overridden | P1 | liveview | YES -- `create_lemming_live_test.exs` "auto-generates the slug from the name" |
-| S6D-05 | Creates persisted lemming and redirects to detail page | P0 | liveview | YES -- `create_lemming_live_test.exs` "creates a persisted lemming and redirects to detail" |
-| S6D-06 | Shows duplicate slug validation inline | P0 | liveview | YES -- `create_lemming_live_test.exs` "shows duplicate slug validation inline" |
-| S6D-07 | Gracefully handles invalid department_id param (rescue from `Ecto.NoResultsError`) | P2 | liveview | NO -- `load_page/2` rescues `Ecto.NoResultsError` but no test covers this fallback |
-
-#### 6E: Import Lemming Page
-
-Test file: `test/lemmings_os_web/live/import_lemming_live_test.exs` (DOES NOT EXIST)
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6E-01 | Renders upload form when accessed with valid `dept` param | P1 | liveview | NO |
-| S6E-02 | Redirects with error flash when accessed without `dept` param | P1 | liveview | NO |
-| S6E-03 | Redirects with error flash when accessed with invalid `dept` param | P2 | liveview | NO |
-| S6E-04 | Processes valid JSON file and imports lemmings (no conflicts) | P1 | liveview | NO |
-| S6E-05 | Shows confirm step with conflict list when imported names match existing lemmings | P1 | liveview | NO |
-| S6E-06 | Confirm import updates existing lemmings and creates new ones | P1 | liveview | NO |
-| S6E-07 | Cancel import resets to upload step | P2 | liveview | NO |
-| S6E-08 | Shows upload error for invalid JSON content | P1 | liveview | NO |
-| S6E-09 | Shows upload error for unsupported schema version | P1 | liveview | NO |
-
-#### 6F: Department Page Regressions (Lemming-related)
-
-Test file: `test/lemmings_os_web/live/departments_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6F-01 | Lemmings tab renders persisted lemming definitions with name, slug, status | P0 | liveview | YES -- `departments_live_test.exs` S09 |
-| S6F-02 | Lemmings tab shows empty state with create CTA when department has no lemmings | P0 | liveview | YES -- `departments_live_test.exs` S09b |
-| S6F-03 | City map payload includes persisted lemming counts | P1 | liveview | YES -- `departments_live_test.exs` S09c |
-| S6F-04 | Import button on lemmings tab links to import page | P1 | liveview | YES -- `departments_live_test.exs` S15 |
-
-#### 6G: Home and Navigation Regressions
-
-Test files: `test/lemmings_os_web/live/home_live_test.exs`, `test/lemmings_os_web/live/navigation_live_test.exs`
-
-| ID | Description | Priority | Layer | Already Covered? |
-|----|-------------|----------|-------|-----------------|
-| S6G-01 | Home topology card includes `lemming_count` and `active_lemming_count` | P0 | liveview | YES -- `home_live_test.exs` line 98 |
-| S6G-02 | Navigation test confirms `/lemmings` renders cards and `/lemmings/:id` renders detail | P0 | liveview | YES -- `navigation_live_test.exs` "lemmings page links into dedicated detail view" |
-| S6G-03 | Navigation test confirms `/lemmings/new` renders create page | P1 | liveview | YES -- `navigation_live_test.exs` "tools, logs, settings, and create lemming pages render" |
-
----
-
-## Regression Checklist
-
-This checklist is for Task 16 (implementation) and Task 17 (final QA gate) to confirm before merge.
-
-- [ ] `mix test` passes with zero warnings
-- [ ] `mix precommit` passes (format, Credo, test)
-- [ ] All P0 scenarios marked YES above continue to pass after any Task 16 additions
-- [ ] All P0 scenarios marked NO above have new test implementations
-- [ ] Home page topology card still renders `lemming_count` correctly
-- [ ] Department lemmings tab still renders persisted lemming list
-- [ ] Department city map still includes lemming counts
-- [ ] Create lemming page still auto-generates slug and handles scope selection
-- [ ] Lemmings index page still renders filter panel and scoped cards
-- [ ] Lemming detail page still renders effective config and lifecycle actions
-- [ ] Navigation tests still pass for all Lemming-related routes
-
----
-
-## Deferred / Out of Scope
-
-| Item | Reason |
-|------|--------|
-| `ImportLemmingLive` full upload flow testing (S6E-01 through S6E-09) | The import LiveView has zero coverage. Context-level import/export is well-tested. LiveView file upload testing is mechanically complex. Marked P1; recommended for Task 16 but can be deferred to a follow-up if time-constrained. Awaiting human decision per Questions section. |
-| Runtime process lifecycle testing (spawn, supervise, restart, terminate) | Out of scope for this branch; this branch ships persisted definitions only, not runtime execution. |
-| `tools_config` merge governance semantics (deny-dominant vs override-dominant across levels) | Explicitly deferred per plan.md section 9; `tools_config` only exists at Lemming level in v1 so no merge conflict is possible. |
-| Concurrent slug conflict (double-submit race condition) | DB unique index enforces correctness. Testing concurrent inserts would require manual SQL or process-level coordination that adds test complexity without meaningful risk coverage given the DB constraint. |
-| Cross-world data leakage end-to-end testing | All context functions are World-scoped by construction. Unit tests for `list_lemmings/2` already verify cross-world exclusion. A dedicated E2E pentest-style scenario is not warranted at this layer. |
-| `Departments.topology_summary/1` and `Departments.department_counts_by_city/1` | These functions predate the Lemming management branch and already have coverage in `departments_test.exs`. Not in scope for this plan. |
-| Accessibility, keyboard navigation, and touch target testing for LiveView pages | Manual testing scope; not covered by ExUnit LiveView integration tests. |
-| Observability (structured logging with hierarchy metadata) | No telemetry or structured logging was added in this branch for Lemming operations. When it is added, scenarios should verify `world_id`, `city_id`, `department_id`, and `lemming_id` are present in log metadata. |

--- a/llms/tasks/0004_implement_lemming_management/16_test_implementation.md
+++ b/llms/tasks/0004_implement_lemming_management/16_test_implementation.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 15
 - **Blocks**: Task 17
 - **Estimated Effort**: L
@@ -64,52 +64,39 @@ Add the automated tests needed to prove the Lemming definition foundation is cor
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Implemented the approved Lemming test coverage gaps from Task 15 across schema, context, resolver, import/export, and LiveView layers.
-- Added boundary tests for `instructions` and `description` on the Lemming schema.
-- Added context tests for unknown filter keys, city/world mismatch, empty-string activation rejection, and lemming count read models by department and city.
-- Added resolver coverage for the lemming fallback path where `city.world` and `department.city.world` are `nil`.
-- Added import/export coverage for hierarchy mismatch errors and invalid payload shapes.
-- Added LiveView coverage for the empty-state index view, `phx-change` validation re-rendering, and invalid create scope handling.
-- Ran targeted `mix test` files and finished with `mix precommit` passing.
+- [What was actually done]
 
 ### Outputs Created
 
-- `test/lemmings_os/lemmings/lemming_test.exs`
-- `test/lemmings_os/lemmings_test.exs`
-- `test/lemmings_os/config/resolver_test.exs`
-- `test/lemmings_os/lemmings_import_export_test.exs`
-- `test/lemmings_os_web/live/lemmings_live_test.exs`
-- `test/lemmings_os_web/live/create_lemming_live_test.exs`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| The full `ImportLemmingLive` upload/confirm flow remains a deferred follow-up | Task 15 explicitly marked the import LiveView as lower priority and allowed deferral if time-constrained. |
-| The LiveView validation test should assert stable re-render behavior instead of brittle error text | The settings form does not surface a reliable inline error string for the change event, but it does reliably re-render the typed value without persisting. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Implement missing coverage in the lowest layer that proves each scenario | Could duplicate behavior at multiple layers | Keeps the suite maintainable and avoids redundant assertions. |
-| Keep the `ImportLemmingLive` full file-upload flow out of this task | Could add a large, mechanically complex LiveView test suite now | Task 15 treated it as follow-up scope and the current branch already covers import/export logic at the context layer. |
 
 ### Blockers Encountered
 
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. Do you want the deferred `ImportLemmingLive` upload/confirm/import flow covered in a follow-up task, or should it stay intentionally untested for this branch slice?
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/17_branch_validation_and_precommit.md
+++ b/llms/tasks/0004_implement_lemming_management/17_branch_validation_and_precommit.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 16
 - **Blocks**: Task 18, Task 20
 - **Estimated Effort**: M
@@ -64,46 +64,39 @@ Prove the branch satisfies the required validation gates before formal review an
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Ran the full validation gate for the branch:
-  - `mix test`
-  - `mix test --cover` to generate the coverage report
-  - `mix precommit`
-- Confirmed the final suite passes with 37 doctests and 299 tests.
-- Recorded total coverage at 79.2% from the `mix test --cover` report.
-- Verified the branch remains clean under the repo's formatting, compile, and Credo precommit checks.
+- [What was actually done]
 
 ### Outputs Created
 
-- Coverage output from `mix test --cover` in the terminal
-- No code changes were needed for validation
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| `mix coveralls.html` is not available as a runnable Mix task in this environment | The task lookup failed with `The task "coveralls.html" could not be found`, so coverage validation used the repo-accepted `mix test --cover` workflow instead. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Use `mix test --cover` as the coverage gate | Retry `mix coveralls.html` after dependency changes | The task is not registered in this environment, but `mix test --cover` produced a valid coverage report and matches the branch validation intent. |
 
 ### Blockers Encountered
 
-- `mix coveralls.html` was unavailable as a Mix task. Resolution: used `mix test --cover` to generate the coverage report and recorded the fallback explicitly.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. Do you want the validation task rewritten to explicitly accept `mix test --cover` as the coverage workflow for this branch, or should that remain a documented fallback only?
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/18_security_and_performance_review.md
+++ b/llms/tasks/0004_implement_lemming_management/18_security_and_performance_review.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 17
 - **Blocks**: Task 20
 - **Estimated Effort**: M
@@ -40,11 +40,6 @@ Perform the formal branch review after implementation and validation, before the
 - [ ] Review covers resolver preload / N+1 / aggregate-query risk on the new surfaces
 - [ ] Review explicitly states whether residual risks remain
 
-## Findings
-
-1. Medium: `lib/lemmings_os_web/live/import_lemming_live.ex` resolved import conflicts by `name`, but `name` is not unique for Lemmings. That can update the wrong record or collapse multiple matches into one during confirm-import. I fixed this by switching conflict detection and update lookup to `slug`, which is the stable unique identifier within a department.
-2. No other blocking security or performance findings remain after validation. The branch stays world-scoped, uses aggregate queries for count surfaces, and rejects unsafe deletes consistently.
-
 ## Technical Notes
 
 ### Constraints
@@ -67,42 +62,39 @@ Perform the formal branch review after implementation and validation, before the
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Reviewed the branch end-to-end against the implemented Lemming management surfaces, with focus on world scoping, cross-hierarchy access, import/export boundaries, delete guard honesty, resolver behavior, and aggregate read paths.
-- Identified and fixed a correctness issue in `ImportLemmingLive` where conflict resolution used non-unique `name` values instead of `slug`.
-- Re-ran `mix test` and `mix precommit` on the final tree to confirm the branch still passes quality gates.
+- [What was actually done]
 
 ### Outputs Created
 
-- Updated `lib/lemmings_os_web/live/import_lemming_live.ex` to key import conflicts by `slug`
-- Updated `llms/tasks/0004_implement_lemming_management/18_security_and_performance_review.md`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| The branch review should treat the final fixed tree as the source of truth | The task is a quality gate, so the validated state matters more than the pre-fix state. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Fix the import conflict key in production code instead of only reporting it | Leave the bug documented for a later task | The issue was small, isolated, and clearly within the branch scope, so fixing it reduced risk immediately. |
 
 ### Blockers Encountered
 
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. None.
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/19_adr_and_architecture_update.md
+++ b/llms/tasks/0004_implement_lemming_management/19_adr_and_architecture_update.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [X] Human sign-off
-- **Blocked by**: None
-- **Blocks**: Task 20
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
+- **Blocked by**: Task 01, Task 02, Task 03, Task 04, Task 05
+- **Blocks**: Task 15, Task 16, Task 17, Task 18, Task 20
 - **Estimated Effort**: M
 
 ## Assigned Agent
@@ -89,45 +89,39 @@ The following docs are mandatory review targets for this task:
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Reviewed the live architecture docs against the intended long-term product contract for hierarchical agents, runtime execution, and tool governance.
-- Restored the ADRs and overview docs so they describe the full runtime platform rather than a control-plane-only or branch-specific subset.
-- Kept implementation sequencing isolated as a non-normative note where the docs needed it.
+- [What was actually done]
 
 ### Outputs Created
 
-- Updated `docs/adr/0020-hierarchical-configuration-model.md`
-- Updated `docs/adr/0021-core-domain-schema.md`
-- Updated `docs/architecture.md`
-- Updated `README.md`
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| Task 19 should track the intended product contract, not the branch's temporary implementation shape | ADRs are architectural documents, so they must describe the long-term runtime model. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Restore the full hierarchical runtime model in ADRs | Narrowing the docs to current branch state would weaken the architectural contract. |
-| Keep implementation sequencing separate from the normative architecture | Branch-specific shapes should not redefine the product model. |
 
 ### Blockers Encountered
 
-- None
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-- None
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/llms/tasks/0004_implement_lemming_management/20_final_pr_audit.md
+++ b/llms/tasks/0004_implement_lemming_management/20_final_pr_audit.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: COMPLETE
-- **Approved**: [x] Human sign-off
+- **Status**: BLOCKED
+- **Approved**: [ ] Human sign-off
 - **Blocked by**: Task 18, Task 19
 - **Blocks**: None
 - **Estimated Effort**: S
@@ -61,128 +61,39 @@ Provide the last independent review pass after validation, review, and ADR/doc w
 
 ## Execution Summary
 
+*[Filled by executing agent after completion]*
+
 ### Work Performed
 
-- Reviewed the full branch diff (90 files, ~12,500 lines added/changed) against `main`.
-- Verified `mix test` passes: 37 doctests, 299 tests, 0 failures.
-- Verified `mix format --check-formatted` passes with no drift.
-- Verified `mix credo` passes with no issues.
-- Read all prior task execution summaries (Tasks 17-19).
-- Audited implementation (context, schema, migration, resolver, import/export), LiveView layers, tests, factory, router, page snapshots, and docs.
-- Identified findings ordered by severity below.
-
-### Findings
-
-#### MAJOR
-
-**M1. `inheriting_all_configuration?` always returns false due to empty-list handling in `prune_override`**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os_web/live/lemmings_live.ex`, lines 332-375
-- **Why it matters**: `prune_override/1` strips `nil` values and recursively prunes empty maps, but it does not strip empty lists. `ToolsConfig` defaults to `%ToolsConfig{allowed_tools: [], denied_tools: []}`. After `Map.from_struct/1`, that becomes `%{allowed_tools: [], denied_tools: []}`. Since `[]` is not `nil` and not a map, `prune_override` keeps both keys, so the tools bucket never prunes to `%{}`. This means `inheriting_all_configuration?/1` always returns `false` for every lemming, even when no local overrides exist. The UI will never show the "inheriting all configuration" state.
-- **Suggested fix**: Add a clause to `prune_override` that strips empty-list values: `{_key, []}, acc -> acc`. Alternatively, handle `[]` alongside `nil` in the reduce clause. Add a test that asserts a freshly-inserted lemming with no config overrides returns `inheriting? == true`.
-
-**M2. `world_components.ex` still calls `MockData.lemmings_for_department/1`**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os_web/components/world_components.ex`, line 621
-- **Why it matters**: The plan goal explicitly states "a real Department-scoped Lemming listing replacing the current mock-backed `department_lemming_preview`". The `department_room/1` component still calls `MockData.lemmings_for_department(assigns.department.id)` to render lemming sprites. This means the World page visualization of lemmings within departments remains mock-backed, not persisted-data-backed. This is a plan-completeness gap.
-- **Suggested fix**: Replace with `Lemmings.list_lemmings(assigns.department)` (requires the department struct to be available, which it already is). If the sprite component expects mock-shaped data, adapt the mapping.
-
-**M3. Duplicated hierarchy validation helpers across `Lemmings` and `ImportExport`**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os/lemmings.ex` lines 281-292; `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os/lemmings/import_export.ex` lines 160-171
-- **Why it matters**: `validate_city_in_world/2` and `validate_department_in_city_world/3` are copy-pasted between the two modules. If one gets a bug fix (like the error atom being corrected), the other may be missed. This is a maintenance hazard.
-- **Suggested fix**: Extract these into a shared private helper in the `Lemmings` context and delegate from `ImportExport`, or have `ImportExport.import_lemmings/4` delegate to `Lemmings.create_lemming/4` for all validation (which it already does inside `import_records/4`, making the pre-validation in `ImportExport` redundant-but-advisory). At minimum, label this as a follow-up.
-
-#### MINOR
-
-**m1. `get_lemming/2` is not World-scoped**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os/lemmings.ex` lines 72-79
-- **Why it matters**: The constitution states "Context APIs for World-scoped resources MUST require an explicit `world_id` (or `%World{}` struct) as a parameter." `get_lemming/2` takes a UUID and optional opts but does not require a World scope. The existing `get_department!` follows the same pattern (ID-only), so this is a pre-existing convention in the codebase, but it is worth noting for consistency with the constitution's intent.
-- **Suggested fix**: Accept as-is for this branch since it follows the established `get_department!` pattern. Consider a follow-up to add `world_id` scoping to both `get_lemming` and `get_department!` for defense-in-depth.
-
-**m2. `Jason.encode!` in `export_lemming` event handler**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os_web/live/lemmings_live.ex` line 106
-- **Why it matters**: `Jason.encode!/2` will raise on encoding failure. The data comes from a persisted Ecto struct (already validated), so the risk is low, but if a config embed contains a value that Jason cannot serialize (e.g., a tuple or PID that leaked in), this would crash the LiveView process. The constitution flags `Jason.encode!/1` in hot paths with bad data risk.
-- **Suggested fix**: Risk is low given the data source is a controlled export map. Acceptable as-is. If paranoid, wrap in `Jason.encode/2` and handle `:error`.
-
-**m3. `CreateLemmingLive` and `ImportLemmingLive` use `get_department!/2` with rescue**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os_web/live/create_lemming_live.ex` lines 76-108; `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os_web/live/import_lemming_live.ex` lines 148-173
-- **Why it matters**: Using `get_department!/2` with a `rescue Ecto.NoResultsError` is an anti-pattern per the constitution. The `fetch_department/2` function exists and returns `{:ok, dept} | {:error, :not_found}`, which would be cleaner.
-- **Suggested fix**: Replace `get_department!/2 ... rescue Ecto.NoResultsError` with `case Departments.fetch_department(id, preload: ...) do {:ok, dept} -> ...; {:error, :not_found} -> ... end`. This is a style/safety improvement, not blocking.
-
-**m4. `ToolsConfig.changeset/2` does not validate list element types**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os/config/tools_config.ex` lines 24-27
-- **Why it matters**: `allowed_tools` and `denied_tools` are `{:array, :string}` fields cast from user input. Ecto will coerce types at the DB layer, but there is no application-level validation that elements are non-empty strings or follow a naming convention. An import payload with `"allowed_tools": [null, 123, ""]` would silently persist.
-- **Suggested fix**: Add `validate_change/3` or a custom validator for list elements if tool names have a required format. Acceptable to defer.
-
-#### NITS
-
-**n1. Resolver has many pattern-matching clauses for Lemming association loading states**
-
-- **Where**: `/mnt/data4/matt/code/personal_stuffs/lemmings-os/lib/lemmings_os/config/resolver.ex` lines 117-171
-- **Why it matters**: Five separate function heads handle various combinations of `%Ecto.Association.NotLoaded{}` and `nil` on the Lemming's nested associations. This is correct but verbose. A single entry clause that normalizes the chain before delegating to the terminal resolver clause would reduce surface area.
-- **Suggested fix**: Extract a `normalize_lemming_chain/1` helper that ensures all parents are loaded, then have one resolver clause for the fully-loaded case. Low priority.
-
-### Residual Risk Summary
-
-| Risk | Severity | Mitigation |
-|------|----------|------------|
-| `inheriting_all_configuration?` always returns false (M1) | Medium | UI cosmetic -- shows "has overrides" badge when none exist. No data corruption. Fix is a one-line clause addition. |
-| `department_room` still mock-backed (M2) | Medium | Affects World page visualization only. Core Lemming CRUD, listing, and import/export all use real data. Scoped follow-up. |
-| Duplicated validation helpers (M3) | Low | Both copies are identical and tested. Risk is divergence over time. |
-| `get_lemming` not World-scoped (m1) | Low | Matches existing `get_department!` pattern. No cross-world leakage risk in current UI flows. |
-| `get_department!` with rescue (m3) | Low | Functional, just not idiomatic. No user-facing impact. |
-
-### Merge-Readiness Recommendation
-
-**MERGE-READY with caveats.**
-
-The branch is in a clean, passing state: 37 doctests, 299 tests, 0 failures, clean formatting, clean Credo. The core implementation -- schema, migration, context APIs, config resolver extension, import/export, LiveView CRUD, lifecycle management, and test coverage -- is solid and well-structured.
-
-The three MAJOR findings (M1, M2, M3) are all non-blocking for a merge:
-
-- M1 is a UI cosmetic issue (badge state) with a one-line fix.
-- M2 is a plan-completeness gap on a component not central to Lemming management itself.
-- M3 is a maintenance concern, not a correctness issue.
-
-All three can be addressed in an immediate follow-up commit before or after merge at the human's discretion. None introduce data corruption, security exposure, or runtime failure risk.
+- [What was actually done]
 
 ### Outputs Created
 
-- Updated `llms/tasks/0004_implement_lemming_management/20_final_pr_audit.md` (this file)
+- [List of files/artifacts created]
 
 ### Assumptions Made
 
 | Assumption | Rationale |
 |------------|-----------|
-| The `department_room` component in `world_components.ex` is in scope for the plan's desmoke goals | The plan explicitly calls out replacing mock-backed lemming listings, and this component renders lemmings for a department on the World page. |
-| The `get_department!` with rescue pattern is a pre-existing convention, not introduced by this branch | The Departments context already had this pattern before this branch. |
 
 ### Decisions Made
 
 | Decision | Alternatives Considered | Rationale |
 |----------|------------------------|-----------|
-| Classify M1 as MAJOR not BLOCKER | Could require fix before merge | The impact is cosmetic (badge display), not data integrity. A one-line fix can land immediately. |
-| Classify M2 as MAJOR not BLOCKER | Could block merge until World page desmoke is complete | The component is on the World page, not the Lemmings page. Core Lemming management flows all use real data. |
-| Recommend MERGE-READY | Could recommend NOT READY pending M1/M2 fixes | All quality gates pass, the core feature is complete and tested, and the remaining issues are low-risk follow-ups. |
 
 ### Blockers Encountered
 
-- None.
+- [Blocker 1] - Resolution: [How resolved or "Needs human input"]
 
 ### Questions for Human
 
-1. Do you want M1 (prune_override empty-list fix) and M2 (department_room desmoke) addressed in this branch before merge, or tracked as immediate follow-up work?
+1. [Question needing human input]
 
 ### Ready for Next Task
 
-- [x] All outputs complete
-- [x] Summary documented
-- [x] Questions listed (if any)
+- [ ] All outputs complete
+- [ ] Summary documented
+- [ ] Questions listed (if any)
 
 ---
 

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -10,28 +10,28 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/lemmings_os_web/components/layouts.ex:62
+#: lib/lemmings_os_web/components/layouts.ex:59
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr "Open navigation"
 
-#: lib/lemmings_os_web/components/layouts.ex:69
+#: lib/lemmings_os_web/components/layouts.ex:66
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr "LemmingsOS"
 
-#: lib/lemmings_os_web/components/layouts.ex:80
+#: lib/lemmings_os_web/components/layouts.ex:77
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr "MEM: %{value}"
 
-#: lib/lemmings_os_web/components/layouts.ex:81
+#: lib/lemmings_os_web/components/layouts.ex:78
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr "TICK: %{value}"
 
-#: lib/lemmings_os_web/components/layouts.ex:82
+#: lib/lemmings_os_web/components/layouts.ex:79
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr "AGENTS: %{current}/%{max}"
@@ -41,102 +41,100 @@ msgstr "AGENTS: %{current}/%{max}"
 msgid ".sidebar_eyebrow"
 msgstr "Cluster Control"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:146
+#: lib/lemmings_os_web/components/sidebar_components.ex:143
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:176
+#: lib/lemmings_os_web/components/sidebar_components.ex:173
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr "Operations"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/sidebar_components.ex:145
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr "Home"
 
-#: lib/lemmings_os_web/components/home_components.ex:220
-#: lib/lemmings_os_web/components/home_components.ex:224
-#: lib/lemmings_os_web/components/sidebar_components.ex:151
+#: lib/lemmings_os_web/components/home_components.ex:215
+#: lib/lemmings_os_web/components/home_components.ex:219
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:157
+#: lib/lemmings_os_web/components/sidebar_components.ex:154
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:163
+#: lib/lemmings_os_web/components/sidebar_components.ex:160
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:593
+#: lib/lemmings_os_web/components/sidebar_components.ex:166
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/home_components.ex:221
-#: lib/lemmings_os_web/components/sidebar_components.ex:180
+#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/sidebar_components.ex:177
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr "Tools"
 
-#: lib/lemmings_os_web/components/home_components.ex:222
-#: lib/lemmings_os_web/components/sidebar_components.ex:186
+#: lib/lemmings_os_web/components/home_components.ex:217
+#: lib/lemmings_os_web/components/sidebar_components.ex:183
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr "Logs"
 
-#: lib/lemmings_os_web/components/home_components.ex:223
-#: lib/lemmings_os_web/components/sidebar_components.ex:192
+#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/sidebar_components.ex:189
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr "Settings"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
-#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "New Lemming"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:79
+#: lib/lemmings_os_web/components/sidebar_components.ex:76
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr "Toggle sidebar"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:91
+#: lib/lemmings_os_web/components/sidebar_components.ex:88
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr "Agents"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:99
+#: lib/lemmings_os_web/components/sidebar_components.ex:96
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:107
+#: lib/lemmings_os_web/components/sidebar_components.ex:104
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr "CPU"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:115
+#: lib/lemmings_os_web/components/sidebar_components.ex:112
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr "Tools"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:126
+#: lib/lemmings_os_web/components/sidebar_components.ex:123
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr "Cluster online"
@@ -202,7 +200,7 @@ msgstr "Environment Notes"
 msgid ".page_title_home"
 msgstr "Home"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:21
+#: lib/lemmings_os_web/live/lemmings_live.ex:11
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
@@ -212,12 +210,12 @@ msgstr "Lemmings"
 msgid ".page_title_cities"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/live/departments_live.ex:17
+#: lib/lemmings_os_web/live/departments_live.ex:21
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/live/world_live.ex:18
+#: lib/lemmings_os_web/live/world_live.ex:16
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr "World"
@@ -499,19 +497,19 @@ msgstr "Some runtime tools still have partial policy state."
 msgid ".tools_policy_copy_unknown"
 msgstr "Policy state is not yet available."
 
-#: lib/lemmings_os_web/components/home_components.ex:226
+#: lib/lemmings_os_web/components/home_components.ex:221
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr "Deferred"
 
-#: lib/lemmings_os_web/components/home_components.ex:228
+#: lib/lemmings_os_web/components/home_components.ex:223
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr "Known"
 
-#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/components/home_components.ex:222
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -553,65 +551,65 @@ msgstr "Runtime Capability"
 msgid ".tools_usage_unknown"
 msgstr "Unknown"
 
-#: lib/lemmings_os_web/components/home_components.ex:260
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:262
+#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr "Import or recover the default World before relying on dashboard signals."
 
-#: lib/lemmings_os_web/components/home_components.ex:246
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
+#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr "Home cannot claim hierarchy or runtime coverage until a World is available."
 
-#: lib/lemmings_os_web/components/home_components.ex:232
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr "No persisted world available"
 
-#: lib/lemmings_os_web/components/home_components.ex:263
+#: lib/lemmings_os_web/components/home_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr "Treat tools policy as partial until reconciliation exists."
 
-#: lib/lemmings_os_web/components/home_components.ex:249
+#: lib/lemmings_os_web/components/home_components.ex:244
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr "Some runtime tools still have partial policy state."
 
-#: lib/lemmings_os_web/components/home_components.ex:235
+#: lib/lemmings_os_web/components/home_components.ex:230
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr "Tools policy reconciliation is partial"
 
-#: lib/lemmings_os_web/components/home_components.ex:266
+#: lib/lemmings_os_web/components/home_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr "Use runtime capability facts as primary until policy state is available."
 
-#: lib/lemmings_os_web/components/home_components.ex:252
+#: lib/lemmings_os_web/components/home_components.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr "Runtime tools are visible, but policy reconciliation could not be loaded."
 
-#: lib/lemmings_os_web/components/home_components.ex:238
+#: lib/lemmings_os_web/components/home_components.ex:233
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr "Tools policy state unavailable"
 
-#: lib/lemmings_os_web/components/home_components.ex:269
+#: lib/lemmings_os_web/components/home_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr "Verify the runtime capability source before relying on tool availability."
 
-#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/components/home_components.ex:250
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr "The page could not obtain runtime capability data from the current source."
 
-#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/components/home_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr "Runtime capability source unavailable"
@@ -747,23 +745,23 @@ msgstr "Core runtime signals, not fake operational breadth."
 msgid ".home_signals_title"
 msgstr "Trusted Signals"
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr "Bootstrap Config"
 
-#: lib/lemmings_os_web/components/home_components.ex:210
+#: lib/lemmings_os_web/components/home_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr "Persisted World"
 
-#: lib/lemmings_os_web/components/home_components.ex:212
-#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/home_components.ex:207
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr "Runtime Checks"
 
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:208
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr "Tools Snapshot"
@@ -813,12 +811,7 @@ msgstr "Departments"
 msgid ".home_card_topology_summary_title"
 msgstr "Topology Summary"
 
-#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
 msgstr "Persisted Topology"
-
-#: lib/lemmings_os_web/components/home_components.ex:203
-#, elixir-autogen, elixir-format
-msgid ".home_card_topology_lemming_count_label"
-msgstr "Lemmings"

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -10,28 +10,28 @@ msgid ""
 msgstr ""
 "Language: en\n"
 
-#: lib/lemmings_os_web/components/layouts.ex:59
+#: lib/lemmings_os_web/components/layouts.ex:62
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr "Open navigation"
 
-#: lib/lemmings_os_web/components/layouts.ex:66
+#: lib/lemmings_os_web/components/layouts.ex:69
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr "LemmingsOS"
 
-#: lib/lemmings_os_web/components/layouts.ex:77
+#: lib/lemmings_os_web/components/layouts.ex:80
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr "MEM: %{value}"
 
-#: lib/lemmings_os_web/components/layouts.ex:78
+#: lib/lemmings_os_web/components/layouts.ex:81
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr "TICK: %{value}"
 
-#: lib/lemmings_os_web/components/layouts.ex:79
+#: lib/lemmings_os_web/components/layouts.ex:82
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr "AGENTS: %{current}/%{max}"
@@ -41,100 +41,102 @@ msgstr "AGENTS: %{current}/%{max}"
 msgid ".sidebar_eyebrow"
 msgstr "Cluster Control"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:143
+#: lib/lemmings_os_web/components/sidebar_components.ex:146
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:173
+#: lib/lemmings_os_web/components/sidebar_components.ex:176
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr "Operations"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:145
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr "Home"
 
-#: lib/lemmings_os_web/components/home_components.ex:215
-#: lib/lemmings_os_web/components/home_components.ex:219
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/home_components.ex:220
+#: lib/lemmings_os_web/components/home_components.ex:224
+#: lib/lemmings_os_web/components/sidebar_components.ex:151
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:154
+#: lib/lemmings_os_web/components/sidebar_components.ex:157
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:160
+#: lib/lemmings_os_web/components/sidebar_components.ex:163
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:166
+#: lib/lemmings_os_web/components/sidebar_components.ex:169
+#: lib/lemmings_os_web/components/world_components.ex:593
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/home_components.ex:216
-#: lib/lemmings_os_web/components/sidebar_components.ex:177
+#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/sidebar_components.ex:180
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr "Tools"
 
-#: lib/lemmings_os_web/components/home_components.ex:217
-#: lib/lemmings_os_web/components/sidebar_components.ex:183
+#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/sidebar_components.ex:186
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr "Logs"
 
-#: lib/lemmings_os_web/components/home_components.ex:218
-#: lib/lemmings_os_web/components/sidebar_components.ex:189
+#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/sidebar_components.ex:192
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr "Settings"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
+#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "New Lemming"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:76
+#: lib/lemmings_os_web/components/sidebar_components.ex:79
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr "Toggle sidebar"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:88
+#: lib/lemmings_os_web/components/sidebar_components.ex:91
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr "Agents"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:96
+#: lib/lemmings_os_web/components/sidebar_components.ex:99
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:104
+#: lib/lemmings_os_web/components/sidebar_components.ex:107
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr "CPU"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:112
+#: lib/lemmings_os_web/components/sidebar_components.ex:115
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr "Tools"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:123
+#: lib/lemmings_os_web/components/sidebar_components.ex:126
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr "Cluster online"
@@ -200,7 +202,7 @@ msgstr "Environment Notes"
 msgid ".page_title_home"
 msgstr "Home"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:11
+#: lib/lemmings_os_web/live/lemmings_live.ex:21
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
@@ -497,19 +499,19 @@ msgstr "Some runtime tools still have partial policy state."
 msgid ".tools_policy_copy_unknown"
 msgstr "Policy state is not yet available."
 
-#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/home_components.ex:226
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr "Deferred"
 
-#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/home_components.ex:228
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr "Known"
 
-#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/home_components.ex:227
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -551,65 +553,65 @@ msgstr "Runtime Capability"
 msgid ".tools_usage_unknown"
 msgstr "Unknown"
 
-#: lib/lemmings_os_web/components/home_components.ex:255
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
+#: lib/lemmings_os_web/components/home_components.ex:260
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr "Import or recover the default World before relying on dashboard signals."
 
-#: lib/lemmings_os_web/components/home_components.ex:241
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
+#: lib/lemmings_os_web/components/home_components.ex:246
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:260
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr "Home cannot claim hierarchy or runtime coverage until a World is available."
 
-#: lib/lemmings_os_web/components/home_components.ex:227
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:232
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr "No persisted world available"
 
-#: lib/lemmings_os_web/components/home_components.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr "Treat tools policy as partial until reconciliation exists."
 
-#: lib/lemmings_os_web/components/home_components.ex:244
+#: lib/lemmings_os_web/components/home_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr "Some runtime tools still have partial policy state."
 
-#: lib/lemmings_os_web/components/home_components.ex:230
+#: lib/lemmings_os_web/components/home_components.ex:235
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr "Tools policy reconciliation is partial"
 
-#: lib/lemmings_os_web/components/home_components.ex:261
+#: lib/lemmings_os_web/components/home_components.ex:266
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr "Use runtime capability facts as primary until policy state is available."
 
-#: lib/lemmings_os_web/components/home_components.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:252
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr "Runtime tools are visible, but policy reconciliation could not be loaded."
 
-#: lib/lemmings_os_web/components/home_components.ex:233
+#: lib/lemmings_os_web/components/home_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr "Tools policy state unavailable"
 
-#: lib/lemmings_os_web/components/home_components.ex:264
+#: lib/lemmings_os_web/components/home_components.ex:269
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr "Verify the runtime capability source before relying on tool availability."
 
-#: lib/lemmings_os_web/components/home_components.ex:250
+#: lib/lemmings_os_web/components/home_components.ex:255
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr "The page could not obtain runtime capability data from the current source."
 
-#: lib/lemmings_os_web/components/home_components.ex:236
+#: lib/lemmings_os_web/components/home_components.ex:241
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr "Runtime capability source unavailable"
@@ -745,23 +747,23 @@ msgstr "Core runtime signals, not fake operational breadth."
 msgid ".home_signals_title"
 msgstr "Trusted Signals"
 
-#: lib/lemmings_os_web/components/home_components.ex:206
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr "Bootstrap Config"
 
-#: lib/lemmings_os_web/components/home_components.ex:205
+#: lib/lemmings_os_web/components/home_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr "Persisted World"
 
-#: lib/lemmings_os_web/components/home_components.ex:207
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:212
+#: lib/lemmings_os_web/components/home_components.ex:218
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr "Runtime Checks"
 
-#: lib/lemmings_os_web/components/home_components.ex:208
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr "Tools Snapshot"
@@ -811,7 +813,12 @@ msgstr "Departments"
 msgid ".home_card_topology_summary_title"
 msgstr "Topology Summary"
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
 msgstr "Persisted Topology"
+
+#: lib/lemmings_os_web/components/home_components.ex:203
+#, elixir-autogen, elixir-format
+msgid ".home_card_topology_lemming_count_label"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/en/LC_MESSAGES/lemmings.po
@@ -354,8 +354,8 @@ msgid ".empty_create_missing_department_copy"
 msgstr "Select a city and department to create the new lemming in the right topology scope."
 
 #: lib/lemmings_os_web/live/create_lemming_live.ex:72
-#: lib/lemmings_os_web/live/import_lemming_live.ex:171
-#: lib/lemmings_os_web/live/import_lemming_live.ex:177
+#: lib/lemmings_os_web/live/import_lemming_live.ex:152
+#: lib/lemmings_os_web/live/import_lemming_live.ex:178
 #, elixir-autogen, elixir-format
 msgid ".flash_create_scope_invalid"
 msgstr "The selected department does not belong to the expected city or world scope."
@@ -427,34 +427,34 @@ msgid ".flash_export_no_lemming"
 msgstr "No lemming selected for export."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:114
-#: lib/lemmings_os_web/live/import_lemming_live.ex:235
+#: lib/lemmings_os_web/live/import_lemming_live.ex:236
 #, elixir-autogen
 msgid ".flash_import_success"
 msgstr "Imported %{count} lemming(s) successfully."
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:218
-#: lib/lemmings_os_web/live/import_lemming_live.ex:222
+#: lib/lemmings_os_web/live/import_lemming_live.ex:219
+#: lib/lemmings_os_web/live/import_lemming_live.ex:223
 #, elixir-autogen
 msgid ".error_import_invalid_json"
 msgstr "The pasted text is not valid JSON. Check for syntax errors and try again."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:124
-#: lib/lemmings_os_web/live/import_lemming_live.ex:246
+#: lib/lemmings_os_web/live/import_lemming_live.ex:247
 #, elixir-autogen
 msgid ".error_import_unsupported_version"
 msgstr "Unsupported schema version. Only version 1 exports are supported."
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:273
-#: lib/lemmings_os_web/live/import_lemming_live.ex:281
-#: lib/lemmings_os_web/live/import_lemming_live.ex:288
+#: lib/lemmings_os_web/live/import_lemming_live.ex:274
+#: lib/lemmings_os_web/live/import_lemming_live.ex:282
+#: lib/lemmings_os_web/live/import_lemming_live.ex:289
 #, elixir-autogen
 msgid ".error_import_record_invalid"
 msgstr "Record %{index} is invalid: %{errors}."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:131
-#: lib/lemmings_os_web/live/import_lemming_live.ex:253
-#: lib/lemmings_os_web/live/import_lemming_live.ex:290
-#: lib/lemmings_os_web/live/import_lemming_live.ex:295
+#: lib/lemmings_os_web/live/import_lemming_live.ex:254
+#: lib/lemmings_os_web/live/import_lemming_live.ex:291
+#: lib/lemmings_os_web/live/import_lemming_live.ex:296
 #, elixir-autogen
 msgid ".error_import_failed"
 msgstr "Import failed. Check the JSON payload and try again."

--- a/priv/gettext/en/LC_MESSAGES/world.po
+++ b/priv/gettext/en/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Unknown"
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1071
-#: lib/lemmings_os_web/components/world_components.ex:1101
-#: lib/lemmings_os_web/components/world_components.ex:1118
-#: lib/lemmings_os_web/components/world_components.ex:1135
-#: lib/lemmings_os_web/components/world_components.ex:1139
-#: lib/lemmings_os_web/components/world_components.ex:1160
+#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1075
+#: lib/lemmings_os_web/components/world_components.ex:1092
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1117
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "Not available"
@@ -53,7 +53,7 @@ msgstr "Not available"
 msgid ".label_not_imported"
 msgstr "Not imported yet"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:164
+#: lib/lemmings_os_web/components/city_map_components.ex:166
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr "City map"
@@ -63,7 +63,7 @@ msgstr "City map"
 msgid ".aria_city_node"
 msgstr "City node"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:35
+#: lib/lemmings_os_web/components/city_map_components.ex:37
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr "Department node"
@@ -73,8 +73,7 @@ msgstr "Department node"
 msgid ".aria_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:670
-#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
+#: lib/lemmings_os_web/components/world_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "All Departments"
@@ -85,7 +84,7 @@ msgstr "All Departments"
 msgid ".button_import_bootstrap"
 msgstr "Import bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:624
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Open department"
@@ -106,26 +105,26 @@ msgstr "The city summary will appear here once a real source exists."
 msgid ".copy_world_tools_placeholder"
 msgstr "The tools summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departments"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:136
+#: lib/lemmings_os_web/components/city_map_components.ex:138
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr "%{running} of %{total} running"
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/live/departments_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "No departments yet"
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:123
+#: lib/lemmings_os_web/live/departments_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Create or import a department to see it here."
@@ -157,27 +156,27 @@ msgstr "Bootstrap source"
 msgid ".label_budgets"
 msgstr "Budgets"
 
-#: lib/lemmings_os_web/components/world_components.ex:1094
+#: lib/lemmings_os_web/components/world_components.ex:1051
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1090
+#: lib/lemmings_os_web/components/world_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1099
+#: lib/lemmings_os_web/components/world_components.ex:1056
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declared"
 
-#: lib/lemmings_os_web/components/world_components.ex:1083
+#: lib/lemmings_os_web/components/world_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Depts."
 
-#: lib/lemmings_os_web/components/world_components.ex:645
+#: lib/lemmings_os_web/components/world_components.ex:639
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Empty"
@@ -206,7 +205,7 @@ msgstr "Last imported at"
 msgid ".label_last_sync"
 msgstr "Last sync"
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
@@ -217,7 +216,7 @@ msgstr "Lemms."
 msgid ".label_limits"
 msgstr "Limits"
 
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:1030
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "No fallbacks"
@@ -244,17 +243,17 @@ msgstr "Placeholder sections"
 msgid ".label_profiles"
 msgstr "Profiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1146
+#: lib/lemmings_os_web/components/world_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credentials ready"
 
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Provider disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Provider enabled"
@@ -264,7 +263,7 @@ msgstr "Provider enabled"
 msgid ".label_providers"
 msgstr "Providers"
 
-#: lib/lemmings_os_web/components/world_components.ex:644
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Queue"
@@ -275,39 +274,43 @@ msgstr "Queue"
 msgid ".label_runtime_defaults"
 msgstr "Runtime defaults"
 
-#: lib/lemmings_os_web/components/world_components.ex:1155
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Runtime deferred"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "World ID"
 
-#: lib/lemmings_os_web/components/world_components.ex:723
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr "World slug"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:192
+#: lib/lemmings_os_web/components/city_map_components.ex:194
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr "Department"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:177
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
+#, elixir-autogen, elixir-format
+msgid ".metric_agents"
+msgstr "Agents"
+
+#: lib/lemmings_os_web/components/city_map_components.ex:179
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:181
+#: lib/lemmings_os_web/components/city_map_components.ex:183
 #: lib/lemmings_os_web/components/city_map_components.ex:251
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr "Lemmings"
@@ -322,47 +325,47 @@ msgstr "Nodes"
 msgid ".metric_online"
 msgstr "Online"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:185
+#: lib/lemmings_os_web/components/city_map_components.ex:187
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/world_components.ex:1121
+#: lib/lemmings_os_web/components/world_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Bootstrap file"
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Postgres connection"
 
-#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Provider credentials"
 
-#: lib/lemmings_os_web/components/world_components.ex:1130
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Provider reachability"
 
-#: lib/lemmings_os_web/components/core_components.ex:578
-#: lib/lemmings_os_web/components/core_components.ex:581
+#: lib/lemmings_os_web/components/core_components.ex:573
+#: lib/lemmings_os_web/components/core_components.ex:576
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr "Degraded"
 
-#: lib/lemmings_os_web/components/core_components.ex:579
-#: lib/lemmings_os_web/components/core_components.ex:582
+#: lib/lemmings_os_web/components/core_components.ex:574
+#: lib/lemmings_os_web/components/core_components.ex:577
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr "Offline"
 
-#: lib/lemmings_os_web/components/core_components.ex:577
-#: lib/lemmings_os_web/components/core_components.ex:580
+#: lib/lemmings_os_web/components/core_components.ex:572
+#: lib/lemmings_os_web/components/core_components.ex:575
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -406,7 +409,7 @@ msgid ".title_bootstrap_config"
 msgstr "Bootstrap config"
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:111
+#: lib/lemmings_os_web/live/departments_live.html.heex:109
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departments"
@@ -431,7 +434,7 @@ msgstr "World cities"
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:712
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "World identity"
@@ -471,7 +474,7 @@ msgstr "Running"
 msgid ".copy_city_effective_config"
 msgstr "Resolved from the persisted World and City layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:713
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -530,6 +533,11 @@ msgstr "BEAM node"
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
+
+#: lib/lemmings_os_web/components/world_components.ex:800
+#, elixir-autogen
+msgid ".label_mock_backed_preview"
+msgstr "Mock-backed preview"
 
 #: lib/lemmings_os_web/components/world_components.ex:523
 #, elixir-autogen
@@ -601,7 +609,7 @@ msgstr "BEAM node name"
 msgid ".city_form_node_name_placeholder"
 msgstr "e.g. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:708
+#: lib/lemmings_os_web/components/world_components.ex:702
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -642,12 +650,12 @@ msgstr "Create city"
 msgid ".city_form_submit_update"
 msgstr "Save changes"
 
-#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/cities_live.ex:184
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "City created."
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/cities_live.ex:209
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "City updated."
@@ -663,8 +671,8 @@ msgstr "City deleted."
 msgid ".flash_city_not_found"
 msgstr "City not found."
 
-#: lib/lemmings_os_web/live/cities_live.ex:191
-#: lib/lemmings_os_web/live/cities_live.ex:216
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/cities_live.ex:219
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "Could not save city. Check the form for errors."
@@ -674,7 +682,7 @@ msgstr "Could not save city. Check the form for errors."
 msgid ".flash_city_delete_error"
 msgstr "Could not delete city."
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:605
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Open Departments"
@@ -689,242 +697,216 @@ msgstr "%{city} has %{count} departments."
 msgid ".copy_city_departments_summary"
 msgstr "Compact summary of persisted departments for this city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:86
+#: lib/lemmings_os_web/live/departments_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Change the city scope for the map and department list."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:85
-#: lib/lemmings_os_web/live/departments_live.html.heex:104
+#: lib/lemmings_os_web/live/departments_live.html.heex:83
+#: lib/lemmings_os_web/live/departments_live.html.heex:102
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "Selected City"
 
-#: lib/lemmings_os_web/components/world_components.ex:762
+#: lib/lemmings_os_web/components/world_components.ex:756
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activate"
 
-#: lib/lemmings_os_web/components/world_components.ex:790
+#: lib/lemmings_os_web/components/world_components.ex:784
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Delete"
 
-#: lib/lemmings_os_web/components/world_components.ex:780
+#: lib/lemmings_os_web/components/world_components.ex:774
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Disable"
 
-#: lib/lemmings_os_web/components/world_components.ex:771
+#: lib/lemmings_os_web/components/world_components.ex:765
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drain"
 
-#: lib/lemmings_os_web/components/world_components.ex:998
+#: lib/lemmings_os_web/components/world_components.ex:955
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Save settings"
 
-#: lib/lemmings_os_web/components/world_components.ex:787
+#: lib/lemmings_os_web/components/world_components.ex:781
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "Are you sure you want to delete this department?"
 
-#: lib/lemmings_os_web/components/world_components.ex:734
+#: lib/lemmings_os_web/components/world_components.ex:728
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/world_components.ex:744
+#: lib/lemmings_os_web/components/world_components.ex:738
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notes"
 
-#: lib/lemmings_os_web/components/world_components.ex:739
+#: lib/lemmings_os_web/components/world_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:824
+#: lib/lemmings_os_web/components/world_components.ex:806
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No lemmings available"
 
-#: lib/lemmings_os_web/components/world_components.ex:825
+#: lib/lemmings_os_web/components/world_components.ex:807
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "No runtime-backed or mock preview lemmings are available for this department yet."
 
-#: lib/lemmings_os_web/components/world_components.ex:800
+#: lib/lemmings_os_web/components/world_components.ex:795
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_mock_copy"
+msgstr "This tab is still mock-backed. It previews likely department lemmings without claiming persisted runtime membership."
+
+#: lib/lemmings_os_web/components/world_components.ex:794
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:745
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Lifecycle actions"
 
-#: lib/lemmings_os_web/components/world_components.ex:752
+#: lib/lemmings_os_web/components/world_components.ex:746
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Use the persisted department lifecycle controls. Delete remains guarded by safety checks."
 
-#: lib/lemmings_os_web/components/world_components.ex:730
+#: lib/lemmings_os_web/components/world_components.ex:724
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadata"
 
-#: lib/lemmings_os_web/components/world_components.ex:893
-#: lib/lemmings_os_web/components/world_components.ex:926
-#: lib/lemmings_os_web/components/world_components.ex:975
+#: lib/lemmings_os_web/components/world_components.ex:850
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:932
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:898
-#: lib/lemmings_os_web/components/world_components.ex:935
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:855
+#: lib/lemmings_os_web/components/world_components.ex:892
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:979
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:978
+#: lib/lemmings_os_web/components/world_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:888
-#: lib/lemmings_os_web/components/world_components.ex:919
-#: lib/lemmings_os_web/components/world_components.ex:969
+#: lib/lemmings_os_web/components/world_components.ex:845
+#: lib/lemmings_os_web/components/world_components.ex:876
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Idle TTL seconds"
 
-#: lib/lemmings_os_web/components/world_components.ex:977
+#: lib/lemmings_os_web/components/world_components.ex:934
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Inherit"
 
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:910
-#: lib/lemmings_os_web/components/world_components.ex:960
+#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Max lemmings per department"
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:836
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Effective values after resolving World, City, and Department layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:878
+#: lib/lemmings_os_web/components/world_components.ex:835
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Effective config"
 
-#: lib/lemmings_os_web/components/world_components.ex:906
+#: lib/lemmings_os_web/components/world_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Only Department-local overrides persisted on this row. Empty values inherit from City or World."
 
-#: lib/lemmings_os_web/components/world_components.ex:905
+#: lib/lemmings_os_web/components/world_components.ex:862
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Local overrides"
 
-#: lib/lemmings_os_web/components/world_components.ex:946
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "V1 editor. This safely updates a narrow subset of Department-local overrides."
 
-#: lib/lemmings_os_web/components/world_components.ex:945
+#: lib/lemmings_os_web/components/world_components.ex:902
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Settings editor"
 
-#: lib/lemmings_os_web/components/world_components.ex:691
+#: lib/lemmings_os_web/components/world_components.ex:685
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:682
+#: lib/lemmings_os_web/components/world_components.ex:676
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:700
+#: lib/lemmings_os_web/components/world_components.ex:694
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Settings"
 
-#: lib/lemmings_os_web/live/departments_live.ex:303
+#: lib/lemmings_os_web/live/departments_live.ex:326
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Department activated."
 
-#: lib/lemmings_os_web/live/departments_live.ex:92
+#: lib/lemmings_os_web/live/departments_live.ex:96
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Department deleted."
 
-#: lib/lemmings_os_web/live/departments_live.ex:305
+#: lib/lemmings_os_web/live/departments_live.ex:328
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Department disabled."
 
-#: lib/lemmings_os_web/live/departments_live.ex:304
+#: lib/lemmings_os_web/live/departments_live.ex:327
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Department set to draining."
 
-#: lib/lemmings_os_web/live/departments_live.ex:106
+#: lib/lemmings_os_web/live/departments_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "Could not update the department lifecycle."
 
-#: lib/lemmings_os_web/live/departments_live.ex:76
+#: lib/lemmings_os_web/live/departments_live.ex:80
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Department settings saved."
 
-#: lib/lemmings_os_web/live/departments_live.ex:306
+#: lib/lemmings_os_web/live/departments_live.ex:329
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Department updated."
-
-#: lib/lemmings_os_web/components/world_components.ex:801
-#, elixir-autogen, elixir-format, fuzzy
-msgid ".department_lemmings_copy"
-msgstr "No lemmings available"
-
-#: lib/lemmings_os_web/components/world_components.ex:809
-#, elixir-autogen
-msgid ".button_import_lemmings"
-msgstr "Import JSON"
-
-msgid ".import_lemmings_title"
-msgstr "Import Lemmings from JSON"
-
-msgid ".import_lemmings_copy"
-msgstr "Paste a single lemming object or a JSON array of lemmings exported from another department. The import is validated before persisting."
-
-msgid ".import_lemmings_label_json"
-msgstr "JSON Payload"
-
-msgid ".import_lemmings_placeholder"
-msgstr "{\"schema_version\": 1, \"name\": \"...\", \"slug\": \"...\", \"status\": \"draft\"}"
-
-msgid ".button_import_cancel"
-msgstr "Cancel"
-
-msgid ".button_import_submit"
-msgstr "Import"
-
-msgid ".button_import_importing"
-msgstr "Importing..."

--- a/priv/gettext/en/LC_MESSAGES/world.po
+++ b/priv/gettext/en/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Unknown"
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1028
-#: lib/lemmings_os_web/components/world_components.ex:1058
-#: lib/lemmings_os_web/components/world_components.ex:1075
-#: lib/lemmings_os_web/components/world_components.ex:1092
-#: lib/lemmings_os_web/components/world_components.ex:1096
-#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1071
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1135
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1160
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "Not available"
@@ -53,7 +53,7 @@ msgstr "Not available"
 msgid ".label_not_imported"
 msgstr "Not imported yet"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:166
+#: lib/lemmings_os_web/components/city_map_components.ex:164
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr "City map"
@@ -63,7 +63,7 @@ msgstr "City map"
 msgid ".aria_city_node"
 msgstr "City node"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:37
+#: lib/lemmings_os_web/components/city_map_components.ex:35
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr "Department node"
@@ -73,7 +73,8 @@ msgstr "Department node"
 msgid ".aria_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:664
+#: lib/lemmings_os_web/components/world_components.ex:670
+#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "All Departments"
@@ -84,7 +85,7 @@ msgstr "All Departments"
 msgid ".button_import_bootstrap"
 msgstr "Import bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:624
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Open department"
@@ -105,26 +106,26 @@ msgstr "The city summary will appear here once a real source exists."
 msgid ".copy_world_tools_placeholder"
 msgstr "The tools summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:113
+#: lib/lemmings_os_web/live/departments_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departments"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:138
+#: lib/lemmings_os_web/components/city_map_components.ex:136
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr "%{running} of %{total} running"
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:120
+#: lib/lemmings_os_web/live/departments_live.html.heex:122
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "No departments yet"
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:121
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Create or import a department to see it here."
@@ -156,27 +157,27 @@ msgstr "Bootstrap source"
 msgid ".label_budgets"
 msgstr "Budgets"
 
-#: lib/lemmings_os_web/components/world_components.ex:1051
+#: lib/lemmings_os_web/components/world_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1047
+#: lib/lemmings_os_web/components/world_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1056
+#: lib/lemmings_os_web/components/world_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declared"
 
-#: lib/lemmings_os_web/components/world_components.ex:1040
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Depts."
 
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:645
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Empty"
@@ -205,7 +206,7 @@ msgstr "Last imported at"
 msgid ".label_last_sync"
 msgstr "Last sync"
 
-#: lib/lemmings_os_web/components/world_components.ex:1041
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
@@ -216,7 +217,7 @@ msgstr "Lemms."
 msgid ".label_limits"
 msgstr "Limits"
 
-#: lib/lemmings_os_web/components/world_components.ex:1030
+#: lib/lemmings_os_web/components/world_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "No fallbacks"
@@ -243,17 +244,17 @@ msgstr "Placeholder sections"
 msgid ".label_profiles"
 msgstr "Profiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1103
+#: lib/lemmings_os_web/components/world_components.ex:1146
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credentials ready"
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Provider disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1026
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Provider enabled"
@@ -263,7 +264,7 @@ msgstr "Provider enabled"
 msgid ".label_providers"
 msgstr "Providers"
 
-#: lib/lemmings_os_web/components/world_components.ex:638
+#: lib/lemmings_os_web/components/world_components.ex:644
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Queue"
@@ -274,43 +275,39 @@ msgstr "Queue"
 msgid ".label_runtime_defaults"
 msgstr "Runtime defaults"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Runtime deferred"
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1112
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "World ID"
 
-#: lib/lemmings_os_web/components/world_components.ex:717
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:723
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr "World slug"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:194
+#: lib/lemmings_os_web/components/city_map_components.ex:192
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr "Department"
 
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
-#, elixir-autogen, elixir-format
-msgid ".metric_agents"
-msgstr "Agents"
-
-#: lib/lemmings_os_web/components/city_map_components.ex:179
+#: lib/lemmings_os_web/components/city_map_components.ex:177
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:183
+#: lib/lemmings_os_web/components/city_map_components.ex:181
 #: lib/lemmings_os_web/components/city_map_components.ex:251
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr "Lemmings"
@@ -325,47 +322,47 @@ msgstr "Nodes"
 msgid ".metric_online"
 msgstr "Online"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:187
+#: lib/lemmings_os_web/components/city_map_components.ex:185
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/world_components.ex:1078
+#: lib/lemmings_os_web/components/world_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Bootstrap file"
 
-#: lib/lemmings_os_web/components/world_components.ex:1081
+#: lib/lemmings_os_web/components/world_components.ex:1124
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Postgres connection"
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Provider credentials"
 
-#: lib/lemmings_os_web/components/world_components.ex:1087
+#: lib/lemmings_os_web/components/world_components.ex:1130
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Provider reachability"
 
-#: lib/lemmings_os_web/components/core_components.ex:573
-#: lib/lemmings_os_web/components/core_components.ex:576
+#: lib/lemmings_os_web/components/core_components.ex:578
+#: lib/lemmings_os_web/components/core_components.ex:581
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr "Degraded"
 
-#: lib/lemmings_os_web/components/core_components.ex:574
-#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:579
+#: lib/lemmings_os_web/components/core_components.ex:582
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr "Offline"
 
-#: lib/lemmings_os_web/components/core_components.ex:572
-#: lib/lemmings_os_web/components/core_components.ex:575
+#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:580
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -409,7 +406,7 @@ msgid ".title_bootstrap_config"
 msgstr "Bootstrap config"
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:109
+#: lib/lemmings_os_web/live/departments_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departments"
@@ -434,7 +431,7 @@ msgstr "World cities"
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:712
+#: lib/lemmings_os_web/components/world_components.ex:718
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "World identity"
@@ -474,7 +471,7 @@ msgstr "Running"
 msgid ".copy_city_effective_config"
 msgstr "Resolved from the persisted World and City layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:707
+#: lib/lemmings_os_web/components/world_components.ex:713
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -533,11 +530,6 @@ msgstr "BEAM node"
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
-
-#: lib/lemmings_os_web/components/world_components.ex:800
-#, elixir-autogen
-msgid ".label_mock_backed_preview"
-msgstr "Mock-backed preview"
 
 #: lib/lemmings_os_web/components/world_components.ex:523
 #, elixir-autogen
@@ -609,7 +601,7 @@ msgstr "BEAM node name"
 msgid ".city_form_node_name_placeholder"
 msgstr "e.g. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:702
+#: lib/lemmings_os_web/components/world_components.ex:708
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -682,7 +674,7 @@ msgstr "Could not save city. Check the form for errors."
 msgid ".flash_city_delete_error"
 msgstr "Could not delete city."
 
-#: lib/lemmings_os_web/components/world_components.ex:605
+#: lib/lemmings_os_web/components/world_components.ex:611
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Open Departments"
@@ -697,186 +689,181 @@ msgstr "%{city} has %{count} departments."
 msgid ".copy_city_departments_summary"
 msgstr "Compact summary of persisted departments for this city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:84
+#: lib/lemmings_os_web/live/departments_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Change the city scope for the map and department list."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:83
-#: lib/lemmings_os_web/live/departments_live.html.heex:102
+#: lib/lemmings_os_web/live/departments_live.html.heex:85
+#: lib/lemmings_os_web/live/departments_live.html.heex:104
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "Selected City"
 
-#: lib/lemmings_os_web/components/world_components.ex:756
+#: lib/lemmings_os_web/components/world_components.ex:762
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activate"
 
-#: lib/lemmings_os_web/components/world_components.ex:784
+#: lib/lemmings_os_web/components/world_components.ex:790
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Delete"
 
-#: lib/lemmings_os_web/components/world_components.ex:774
+#: lib/lemmings_os_web/components/world_components.ex:780
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Disable"
 
-#: lib/lemmings_os_web/components/world_components.ex:765
+#: lib/lemmings_os_web/components/world_components.ex:771
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drain"
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Save settings"
 
-#: lib/lemmings_os_web/components/world_components.ex:781
+#: lib/lemmings_os_web/components/world_components.ex:787
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "Are you sure you want to delete this department?"
 
-#: lib/lemmings_os_web/components/world_components.ex:728
+#: lib/lemmings_os_web/components/world_components.ex:734
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/world_components.ex:738
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notes"
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:739
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:806
+#: lib/lemmings_os_web/components/world_components.ex:824
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No lemmings available"
 
-#: lib/lemmings_os_web/components/world_components.ex:807
+#: lib/lemmings_os_web/components/world_components.ex:825
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "No runtime-backed or mock preview lemmings are available for this department yet."
 
-#: lib/lemmings_os_web/components/world_components.ex:795
-#, elixir-autogen, elixir-format
-msgid ".department_lemmings_mock_copy"
-msgstr "This tab is still mock-backed. It previews likely department lemmings without claiming persisted runtime membership."
-
-#: lib/lemmings_os_web/components/world_components.ex:794
+#: lib/lemmings_os_web/components/world_components.ex:800
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:745
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Lifecycle actions"
 
-#: lib/lemmings_os_web/components/world_components.ex:746
+#: lib/lemmings_os_web/components/world_components.ex:752
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Use the persisted department lifecycle controls. Delete remains guarded by safety checks."
 
-#: lib/lemmings_os_web/components/world_components.ex:724
+#: lib/lemmings_os_web/components/world_components.ex:730
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadata"
 
-#: lib/lemmings_os_web/components/world_components.ex:850
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:932
+#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:855
-#: lib/lemmings_os_web/components/world_components.ex:892
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:898
+#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:990
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:936
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:978
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:876
-#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:888
+#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:969
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Idle TTL seconds"
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:977
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Inherit"
 
-#: lib/lemmings_os_web/components/world_components.ex:840
-#: lib/lemmings_os_web/components/world_components.ex:867
-#: lib/lemmings_os_web/components/world_components.ex:917
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:910
+#: lib/lemmings_os_web/components/world_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Max lemmings per department"
 
-#: lib/lemmings_os_web/components/world_components.ex:836
+#: lib/lemmings_os_web/components/world_components.ex:879
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Effective values after resolving World, City, and Department layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:835
+#: lib/lemmings_os_web/components/world_components.ex:878
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Effective config"
 
-#: lib/lemmings_os_web/components/world_components.ex:863
+#: lib/lemmings_os_web/components/world_components.ex:906
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Only Department-local overrides persisted on this row. Empty values inherit from City or World."
 
-#: lib/lemmings_os_web/components/world_components.ex:862
+#: lib/lemmings_os_web/components/world_components.ex:905
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Local overrides"
 
-#: lib/lemmings_os_web/components/world_components.ex:903
+#: lib/lemmings_os_web/components/world_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "V1 editor. This safely updates a narrow subset of Department-local overrides."
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:945
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Settings editor"
 
-#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/components/world_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:676
+#: lib/lemmings_os_web/components/world_components.ex:682
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:694
+#: lib/lemmings_os_web/components/world_components.ex:700
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Settings"
 
-#: lib/lemmings_os_web/live/departments_live.ex:326
+#: lib/lemmings_os_web/live/departments_live.ex:307
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Department activated."
@@ -886,12 +873,12 @@ msgstr "Department activated."
 msgid ".flash_department_deleted"
 msgstr "Department deleted."
 
-#: lib/lemmings_os_web/live/departments_live.ex:328
+#: lib/lemmings_os_web/live/departments_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Department disabled."
 
-#: lib/lemmings_os_web/live/departments_live.ex:327
+#: lib/lemmings_os_web/live/departments_live.ex:308
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Department set to draining."
@@ -906,7 +893,17 @@ msgstr "Could not update the department lifecycle."
 msgid ".flash_department_settings_saved"
 msgstr "Department settings saved."
 
-#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:310
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Department updated."
+
+#: lib/lemmings_os_web/components/world_components.ex:809
+#, elixir-autogen, elixir-format
+msgid ".button_import_lemmings"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:801
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_copy"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -11,28 +11,28 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/lemmings_os_web/components/layouts.ex:59
+#: lib/lemmings_os_web/components/layouts.ex:62
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr "Abrir navegación"
 
-#: lib/lemmings_os_web/components/layouts.ex:66
+#: lib/lemmings_os_web/components/layouts.ex:69
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr "Lemmings OS"
 
-#: lib/lemmings_os_web/components/layouts.ex:77
+#: lib/lemmings_os_web/components/layouts.ex:80
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr "mem"
 
-#: lib/lemmings_os_web/components/layouts.ex:78
+#: lib/lemmings_os_web/components/layouts.ex:81
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr "tick"
 
-#: lib/lemmings_os_web/components/layouts.ex:79
+#: lib/lemmings_os_web/components/layouts.ex:82
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr "agentes"
@@ -42,100 +42,102 @@ msgstr "agentes"
 msgid ".sidebar_eyebrow"
 msgstr "Centro de control"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:143
+#: lib/lemmings_os_web/components/sidebar_components.ex:146
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:173
+#: lib/lemmings_os_web/components/sidebar_components.ex:176
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr "Operaciones"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:145
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr "Inicio"
 
-#: lib/lemmings_os_web/components/home_components.ex:215
-#: lib/lemmings_os_web/components/home_components.ex:219
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/home_components.ex:220
+#: lib/lemmings_os_web/components/home_components.ex:224
+#: lib/lemmings_os_web/components/sidebar_components.ex:151
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr "Mundo"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:154
+#: lib/lemmings_os_web/components/sidebar_components.ex:157
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr "Ciudades"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:160
+#: lib/lemmings_os_web/components/sidebar_components.ex:163
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:166
+#: lib/lemmings_os_web/components/sidebar_components.ex:169
+#: lib/lemmings_os_web/components/world_components.ex:593
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/home_components.ex:216
-#: lib/lemmings_os_web/components/sidebar_components.ex:177
+#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/sidebar_components.ex:180
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr "Herramientas"
 
-#: lib/lemmings_os_web/components/home_components.ex:217
-#: lib/lemmings_os_web/components/sidebar_components.ex:183
+#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/sidebar_components.ex:186
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr "Registros"
 
-#: lib/lemmings_os_web/components/home_components.ex:218
-#: lib/lemmings_os_web/components/sidebar_components.ex:189
+#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/sidebar_components.ex:192
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr "Ajustes"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
+#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "Nuevo lemming"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:76
+#: lib/lemmings_os_web/components/sidebar_components.ex:79
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr "Alternar barra lateral"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:88
+#: lib/lemmings_os_web/components/sidebar_components.ex:91
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr "Agentes"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:96
+#: lib/lemmings_os_web/components/sidebar_components.ex:99
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr "Nodos"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:104
+#: lib/lemmings_os_web/components/sidebar_components.ex:107
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr "CPU"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:112
+#: lib/lemmings_os_web/components/sidebar_components.ex:115
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr "Herramientas"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:123
+#: lib/lemmings_os_web/components/sidebar_components.ex:126
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr "Clúster en línea"
@@ -201,7 +203,7 @@ msgstr "Notas del entorno"
 msgid ".page_title_home"
 msgstr "Inicio"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:11
+#: lib/lemmings_os_web/live/lemmings_live.ex:21
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
@@ -498,19 +500,19 @@ msgstr "Algunas herramientas del entorno siguen con estado de política parcial.
 msgid ".tools_policy_copy_unknown"
 msgstr "El estado de policy todavia no esta disponible."
 
-#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/home_components.ex:226
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr "Diferido"
 
-#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/home_components.ex:228
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr "Conocido"
 
-#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/home_components.ex:227
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -552,65 +554,65 @@ msgstr "Capacidad del entorno"
 msgid ".tools_usage_unknown"
 msgstr "Desconocido"
 
-#: lib/lemmings_os_web/components/home_components.ex:255
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
+#: lib/lemmings_os_web/components/home_components.ex:260
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr "Importa o recupera el mundo por defecto antes de confiar en las señales del panel."
 
-#: lib/lemmings_os_web/components/home_components.ex:241
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
+#: lib/lemmings_os_web/components/home_components.ex:246
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:260
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr "La pantalla principal no puede afirmar cobertura de jerarquía ni entorno hasta que exista un mundo."
 
-#: lib/lemmings_os_web/components/home_components.ex:227
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:232
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr "No hay un mundo persistido disponible"
 
-#: lib/lemmings_os_web/components/home_components.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr "Trata la política de herramientas como parcial hasta que exista reconciliación."
 
-#: lib/lemmings_os_web/components/home_components.ex:244
+#: lib/lemmings_os_web/components/home_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr "Algunas herramientas del entorno todavía tienen estado de política parcial."
 
-#: lib/lemmings_os_web/components/home_components.ex:230
+#: lib/lemmings_os_web/components/home_components.ex:235
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr "La reconciliación de política de herramientas es parcial"
 
-#: lib/lemmings_os_web/components/home_components.ex:261
+#: lib/lemmings_os_web/components/home_components.ex:266
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr "Usa los datos del entorno como fuente primaria hasta que exista el estado de política."
 
-#: lib/lemmings_os_web/components/home_components.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:252
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr "Las herramientas del entorno son visibles, pero no se pudo cargar la reconciliación de política."
 
-#: lib/lemmings_os_web/components/home_components.ex:233
+#: lib/lemmings_os_web/components/home_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr "Estado de política de herramientas no disponible"
 
-#: lib/lemmings_os_web/components/home_components.ex:264
+#: lib/lemmings_os_web/components/home_components.ex:269
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr "Verifica la fuente de capacidades del entorno antes de confiar en la disponibilidad de herramientas."
 
-#: lib/lemmings_os_web/components/home_components.ex:250
+#: lib/lemmings_os_web/components/home_components.ex:255
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr "La página no pudo obtener datos de capacidades del entorno desde la fuente actual."
 
-#: lib/lemmings_os_web/components/home_components.ex:236
+#: lib/lemmings_os_web/components/home_components.ex:241
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr "Fuente de capacidades del entorno no disponible"
@@ -746,23 +748,23 @@ msgstr "Señales reales del entorno, no amplitud operacional inventada."
 msgid ".home_signals_title"
 msgstr "Senales confiables"
 
-#: lib/lemmings_os_web/components/home_components.ex:206
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/home_components.ex:205
+#: lib/lemmings_os_web/components/home_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr "Mundo persistido"
 
-#: lib/lemmings_os_web/components/home_components.ex:207
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:212
+#: lib/lemmings_os_web/components/home_components.ex:218
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr "Verificaciones del entorno"
 
-#: lib/lemmings_os_web/components/home_components.ex:208
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr "Instantánea de herramientas"
@@ -812,7 +814,12 @@ msgstr "Departamentos"
 msgid ".home_card_topology_summary_title"
 msgstr "Resumen de topologia"
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
 msgstr "Topologia persistida"
+
+#: lib/lemmings_os_web/components/home_components.ex:203
+#, elixir-autogen, elixir-format
+msgid ".home_card_topology_lemming_count_label"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -11,28 +11,28 @@ msgstr ""
 "Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/lemmings_os_web/components/layouts.ex:62
+#: lib/lemmings_os_web/components/layouts.ex:59
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr "Abrir navegación"
 
-#: lib/lemmings_os_web/components/layouts.ex:69
+#: lib/lemmings_os_web/components/layouts.ex:66
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr "Lemmings OS"
 
-#: lib/lemmings_os_web/components/layouts.ex:80
+#: lib/lemmings_os_web/components/layouts.ex:77
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr "mem"
 
-#: lib/lemmings_os_web/components/layouts.ex:81
+#: lib/lemmings_os_web/components/layouts.ex:78
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr "tick"
 
-#: lib/lemmings_os_web/components/layouts.ex:82
+#: lib/lemmings_os_web/components/layouts.ex:79
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr "agentes"
@@ -42,102 +42,100 @@ msgstr "agentes"
 msgid ".sidebar_eyebrow"
 msgstr "Centro de control"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:146
+#: lib/lemmings_os_web/components/sidebar_components.ex:143
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:176
+#: lib/lemmings_os_web/components/sidebar_components.ex:173
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr "Operaciones"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/sidebar_components.ex:145
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr "Inicio"
 
-#: lib/lemmings_os_web/components/home_components.ex:220
-#: lib/lemmings_os_web/components/home_components.ex:224
-#: lib/lemmings_os_web/components/sidebar_components.ex:151
+#: lib/lemmings_os_web/components/home_components.ex:215
+#: lib/lemmings_os_web/components/home_components.ex:219
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr "Mundo"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:157
+#: lib/lemmings_os_web/components/sidebar_components.ex:154
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr "Ciudades"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:163
+#: lib/lemmings_os_web/components/sidebar_components.ex:160
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:593
+#: lib/lemmings_os_web/components/sidebar_components.ex:166
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/home_components.ex:221
-#: lib/lemmings_os_web/components/sidebar_components.ex:180
+#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/sidebar_components.ex:177
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr "Herramientas"
 
-#: lib/lemmings_os_web/components/home_components.ex:222
-#: lib/lemmings_os_web/components/sidebar_components.ex:186
+#: lib/lemmings_os_web/components/home_components.ex:217
+#: lib/lemmings_os_web/components/sidebar_components.ex:183
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr "Registros"
 
-#: lib/lemmings_os_web/components/home_components.ex:223
-#: lib/lemmings_os_web/components/sidebar_components.ex:192
+#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/sidebar_components.ex:189
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr "Ajustes"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
-#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "Nuevo lemming"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:79
+#: lib/lemmings_os_web/components/sidebar_components.ex:76
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr "Alternar barra lateral"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:91
+#: lib/lemmings_os_web/components/sidebar_components.ex:88
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr "Agentes"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:99
+#: lib/lemmings_os_web/components/sidebar_components.ex:96
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr "Nodos"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:107
+#: lib/lemmings_os_web/components/sidebar_components.ex:104
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr "CPU"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:115
+#: lib/lemmings_os_web/components/sidebar_components.ex:112
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr "Herramientas"
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:126
+#: lib/lemmings_os_web/components/sidebar_components.ex:123
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr "Clúster en línea"
@@ -203,7 +201,7 @@ msgstr "Notas del entorno"
 msgid ".page_title_home"
 msgstr "Inicio"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:21
+#: lib/lemmings_os_web/live/lemmings_live.ex:11
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
@@ -213,12 +211,12 @@ msgstr "Lemmings"
 msgid ".page_title_cities"
 msgstr "Ciudades"
 
-#: lib/lemmings_os_web/live/departments_live.ex:17
+#: lib/lemmings_os_web/live/departments_live.ex:21
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/live/world_live.ex:18
+#: lib/lemmings_os_web/live/world_live.ex:16
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr "Mundo"
@@ -500,19 +498,19 @@ msgstr "Algunas herramientas del entorno siguen con estado de política parcial.
 msgid ".tools_policy_copy_unknown"
 msgstr "El estado de policy todavia no esta disponible."
 
-#: lib/lemmings_os_web/components/home_components.ex:226
+#: lib/lemmings_os_web/components/home_components.ex:221
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr "Diferido"
 
-#: lib/lemmings_os_web/components/home_components.ex:228
+#: lib/lemmings_os_web/components/home_components.ex:223
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr "Conocido"
 
-#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/components/home_components.ex:222
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -554,65 +552,65 @@ msgstr "Capacidad del entorno"
 msgid ".tools_usage_unknown"
 msgstr "Desconocido"
 
-#: lib/lemmings_os_web/components/home_components.ex:260
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:262
+#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr "Importa o recupera el mundo por defecto antes de confiar en las señales del panel."
 
-#: lib/lemmings_os_web/components/home_components.ex:246
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
+#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr "La pantalla principal no puede afirmar cobertura de jerarquía ni entorno hasta que exista un mundo."
 
-#: lib/lemmings_os_web/components/home_components.ex:232
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr "No hay un mundo persistido disponible"
 
-#: lib/lemmings_os_web/components/home_components.ex:263
+#: lib/lemmings_os_web/components/home_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr "Trata la política de herramientas como parcial hasta que exista reconciliación."
 
-#: lib/lemmings_os_web/components/home_components.ex:249
+#: lib/lemmings_os_web/components/home_components.ex:244
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr "Algunas herramientas del entorno todavía tienen estado de política parcial."
 
-#: lib/lemmings_os_web/components/home_components.ex:235
+#: lib/lemmings_os_web/components/home_components.ex:230
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr "La reconciliación de política de herramientas es parcial"
 
-#: lib/lemmings_os_web/components/home_components.ex:266
+#: lib/lemmings_os_web/components/home_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr "Usa los datos del entorno como fuente primaria hasta que exista el estado de política."
 
-#: lib/lemmings_os_web/components/home_components.ex:252
+#: lib/lemmings_os_web/components/home_components.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr "Las herramientas del entorno son visibles, pero no se pudo cargar la reconciliación de política."
 
-#: lib/lemmings_os_web/components/home_components.ex:238
+#: lib/lemmings_os_web/components/home_components.ex:233
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr "Estado de política de herramientas no disponible"
 
-#: lib/lemmings_os_web/components/home_components.ex:269
+#: lib/lemmings_os_web/components/home_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr "Verifica la fuente de capacidades del entorno antes de confiar en la disponibilidad de herramientas."
 
-#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/components/home_components.ex:250
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr "La página no pudo obtener datos de capacidades del entorno desde la fuente actual."
 
-#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/components/home_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr "Fuente de capacidades del entorno no disponible"
@@ -748,23 +746,23 @@ msgstr "Señales reales del entorno, no amplitud operacional inventada."
 msgid ".home_signals_title"
 msgstr "Senales confiables"
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/home_components.ex:210
+#: lib/lemmings_os_web/components/home_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr "Mundo persistido"
 
-#: lib/lemmings_os_web/components/home_components.ex:212
-#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/home_components.ex:207
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr "Verificaciones del entorno"
 
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:208
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr "Instantánea de herramientas"
@@ -814,12 +812,7 @@ msgstr "Departamentos"
 msgid ".home_card_topology_summary_title"
 msgstr "Resumen de topologia"
 
-#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
 msgstr "Topologia persistida"
-
-#: lib/lemmings_os_web/components/home_components.ex:203
-#, elixir-autogen, elixir-format
-msgid ".home_card_topology_lemming_count_label"
-msgstr "Lemmings"

--- a/priv/gettext/es/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/es/LC_MESSAGES/lemmings.po
@@ -355,8 +355,8 @@ msgid ".empty_create_missing_department_copy"
 msgstr "Selecciona una ciudad y un departamento para crear el nuevo lemming en el scope correcto."
 
 #: lib/lemmings_os_web/live/create_lemming_live.ex:72
-#: lib/lemmings_os_web/live/import_lemming_live.ex:171
-#: lib/lemmings_os_web/live/import_lemming_live.ex:177
+#: lib/lemmings_os_web/live/import_lemming_live.ex:152
+#: lib/lemmings_os_web/live/import_lemming_live.ex:178
 #, elixir-autogen, elixir-format
 msgid ".flash_create_scope_invalid"
 msgstr "El departamento seleccionado no pertenece al scope esperado de ciudad o mundo."
@@ -428,34 +428,34 @@ msgid ".flash_export_no_lemming"
 msgstr "No hay lemming seleccionado para exportar."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:114
-#: lib/lemmings_os_web/live/import_lemming_live.ex:235
+#: lib/lemmings_os_web/live/import_lemming_live.ex:236
 #, elixir-autogen
 msgid ".flash_import_success"
 msgstr "Se importaron %{count} lemming(s) correctamente."
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:218
-#: lib/lemmings_os_web/live/import_lemming_live.ex:222
+#: lib/lemmings_os_web/live/import_lemming_live.ex:219
+#: lib/lemmings_os_web/live/import_lemming_live.ex:223
 #, elixir-autogen
 msgid ".error_import_invalid_json"
 msgstr "El texto pegado no es JSON valido. Revisa la sintaxis e intenta de nuevo."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:124
-#: lib/lemmings_os_web/live/import_lemming_live.ex:246
+#: lib/lemmings_os_web/live/import_lemming_live.ex:247
 #, elixir-autogen
 msgid ".error_import_unsupported_version"
 msgstr "Version de esquema no soportada. Solo se soportan exportaciones de version 1."
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:273
-#: lib/lemmings_os_web/live/import_lemming_live.ex:281
-#: lib/lemmings_os_web/live/import_lemming_live.ex:288
+#: lib/lemmings_os_web/live/import_lemming_live.ex:274
+#: lib/lemmings_os_web/live/import_lemming_live.ex:282
+#: lib/lemmings_os_web/live/import_lemming_live.ex:289
 #, elixir-autogen
 msgid ".error_import_record_invalid"
 msgstr "El registro %{index} es invalido: %{errors}."
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:131
-#: lib/lemmings_os_web/live/import_lemming_live.ex:253
-#: lib/lemmings_os_web/live/import_lemming_live.ex:290
-#: lib/lemmings_os_web/live/import_lemming_live.ex:295
+#: lib/lemmings_os_web/live/import_lemming_live.ex:254
+#: lib/lemmings_os_web/live/import_lemming_live.ex:291
+#: lib/lemmings_os_web/live/import_lemming_live.ex:296
 #, elixir-autogen
 msgid ".error_import_failed"
 msgstr "Error en la importacion. Verifica el payload JSON e intenta de nuevo."

--- a/priv/gettext/es/LC_MESSAGES/world.po
+++ b/priv/gettext/es/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Desconocido"
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1071
-#: lib/lemmings_os_web/components/world_components.ex:1101
-#: lib/lemmings_os_web/components/world_components.ex:1118
-#: lib/lemmings_os_web/components/world_components.ex:1135
-#: lib/lemmings_os_web/components/world_components.ex:1139
-#: lib/lemmings_os_web/components/world_components.ex:1160
+#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1075
+#: lib/lemmings_os_web/components/world_components.ex:1092
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1117
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "No disponible"
@@ -53,7 +53,7 @@ msgstr "No disponible"
 msgid ".label_not_imported"
 msgstr "Todavía no importado"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:164
+#: lib/lemmings_os_web/components/city_map_components.ex:166
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr "Mapa de ciudades"
@@ -63,7 +63,7 @@ msgstr "Mapa de ciudades"
 msgid ".aria_city_node"
 msgstr "Nodo de ciudad"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:35
+#: lib/lemmings_os_web/components/city_map_components.ex:37
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr "Nodo de departamento"
@@ -73,8 +73,7 @@ msgstr "Nodo de departamento"
 msgid ".aria_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:670
-#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
+#: lib/lemmings_os_web/components/world_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "Todos los departamentos"
@@ -85,7 +84,7 @@ msgstr "Todos los departamentos"
 msgid ".button_import_bootstrap"
 msgstr "Importar bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:624
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Abrir departamento"
@@ -106,26 +105,26 @@ msgstr "Aquí aparecerá el resumen de ciudades cuando exista una fuente real."
 msgid ".copy_world_tools_placeholder"
 msgstr "Aquí aparecerá el resumen de herramientas cuando exista una fuente real."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departamentos"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:136
+#: lib/lemmings_os_web/components/city_map_components.ex:138
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr "%{running} de %{total} en ejecución"
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/live/departments_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "Aún no hay departamentos"
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:123
+#: lib/lemmings_os_web/live/departments_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Crea o importa un departamento para verlo aquí."
@@ -157,27 +156,27 @@ msgstr "Fuente del bootstrap"
 msgid ".label_budgets"
 msgstr "Presupuestos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1094
+#: lib/lemmings_os_web/components/world_components.ex:1051
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1090
+#: lib/lemmings_os_web/components/world_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1099
+#: lib/lemmings_os_web/components/world_components.ex:1056
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declarado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1083
+#: lib/lemmings_os_web/components/world_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Deps."
 
-#: lib/lemmings_os_web/components/world_components.ex:645
+#: lib/lemmings_os_web/components/world_components.ex:639
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Vacío"
@@ -206,7 +205,7 @@ msgstr "Última importación"
 msgid ".label_last_sync"
 msgstr "Última sincronización"
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
@@ -217,7 +216,7 @@ msgstr "Lemms."
 msgid ".label_limits"
 msgstr "Límites"
 
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:1030
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "Sin fallback"
@@ -244,17 +243,17 @@ msgstr "Secciones de marcador"
 msgid ".label_profiles"
 msgstr "Perfiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1146
+#: lib/lemmings_os_web/components/world_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credenciales listas"
 
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Proveedor deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Proveedor habilitado"
@@ -264,7 +263,7 @@ msgstr "Proveedor habilitado"
 msgid ".label_providers"
 msgstr "Proveedores"
 
-#: lib/lemmings_os_web/components/world_components.ex:644
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Cola"
@@ -275,39 +274,43 @@ msgstr "Cola"
 msgid ".label_runtime_defaults"
 msgstr "Valores por defecto del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1155
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Diferido por el entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "ID del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:723
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr "Slug del mundo"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:192
+#: lib/lemmings_os_web/components/city_map_components.ex:194
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr "Departamento"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:177
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
+#, elixir-autogen, elixir-format
+msgid ".metric_agents"
+msgstr "Agentes"
+
+#: lib/lemmings_os_web/components/city_map_components.ex:179
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:181
+#: lib/lemmings_os_web/components/city_map_components.ex:183
 #: lib/lemmings_os_web/components/city_map_components.ex:251
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr "Lemmings"
@@ -322,47 +325,47 @@ msgstr "Nodos"
 msgid ".metric_online"
 msgstr "En línea"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:185
+#: lib/lemmings_os_web/components/city_map_components.ex:187
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1121
+#: lib/lemmings_os_web/components/world_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Archivo bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Conexión a Postgres"
 
-#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Credenciales del proveedor"
 
-#: lib/lemmings_os_web/components/world_components.ex:1130
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Alcance del proveedor"
 
-#: lib/lemmings_os_web/components/core_components.ex:578
-#: lib/lemmings_os_web/components/core_components.ex:581
+#: lib/lemmings_os_web/components/core_components.ex:573
+#: lib/lemmings_os_web/components/core_components.ex:576
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr "Degradado"
 
-#: lib/lemmings_os_web/components/core_components.ex:579
-#: lib/lemmings_os_web/components/core_components.ex:582
+#: lib/lemmings_os_web/components/core_components.ex:574
+#: lib/lemmings_os_web/components/core_components.ex:577
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr "Desconectado"
 
-#: lib/lemmings_os_web/components/core_components.ex:577
-#: lib/lemmings_os_web/components/core_components.ex:580
+#: lib/lemmings_os_web/components/core_components.ex:572
+#: lib/lemmings_os_web/components/core_components.ex:575
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -406,7 +409,7 @@ msgid ".title_bootstrap_config"
 msgstr "Configuración bootstrap"
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:111
+#: lib/lemmings_os_web/live/departments_live.html.heex:109
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departamentos"
@@ -431,7 +434,7 @@ msgstr "Ciudades del mundo"
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:712
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "Identidad del mundo"
@@ -471,7 +474,7 @@ msgstr "En ejecución"
 msgid ".copy_city_effective_config"
 msgstr "Se resuelve a partir de las capas persistidas World y City."
 
-#: lib/lemmings_os_web/components/world_components.ex:713
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -530,6 +533,11 @@ msgstr "Nodo BEAM"
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
+
+#: lib/lemmings_os_web/components/world_components.ex:800
+#, elixir-autogen
+msgid ".label_mock_backed_preview"
+msgstr "Vista previa mock"
 
 #: lib/lemmings_os_web/components/world_components.ex:523
 #, elixir-autogen
@@ -601,7 +609,7 @@ msgstr "Nombre del nodo BEAM"
 msgid ".city_form_node_name_placeholder"
 msgstr "ej. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:708
+#: lib/lemmings_os_web/components/world_components.ex:702
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -642,12 +650,12 @@ msgstr "Crear ciudad"
 msgid ".city_form_submit_update"
 msgstr "Guardar cambios"
 
-#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/cities_live.ex:184
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "Ciudad creada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/cities_live.ex:209
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "Ciudad actualizada."
@@ -663,8 +671,8 @@ msgstr "Ciudad eliminada."
 msgid ".flash_city_not_found"
 msgstr "Ciudad no encontrada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:191
-#: lib/lemmings_os_web/live/cities_live.ex:216
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/cities_live.ex:219
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "No se pudo guardar la ciudad. Revisá el formulario."
@@ -674,7 +682,7 @@ msgstr "No se pudo guardar la ciudad. Revisá el formulario."
 msgid ".flash_city_delete_error"
 msgstr "No se pudo eliminar la ciudad."
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:605
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Abrir departamentos"
@@ -689,242 +697,216 @@ msgstr "%{city} tiene %{count} departamentos."
 msgid ".copy_city_departments_summary"
 msgstr "Resumen compacto de los departamentos persistidos para esta city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:86
+#: lib/lemmings_os_web/live/departments_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Cambiá la city activa para el mapa y la lista de departamentos."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:85
-#: lib/lemmings_os_web/live/departments_live.html.heex:104
+#: lib/lemmings_os_web/live/departments_live.html.heex:83
+#: lib/lemmings_os_web/live/departments_live.html.heex:102
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "City seleccionada"
 
-#: lib/lemmings_os_web/components/world_components.ex:762
+#: lib/lemmings_os_web/components/world_components.ex:756
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activar"
 
-#: lib/lemmings_os_web/components/world_components.ex:790
+#: lib/lemmings_os_web/components/world_components.ex:784
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Borrar"
 
-#: lib/lemmings_os_web/components/world_components.ex:780
+#: lib/lemmings_os_web/components/world_components.ex:774
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Deshabilitar"
 
-#: lib/lemmings_os_web/components/world_components.ex:771
+#: lib/lemmings_os_web/components/world_components.ex:765
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drenar"
 
-#: lib/lemmings_os_web/components/world_components.ex:998
+#: lib/lemmings_os_web/components/world_components.ex:955
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Guardar ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:787
+#: lib/lemmings_os_web/components/world_components.ex:781
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "¿Seguro que quieres borrar este departamento?"
 
-#: lib/lemmings_os_web/components/world_components.ex:734
+#: lib/lemmings_os_web/components/world_components.ex:728
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/world_components.ex:744
+#: lib/lemmings_os_web/components/world_components.ex:738
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notas"
 
-#: lib/lemmings_os_web/components/world_components.ex:739
+#: lib/lemmings_os_web/components/world_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:824
+#: lib/lemmings_os_web/components/world_components.ex:806
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No hay lemmings disponibles"
 
-#: lib/lemmings_os_web/components/world_components.ex:825
+#: lib/lemmings_os_web/components/world_components.ex:807
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "Todavía no hay lemmings con respaldo de runtime ni vista mock para este departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:800
+#: lib/lemmings_os_web/components/world_components.ex:795
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_mock_copy"
+msgstr "Esta pestaña sigue respaldada por mocks. Muestra un preview probable de lemmings del departamento sin afirmar membresía persistida en runtime."
+
+#: lib/lemmings_os_web/components/world_components.ex:794
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:745
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Acciones de ciclo de vida"
 
-#: lib/lemmings_os_web/components/world_components.ex:752
+#: lib/lemmings_os_web/components/world_components.ex:746
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Usa los controles persistidos del ciclo de vida del departamento. El borrado sigue protegido por checks de seguridad."
 
-#: lib/lemmings_os_web/components/world_components.ex:730
+#: lib/lemmings_os_web/components/world_components.ex:724
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadatos"
 
-#: lib/lemmings_os_web/components/world_components.ex:893
-#: lib/lemmings_os_web/components/world_components.ex:926
-#: lib/lemmings_os_web/components/world_components.ex:975
+#: lib/lemmings_os_web/components/world_components.ex:850
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:932
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:898
-#: lib/lemmings_os_web/components/world_components.ex:935
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:855
+#: lib/lemmings_os_web/components/world_components.ex:892
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:979
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:978
+#: lib/lemmings_os_web/components/world_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:888
-#: lib/lemmings_os_web/components/world_components.ex:919
-#: lib/lemmings_os_web/components/world_components.ex:969
+#: lib/lemmings_os_web/components/world_components.ex:845
+#: lib/lemmings_os_web/components/world_components.ex:876
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Segundos TTL inactivo"
 
-#: lib/lemmings_os_web/components/world_components.ex:977
+#: lib/lemmings_os_web/components/world_components.ex:934
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Heredar"
 
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:910
-#: lib/lemmings_os_web/components/world_components.ex:960
+#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Máximo de lemmings por departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:836
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Valores efectivos después de resolver las capas de Mundo, Ciudad y Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:878
+#: lib/lemmings_os_web/components/world_components.ex:835
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Configuración efectiva"
 
-#: lib/lemmings_os_web/components/world_components.ex:906
+#: lib/lemmings_os_web/components/world_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Solo los overrides locales del Departamento persistidos en esta fila. Los valores vacíos heredan desde Ciudad o Mundo."
 
-#: lib/lemmings_os_web/components/world_components.ex:905
+#: lib/lemmings_os_web/components/world_components.ex:862
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Overrides locales"
 
-#: lib/lemmings_os_web/components/world_components.ex:946
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "Editor V1. Actualiza de forma segura un subconjunto pequeño de overrides locales del Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:945
+#: lib/lemmings_os_web/components/world_components.ex:902
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Editor de ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:691
+#: lib/lemmings_os_web/components/world_components.ex:685
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:682
+#: lib/lemmings_os_web/components/world_components.ex:676
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:700
+#: lib/lemmings_os_web/components/world_components.ex:694
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Ajustes"
 
-#: lib/lemmings_os_web/live/departments_live.ex:303
+#: lib/lemmings_os_web/live/departments_live.ex:326
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Departamento activado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:92
+#: lib/lemmings_os_web/live/departments_live.ex:96
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Departamento borrado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:305
+#: lib/lemmings_os_web/live/departments_live.ex:328
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Departamento deshabilitado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:304
+#: lib/lemmings_os_web/live/departments_live.ex:327
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Departamento puesto en drenaje."
 
-#: lib/lemmings_os_web/live/departments_live.ex:106
+#: lib/lemmings_os_web/live/departments_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "No se pudo actualizar el ciclo de vida del departamento."
 
-#: lib/lemmings_os_web/live/departments_live.ex:76
+#: lib/lemmings_os_web/live/departments_live.ex:80
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Ajustes del departamento guardados."
 
-#: lib/lemmings_os_web/live/departments_live.ex:306
+#: lib/lemmings_os_web/live/departments_live.ex:329
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Departamento actualizado."
-
-#: lib/lemmings_os_web/components/world_components.ex:801
-#, elixir-autogen, elixir-format, fuzzy
-msgid ".department_lemmings_copy"
-msgstr "No hay lemmings disponibles"
-
-#: lib/lemmings_os_web/components/world_components.ex:809
-#, elixir-autogen
-msgid ".button_import_lemmings"
-msgstr "Importar JSON"
-
-msgid ".import_lemmings_title"
-msgstr "Importar lemmings desde JSON"
-
-msgid ".import_lemmings_copy"
-msgstr "Pega un objeto de lemming o un array JSON de lemmings exportados desde otro departamento. La importación se valida antes de persistir."
-
-msgid ".import_lemmings_label_json"
-msgstr "Carga útil JSON"
-
-msgid ".import_lemmings_placeholder"
-msgstr "{\"schema_version\": 1, \"name\": \"...\", \"slug\": \"...\", \"status\": \"draft\"}"
-
-msgid ".button_import_cancel"
-msgstr "Cancelar"
-
-msgid ".button_import_submit"
-msgstr "Importar"
-
-msgid ".button_import_importing"
-msgstr "Importando..."

--- a/priv/gettext/es/LC_MESSAGES/world.po
+++ b/priv/gettext/es/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Desconocido"
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1028
-#: lib/lemmings_os_web/components/world_components.ex:1058
-#: lib/lemmings_os_web/components/world_components.ex:1075
-#: lib/lemmings_os_web/components/world_components.ex:1092
-#: lib/lemmings_os_web/components/world_components.ex:1096
-#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1071
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1135
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1160
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "No disponible"
@@ -53,7 +53,7 @@ msgstr "No disponible"
 msgid ".label_not_imported"
 msgstr "Todavía no importado"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:166
+#: lib/lemmings_os_web/components/city_map_components.ex:164
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr "Mapa de ciudades"
@@ -63,7 +63,7 @@ msgstr "Mapa de ciudades"
 msgid ".aria_city_node"
 msgstr "Nodo de ciudad"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:37
+#: lib/lemmings_os_web/components/city_map_components.ex:35
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr "Nodo de departamento"
@@ -73,7 +73,8 @@ msgstr "Nodo de departamento"
 msgid ".aria_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:664
+#: lib/lemmings_os_web/components/world_components.ex:670
+#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "Todos los departamentos"
@@ -84,7 +85,7 @@ msgstr "Todos los departamentos"
 msgid ".button_import_bootstrap"
 msgstr "Importar bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:624
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Abrir departamento"
@@ -105,26 +106,26 @@ msgstr "Aquí aparecerá el resumen de ciudades cuando exista una fuente real."
 msgid ".copy_world_tools_placeholder"
 msgstr "Aquí aparecerá el resumen de herramientas cuando exista una fuente real."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:113
+#: lib/lemmings_os_web/live/departments_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departamentos"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:138
+#: lib/lemmings_os_web/components/city_map_components.ex:136
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr "%{running} de %{total} en ejecución"
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:120
+#: lib/lemmings_os_web/live/departments_live.html.heex:122
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "Aún no hay departamentos"
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:121
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Crea o importa un departamento para verlo aquí."
@@ -156,27 +157,27 @@ msgstr "Fuente del bootstrap"
 msgid ".label_budgets"
 msgstr "Presupuestos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1051
+#: lib/lemmings_os_web/components/world_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1047
+#: lib/lemmings_os_web/components/world_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1056
+#: lib/lemmings_os_web/components/world_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declarado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1040
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Deps."
 
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:645
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Vacío"
@@ -205,7 +206,7 @@ msgstr "Última importación"
 msgid ".label_last_sync"
 msgstr "Última sincronización"
 
-#: lib/lemmings_os_web/components/world_components.ex:1041
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
@@ -216,7 +217,7 @@ msgstr "Lemms."
 msgid ".label_limits"
 msgstr "Límites"
 
-#: lib/lemmings_os_web/components/world_components.ex:1030
+#: lib/lemmings_os_web/components/world_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "Sin fallback"
@@ -243,17 +244,17 @@ msgstr "Secciones de marcador"
 msgid ".label_profiles"
 msgstr "Perfiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1103
+#: lib/lemmings_os_web/components/world_components.ex:1146
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credenciales listas"
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Proveedor deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1026
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Proveedor habilitado"
@@ -263,7 +264,7 @@ msgstr "Proveedor habilitado"
 msgid ".label_providers"
 msgstr "Proveedores"
 
-#: lib/lemmings_os_web/components/world_components.ex:638
+#: lib/lemmings_os_web/components/world_components.ex:644
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Cola"
@@ -274,43 +275,39 @@ msgstr "Cola"
 msgid ".label_runtime_defaults"
 msgstr "Valores por defecto del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Diferido por el entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1112
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "ID del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:717
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:723
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr "Slug del mundo"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:194
+#: lib/lemmings_os_web/components/city_map_components.ex:192
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr "Departamento"
 
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
-#, elixir-autogen, elixir-format
-msgid ".metric_agents"
-msgstr "Agentes"
-
-#: lib/lemmings_os_web/components/city_map_components.ex:179
+#: lib/lemmings_os_web/components/city_map_components.ex:177
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:183
+#: lib/lemmings_os_web/components/city_map_components.ex:181
 #: lib/lemmings_os_web/components/city_map_components.ex:251
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr "Lemmings"
@@ -325,47 +322,47 @@ msgstr "Nodos"
 msgid ".metric_online"
 msgstr "En línea"
 
-#: lib/lemmings_os_web/components/city_map_components.ex:187
+#: lib/lemmings_os_web/components/city_map_components.ex:185
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1078
+#: lib/lemmings_os_web/components/world_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Archivo bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:1081
+#: lib/lemmings_os_web/components/world_components.ex:1124
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Conexión a Postgres"
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Credenciales del proveedor"
 
-#: lib/lemmings_os_web/components/world_components.ex:1087
+#: lib/lemmings_os_web/components/world_components.ex:1130
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Alcance del proveedor"
 
-#: lib/lemmings_os_web/components/core_components.ex:573
-#: lib/lemmings_os_web/components/core_components.ex:576
+#: lib/lemmings_os_web/components/core_components.ex:578
+#: lib/lemmings_os_web/components/core_components.ex:581
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr "Degradado"
 
-#: lib/lemmings_os_web/components/core_components.ex:574
-#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:579
+#: lib/lemmings_os_web/components/core_components.ex:582
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr "Desconectado"
 
-#: lib/lemmings_os_web/components/core_components.ex:572
-#: lib/lemmings_os_web/components/core_components.ex:575
+#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:580
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -409,7 +406,7 @@ msgid ".title_bootstrap_config"
 msgstr "Configuración bootstrap"
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:109
+#: lib/lemmings_os_web/live/departments_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departamentos"
@@ -434,7 +431,7 @@ msgstr "Ciudades del mundo"
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:712
+#: lib/lemmings_os_web/components/world_components.ex:718
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "Identidad del mundo"
@@ -474,7 +471,7 @@ msgstr "En ejecución"
 msgid ".copy_city_effective_config"
 msgstr "Se resuelve a partir de las capas persistidas World y City."
 
-#: lib/lemmings_os_web/components/world_components.ex:707
+#: lib/lemmings_os_web/components/world_components.ex:713
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -533,11 +530,6 @@ msgstr "Nodo BEAM"
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
-
-#: lib/lemmings_os_web/components/world_components.ex:800
-#, elixir-autogen
-msgid ".label_mock_backed_preview"
-msgstr "Vista previa mock"
 
 #: lib/lemmings_os_web/components/world_components.ex:523
 #, elixir-autogen
@@ -609,7 +601,7 @@ msgstr "Nombre del nodo BEAM"
 msgid ".city_form_node_name_placeholder"
 msgstr "ej. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:702
+#: lib/lemmings_os_web/components/world_components.ex:708
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -682,7 +674,7 @@ msgstr "No se pudo guardar la ciudad. Revisá el formulario."
 msgid ".flash_city_delete_error"
 msgstr "No se pudo eliminar la ciudad."
 
-#: lib/lemmings_os_web/components/world_components.ex:605
+#: lib/lemmings_os_web/components/world_components.ex:611
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Abrir departamentos"
@@ -697,186 +689,181 @@ msgstr "%{city} tiene %{count} departamentos."
 msgid ".copy_city_departments_summary"
 msgstr "Resumen compacto de los departamentos persistidos para esta city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:84
+#: lib/lemmings_os_web/live/departments_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Cambiá la city activa para el mapa y la lista de departamentos."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:83
-#: lib/lemmings_os_web/live/departments_live.html.heex:102
+#: lib/lemmings_os_web/live/departments_live.html.heex:85
+#: lib/lemmings_os_web/live/departments_live.html.heex:104
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "City seleccionada"
 
-#: lib/lemmings_os_web/components/world_components.ex:756
+#: lib/lemmings_os_web/components/world_components.ex:762
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activar"
 
-#: lib/lemmings_os_web/components/world_components.ex:784
+#: lib/lemmings_os_web/components/world_components.ex:790
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Borrar"
 
-#: lib/lemmings_os_web/components/world_components.ex:774
+#: lib/lemmings_os_web/components/world_components.ex:780
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Deshabilitar"
 
-#: lib/lemmings_os_web/components/world_components.ex:765
+#: lib/lemmings_os_web/components/world_components.ex:771
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drenar"
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Guardar ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:781
+#: lib/lemmings_os_web/components/world_components.ex:787
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "¿Seguro que quieres borrar este departamento?"
 
-#: lib/lemmings_os_web/components/world_components.ex:728
+#: lib/lemmings_os_web/components/world_components.ex:734
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/world_components.ex:738
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notas"
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:739
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:806
+#: lib/lemmings_os_web/components/world_components.ex:824
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No hay lemmings disponibles"
 
-#: lib/lemmings_os_web/components/world_components.ex:807
+#: lib/lemmings_os_web/components/world_components.ex:825
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "Todavía no hay lemmings con respaldo de runtime ni vista mock para este departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:795
-#, elixir-autogen, elixir-format
-msgid ".department_lemmings_mock_copy"
-msgstr "Esta pestaña sigue respaldada por mocks. Muestra un preview probable de lemmings del departamento sin afirmar membresía persistida en runtime."
-
-#: lib/lemmings_os_web/components/world_components.ex:794
+#: lib/lemmings_os_web/components/world_components.ex:800
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:745
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Acciones de ciclo de vida"
 
-#: lib/lemmings_os_web/components/world_components.ex:746
+#: lib/lemmings_os_web/components/world_components.ex:752
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Usa los controles persistidos del ciclo de vida del departamento. El borrado sigue protegido por checks de seguridad."
 
-#: lib/lemmings_os_web/components/world_components.ex:724
+#: lib/lemmings_os_web/components/world_components.ex:730
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadatos"
 
-#: lib/lemmings_os_web/components/world_components.ex:850
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:932
+#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:855
-#: lib/lemmings_os_web/components/world_components.ex:892
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:898
+#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:990
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:936
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:978
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:876
-#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:888
+#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:969
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Segundos TTL inactivo"
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:977
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Heredar"
 
-#: lib/lemmings_os_web/components/world_components.ex:840
-#: lib/lemmings_os_web/components/world_components.ex:867
-#: lib/lemmings_os_web/components/world_components.ex:917
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:910
+#: lib/lemmings_os_web/components/world_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Máximo de lemmings por departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:836
+#: lib/lemmings_os_web/components/world_components.ex:879
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Valores efectivos después de resolver las capas de Mundo, Ciudad y Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:835
+#: lib/lemmings_os_web/components/world_components.ex:878
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Configuración efectiva"
 
-#: lib/lemmings_os_web/components/world_components.ex:863
+#: lib/lemmings_os_web/components/world_components.ex:906
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Solo los overrides locales del Departamento persistidos en esta fila. Los valores vacíos heredan desde Ciudad o Mundo."
 
-#: lib/lemmings_os_web/components/world_components.ex:862
+#: lib/lemmings_os_web/components/world_components.ex:905
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Overrides locales"
 
-#: lib/lemmings_os_web/components/world_components.ex:903
+#: lib/lemmings_os_web/components/world_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "Editor V1. Actualiza de forma segura un subconjunto pequeño de overrides locales del Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:945
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Editor de ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/components/world_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:676
+#: lib/lemmings_os_web/components/world_components.ex:682
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:694
+#: lib/lemmings_os_web/components/world_components.ex:700
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Ajustes"
 
-#: lib/lemmings_os_web/live/departments_live.ex:326
+#: lib/lemmings_os_web/live/departments_live.ex:307
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Departamento activado."
@@ -886,12 +873,12 @@ msgstr "Departamento activado."
 msgid ".flash_department_deleted"
 msgstr "Departamento borrado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:328
+#: lib/lemmings_os_web/live/departments_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Departamento deshabilitado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:327
+#: lib/lemmings_os_web/live/departments_live.ex:308
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Departamento puesto en drenaje."
@@ -906,7 +893,17 @@ msgstr "No se pudo actualizar el ciclo de vida del departamento."
 msgid ".flash_department_settings_saved"
 msgstr "Ajustes del departamento guardados."
 
-#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:310
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Departamento actualizado."
+
+#: lib/lemmings_os_web/components/world_components.ex:809
+#, elixir-autogen, elixir-format
+msgid ".button_import_lemmings"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:801
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_copy"
+msgstr ""

--- a/priv/gettext/layout.pot
+++ b/priv/gettext/layout.pot
@@ -6,28 +6,28 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-#: lib/lemmings_os_web/components/layouts.ex:62
+#: lib/lemmings_os_web/components/layouts.ex:59
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:69
+#: lib/lemmings_os_web/components/layouts.ex:66
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:80
+#: lib/lemmings_os_web/components/layouts.ex:77
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:81
+#: lib/lemmings_os_web/components/layouts.ex:78
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:82
+#: lib/lemmings_os_web/components/layouts.ex:79
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr ""
@@ -37,102 +37,100 @@ msgstr ""
 msgid ".sidebar_eyebrow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:146
+#: lib/lemmings_os_web/components/sidebar_components.ex:143
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:176
+#: lib/lemmings_os_web/components/sidebar_components.ex:173
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/sidebar_components.ex:145
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:220
-#: lib/lemmings_os_web/components/home_components.ex:224
-#: lib/lemmings_os_web/components/sidebar_components.ex:151
+#: lib/lemmings_os_web/components/home_components.ex:215
+#: lib/lemmings_os_web/components/home_components.ex:219
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:157
+#: lib/lemmings_os_web/components/sidebar_components.ex:154
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:163
+#: lib/lemmings_os_web/components/sidebar_components.ex:160
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:593
+#: lib/lemmings_os_web/components/sidebar_components.ex:166
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:221
-#: lib/lemmings_os_web/components/sidebar_components.ex:180
+#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/sidebar_components.ex:177
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:222
-#: lib/lemmings_os_web/components/sidebar_components.ex:186
+#: lib/lemmings_os_web/components/home_components.ex:217
+#: lib/lemmings_os_web/components/sidebar_components.ex:183
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:223
-#: lib/lemmings_os_web/components/sidebar_components.ex:192
+#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/sidebar_components.ex:189
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
-#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:79
+#: lib/lemmings_os_web/components/sidebar_components.ex:76
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:91
+#: lib/lemmings_os_web/components/sidebar_components.ex:88
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:99
+#: lib/lemmings_os_web/components/sidebar_components.ex:96
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:107
+#: lib/lemmings_os_web/components/sidebar_components.ex:104
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:115
+#: lib/lemmings_os_web/components/sidebar_components.ex:112
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:126
+#: lib/lemmings_os_web/components/sidebar_components.ex:123
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr ""
@@ -198,7 +196,7 @@ msgstr ""
 msgid ".page_title_home"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:21
+#: lib/lemmings_os_web/live/lemmings_live.ex:11
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr ""
@@ -208,12 +206,12 @@ msgstr ""
 msgid ".page_title_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:17
+#: lib/lemmings_os_web/live/departments_live.ex:21
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:18
+#: lib/lemmings_os_web/live/world_live.ex:16
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr ""
@@ -495,19 +493,19 @@ msgstr ""
 msgid ".tools_policy_copy_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:226
+#: lib/lemmings_os_web/components/home_components.ex:221
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:228
+#: lib/lemmings_os_web/components/home_components.ex:223
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/components/home_components.ex:222
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -549,65 +547,65 @@ msgstr ""
 msgid ".tools_usage_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:260
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:262
+#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:246
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
+#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:232
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:227
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:263
+#: lib/lemmings_os_web/components/home_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:249
+#: lib/lemmings_os_web/components/home_components.ex:244
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:235
+#: lib/lemmings_os_web/components/home_components.ex:230
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:266
+#: lib/lemmings_os_web/components/home_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:252
+#: lib/lemmings_os_web/components/home_components.ex:247
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:238
+#: lib/lemmings_os_web/components/home_components.ex:233
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:269
+#: lib/lemmings_os_web/components/home_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:255
+#: lib/lemmings_os_web/components/home_components.ex:250
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:241
+#: lib/lemmings_os_web/components/home_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr ""
@@ -743,23 +741,23 @@ msgstr ""
 msgid ".home_signals_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:210
+#: lib/lemmings_os_web/components/home_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:212
-#: lib/lemmings_os_web/components/home_components.ex:218
+#: lib/lemmings_os_web/components/home_components.ex:207
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:208
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr ""
@@ -809,12 +807,7 @@ msgstr ""
 msgid ".home_card_topology_summary_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:216
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
-msgstr ""
-
-#: lib/lemmings_os_web/components/home_components.ex:203
-#, elixir-autogen, elixir-format
-msgid ".home_card_topology_lemming_count_label"
 msgstr ""

--- a/priv/gettext/layout.pot
+++ b/priv/gettext/layout.pot
@@ -6,28 +6,28 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-#: lib/lemmings_os_web/components/layouts.ex:59
+#: lib/lemmings_os_web/components/layouts.ex:62
 #, elixir-autogen
 msgid ".aria_open_navigation"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:66
+#: lib/lemmings_os_web/components/layouts.ex:69
 #: lib/lemmings_os_web/components/layouts/root.html.heex:8
 #, elixir-autogen
 msgid ".brand_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:77
+#: lib/lemmings_os_web/components/layouts.ex:80
 #, elixir-autogen
 msgid ".terminal_mem"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:78
+#: lib/lemmings_os_web/components/layouts.ex:81
 #, elixir-autogen
 msgid ".terminal_tick"
 msgstr ""
 
-#: lib/lemmings_os_web/components/layouts.ex:79
+#: lib/lemmings_os_web/components/layouts.ex:82
 #, elixir-autogen
 msgid ".terminal_agents"
 msgstr ""
@@ -37,100 +37,102 @@ msgstr ""
 msgid ".sidebar_eyebrow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:143
+#: lib/lemmings_os_web/components/sidebar_components.ex:146
 #, elixir-autogen
 msgid ".nav_section_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:173
+#: lib/lemmings_os_web/components/sidebar_components.ex:176
 #, elixir-autogen
 msgid ".nav_section_operations"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:145
+#: lib/lemmings_os_web/components/sidebar_components.ex:148
 #: lib/lemmings_os_web/live/mock_shell.ex:40
 #, elixir-autogen
 msgid ".nav_home"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:215
-#: lib/lemmings_os_web/components/home_components.ex:219
-#: lib/lemmings_os_web/components/sidebar_components.ex:148
+#: lib/lemmings_os_web/components/home_components.ex:220
+#: lib/lemmings_os_web/components/home_components.ex:224
+#: lib/lemmings_os_web/components/sidebar_components.ex:151
 #: lib/lemmings_os_web/live/mock_shell.ex:41
 #, elixir-autogen
 msgid ".nav_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:154
+#: lib/lemmings_os_web/components/sidebar_components.ex:157
 #: lib/lemmings_os_web/live/mock_shell.ex:42
 #, elixir-autogen
 msgid ".nav_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:160
+#: lib/lemmings_os_web/components/sidebar_components.ex:163
 #: lib/lemmings_os_web/live/mock_shell.ex:45
 #, elixir-autogen
 msgid ".nav_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:166
+#: lib/lemmings_os_web/components/sidebar_components.ex:169
+#: lib/lemmings_os_web/components/world_components.ex:593
 #: lib/lemmings_os_web/live/mock_shell.ex:47
 #, elixir-autogen
 msgid ".nav_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:216
-#: lib/lemmings_os_web/components/sidebar_components.ex:177
+#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/sidebar_components.ex:180
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:217
-#: lib/lemmings_os_web/components/sidebar_components.ex:183
+#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/sidebar_components.ex:186
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_logs"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:218
-#: lib/lemmings_os_web/components/sidebar_components.ex:189
+#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/sidebar_components.ex:192
 #: lib/lemmings_os_web/live/mock_shell.ex:50
 #, elixir-autogen
 msgid ".nav_settings"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:69
+#: lib/lemmings_os_web/components/world_components.ex:833
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:76
+#: lib/lemmings_os_web/components/sidebar_components.ex:79
 #, elixir-autogen
 msgid ".aria_toggle_sidebar"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:88
+#: lib/lemmings_os_web/components/sidebar_components.ex:91
 #, elixir-autogen
 msgid ".footer_agents"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:96
+#: lib/lemmings_os_web/components/sidebar_components.ex:99
 #, elixir-autogen
 msgid ".footer_nodes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:104
+#: lib/lemmings_os_web/components/sidebar_components.ex:107
 #, elixir-autogen
 msgid ".footer_cpu"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:112
+#: lib/lemmings_os_web/components/sidebar_components.ex:115
 #, elixir-autogen
 msgid ".footer_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/sidebar_components.ex:123
+#: lib/lemmings_os_web/components/sidebar_components.ex:126
 #, elixir-autogen
 msgid ".footer_cluster_online"
 msgstr ""
@@ -196,7 +198,7 @@ msgstr ""
 msgid ".page_title_home"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:11
+#: lib/lemmings_os_web/live/lemmings_live.ex:21
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr ""
@@ -493,19 +495,19 @@ msgstr ""
 msgid ".tools_policy_copy_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:221
+#: lib/lemmings_os_web/components/home_components.ex:226
 #: lib/lemmings_os_web/components/system_components.ex:80
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:223
+#: lib/lemmings_os_web/components/home_components.ex:228
 #: lib/lemmings_os_web/components/system_components.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_known"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:222
+#: lib/lemmings_os_web/components/home_components.ex:227
 #: lib/lemmings_os_web/components/system_components.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_mode_partial"
@@ -547,65 +549,65 @@ msgstr ""
 msgid ".tools_usage_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:255
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:251
+#: lib/lemmings_os_web/components/home_components.ex:260
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:241
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:248
+#: lib/lemmings_os_web/components/home_components.ex:246
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:260
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:227
-#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:232
+#: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:259
 #, elixir-autogen, elixir-format
 msgid ".home_world_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:258
+#: lib/lemmings_os_web/components/home_components.ex:263
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:244
+#: lib/lemmings_os_web/components/home_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:230
+#: lib/lemmings_os_web/components/home_components.ex:235
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_partial_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:261
+#: lib/lemmings_os_web/components/home_components.ex:266
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:247
+#: lib/lemmings_os_web/components/home_components.ex:252
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:233
+#: lib/lemmings_os_web/components/home_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_policy_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:264
+#: lib/lemmings_os_web/components/home_components.ex:269
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:250
+#: lib/lemmings_os_web/components/home_components.ex:255
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:236
+#: lib/lemmings_os_web/components/home_components.ex:241
 #, elixir-autogen, elixir-format
 msgid ".home_alert_tools_runtime_source_unavailable_summary"
 msgstr ""
@@ -741,23 +743,23 @@ msgstr ""
 msgid ".home_signals_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:206
+#: lib/lemmings_os_web/components/home_components.ex:211
 #, elixir-autogen, elixir-format
 msgid ".home_source_bootstrap_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:205
+#: lib/lemmings_os_web/components/home_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:207
-#: lib/lemmings_os_web/components/home_components.ex:213
+#: lib/lemmings_os_web/components/home_components.ex:212
+#: lib/lemmings_os_web/components/home_components.ex:218
 #, elixir-autogen, elixir-format
 msgid ".home_source_runtime_checks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:208
+#: lib/lemmings_os_web/components/home_components.ex:213
 #, elixir-autogen, elixir-format
 msgid ".home_source_tools_snapshot"
 msgstr ""
@@ -807,7 +809,12 @@ msgstr ""
 msgid ".home_card_topology_summary_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/home_components.ex:211
+#: lib/lemmings_os_web/components/home_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".home_source_persisted_topology"
+msgstr ""
+
+#: lib/lemmings_os_web/components/home_components.ex:203
+#, elixir-autogen, elixir-format
+msgid ".home_card_topology_lemming_count_label"
 msgstr ""

--- a/priv/gettext/lemmings.pot
+++ b/priv/gettext/lemmings.pot
@@ -342,8 +342,8 @@ msgid ".empty_create_missing_department_copy"
 msgstr ""
 
 #: lib/lemmings_os_web/live/create_lemming_live.ex:72
-#: lib/lemmings_os_web/live/import_lemming_live.ex:171
-#: lib/lemmings_os_web/live/import_lemming_live.ex:177
+#: lib/lemmings_os_web/live/import_lemming_live.ex:152
+#: lib/lemmings_os_web/live/import_lemming_live.ex:178
 #, elixir-autogen, elixir-format
 msgid ".flash_create_scope_invalid"
 msgstr ""
@@ -415,34 +415,34 @@ msgid ".flash_export_no_lemming"
 msgstr ""
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:114
-#: lib/lemmings_os_web/live/import_lemming_live.ex:235
+#: lib/lemmings_os_web/live/import_lemming_live.ex:236
 #, elixir-autogen
 msgid ".flash_import_success"
 msgstr ""
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:218
-#: lib/lemmings_os_web/live/import_lemming_live.ex:222
+#: lib/lemmings_os_web/live/import_lemming_live.ex:219
+#: lib/lemmings_os_web/live/import_lemming_live.ex:223
 #, elixir-autogen
 msgid ".error_import_invalid_json"
 msgstr ""
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:124
-#: lib/lemmings_os_web/live/import_lemming_live.ex:246
+#: lib/lemmings_os_web/live/import_lemming_live.ex:247
 #, elixir-autogen
 msgid ".error_import_unsupported_version"
 msgstr ""
 
-#: lib/lemmings_os_web/live/import_lemming_live.ex:273
-#: lib/lemmings_os_web/live/import_lemming_live.ex:281
-#: lib/lemmings_os_web/live/import_lemming_live.ex:288
+#: lib/lemmings_os_web/live/import_lemming_live.ex:274
+#: lib/lemmings_os_web/live/import_lemming_live.ex:282
+#: lib/lemmings_os_web/live/import_lemming_live.ex:289
 #, elixir-autogen
 msgid ".error_import_record_invalid"
 msgstr ""
 
 #: lib/lemmings_os_web/live/import_lemming_live.ex:131
-#: lib/lemmings_os_web/live/import_lemming_live.ex:253
-#: lib/lemmings_os_web/live/import_lemming_live.ex:290
-#: lib/lemmings_os_web/live/import_lemming_live.ex:295
+#: lib/lemmings_os_web/live/import_lemming_live.ex:254
+#: lib/lemmings_os_web/live/import_lemming_live.ex:291
+#: lib/lemmings_os_web/live/import_lemming_live.ex:296
 #, elixir-autogen
 msgid ".error_import_failed"
 msgstr ""

--- a/priv/gettext/world.pot
+++ b/priv/gettext/world.pot
@@ -34,12 +34,12 @@ msgstr ""
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1028
-#: lib/lemmings_os_web/components/world_components.ex:1058
-#: lib/lemmings_os_web/components/world_components.ex:1075
-#: lib/lemmings_os_web/components/world_components.ex:1092
-#: lib/lemmings_os_web/components/world_components.ex:1096
-#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1071
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1135
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1160
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr ""
@@ -49,7 +49,7 @@ msgstr ""
 msgid ".label_not_imported"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:166
+#: lib/lemmings_os_web/components/city_map_components.ex:164
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr ""
@@ -59,7 +59,7 @@ msgstr ""
 msgid ".aria_city_node"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:37
+#: lib/lemmings_os_web/components/city_map_components.ex:35
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr ""
@@ -69,7 +69,8 @@ msgstr ""
 msgid ".aria_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:664
+#: lib/lemmings_os_web/components/world_components.ex:670
+#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr ""
@@ -80,7 +81,7 @@ msgstr ""
 msgid ".button_import_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:624
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr ""
@@ -101,26 +102,26 @@ msgstr ""
 msgid ".copy_world_tools_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:113
+#: lib/lemmings_os_web/live/departments_live.html.heex:115
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:138
+#: lib/lemmings_os_web/components/city_map_components.ex:136
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:120
+#: lib/lemmings_os_web/live/departments_live.html.heex:122
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:121
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr ""
@@ -152,27 +153,27 @@ msgstr ""
 msgid ".label_budgets"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1051
+#: lib/lemmings_os_web/components/world_components.ex:1094
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1047
+#: lib/lemmings_os_web/components/world_components.ex:1090
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1056
+#: lib/lemmings_os_web/components/world_components.ex:1099
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1040
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:645
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr ""
@@ -201,7 +202,7 @@ msgstr ""
 msgid ".label_last_sync"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1041
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr ""
@@ -212,7 +213,7 @@ msgstr ""
 msgid ".label_limits"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1030
+#: lib/lemmings_os_web/components/world_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr ""
@@ -239,17 +240,17 @@ msgstr ""
 msgid ".label_profiles"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1103
+#: lib/lemmings_os_web/components/world_components.ex:1146
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1026
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr ""
@@ -259,7 +260,7 @@ msgstr ""
 msgid ".label_providers"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:638
+#: lib/lemmings_os_web/components/world_components.ex:644
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr ""
@@ -270,43 +271,39 @@ msgstr ""
 msgid ".label_runtime_defaults"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1156
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1112
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:717
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:723
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:194
+#: lib/lemmings_os_web/components/city_map_components.ex:192
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
-#, elixir-autogen, elixir-format
-msgid ".metric_agents"
-msgstr ""
-
-#: lib/lemmings_os_web/components/city_map_components.ex:179
+#: lib/lemmings_os_web/components/city_map_components.ex:177
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:183
+#: lib/lemmings_os_web/components/city_map_components.ex:181
 #: lib/lemmings_os_web/components/city_map_components.ex:251
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr ""
@@ -321,47 +318,47 @@ msgstr ""
 msgid ".metric_online"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:187
+#: lib/lemmings_os_web/components/city_map_components.ex:185
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1078
+#: lib/lemmings_os_web/components/world_components.ex:1121
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1081
+#: lib/lemmings_os_web/components/world_components.ex:1124
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1127
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1087
+#: lib/lemmings_os_web/components/world_components.ex:1130
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:573
-#: lib/lemmings_os_web/components/core_components.ex:576
+#: lib/lemmings_os_web/components/core_components.ex:578
+#: lib/lemmings_os_web/components/core_components.ex:581
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:574
-#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:579
+#: lib/lemmings_os_web/components/core_components.ex:582
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:572
-#: lib/lemmings_os_web/components/core_components.ex:575
+#: lib/lemmings_os_web/components/core_components.ex:577
+#: lib/lemmings_os_web/components/core_components.ex:580
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -405,7 +402,7 @@ msgid ".title_bootstrap_config"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:109
+#: lib/lemmings_os_web/live/departments_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr ""
@@ -430,7 +427,7 @@ msgstr ""
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:712
+#: lib/lemmings_os_web/components/world_components.ex:718
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr ""
@@ -470,7 +467,7 @@ msgstr ""
 msgid ".copy_city_effective_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:707
+#: lib/lemmings_os_web/components/world_components.ex:713
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -528,11 +525,6 @@ msgstr ""
 #: lib/lemmings_os_web/live/settings_live.html.heex:101
 #, elixir-autogen
 msgid ".label_city_slug"
-msgstr ""
-
-#: lib/lemmings_os_web/components/world_components.ex:800
-#, elixir-autogen
-msgid ".label_mock_backed_preview"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:523
@@ -605,7 +597,7 @@ msgstr ""
 msgid ".city_form_node_name_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:702
+#: lib/lemmings_os_web/components/world_components.ex:708
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -678,7 +670,7 @@ msgstr ""
 msgid ".flash_city_delete_error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:605
+#: lib/lemmings_os_web/components/world_components.ex:611
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr ""
@@ -693,186 +685,181 @@ msgstr ""
 msgid ".copy_city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:84
+#: lib/lemmings_os_web/live/departments_live.html.heex:86
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:83
-#: lib/lemmings_os_web/live/departments_live.html.heex:102
+#: lib/lemmings_os_web/live/departments_live.html.heex:85
+#: lib/lemmings_os_web/live/departments_live.html.heex:104
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:756
+#: lib/lemmings_os_web/components/world_components.ex:762
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:784
+#: lib/lemmings_os_web/components/world_components.ex:790
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:774
+#: lib/lemmings_os_web/components/world_components.ex:780
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:765
+#: lib/lemmings_os_web/components/world_components.ex:771
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:781
+#: lib/lemmings_os_web/components/world_components.ex:787
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:728
+#: lib/lemmings_os_web/components/world_components.ex:734
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:738
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:739
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:806
+#: lib/lemmings_os_web/components/world_components.ex:824
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:807
+#: lib/lemmings_os_web/components/world_components.ex:825
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:795
-#, elixir-autogen, elixir-format
-msgid ".department_lemmings_mock_copy"
-msgstr ""
-
-#: lib/lemmings_os_web/components/world_components.ex:794
+#: lib/lemmings_os_web/components/world_components.ex:800
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:745
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:746
+#: lib/lemmings_os_web/components/world_components.ex:752
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:724
+#: lib/lemmings_os_web/components/world_components.ex:730
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:850
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:932
+#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:855
-#: lib/lemmings_os_web/components/world_components.ex:892
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:898
+#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:990
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:936
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:935
+#: lib/lemmings_os_web/components/world_components.ex:978
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:876
-#: lib/lemmings_os_web/components/world_components.ex:926
+#: lib/lemmings_os_web/components/world_components.ex:888
+#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:969
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:977
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:840
-#: lib/lemmings_os_web/components/world_components.ex:867
-#: lib/lemmings_os_web/components/world_components.ex:917
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:910
+#: lib/lemmings_os_web/components/world_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:836
+#: lib/lemmings_os_web/components/world_components.ex:879
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:835
+#: lib/lemmings_os_web/components/world_components.ex:878
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:863
+#: lib/lemmings_os_web/components/world_components.ex:906
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:862
+#: lib/lemmings_os_web/components/world_components.ex:905
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:903
+#: lib/lemmings_os_web/components/world_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:945
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/components/world_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:676
+#: lib/lemmings_os_web/components/world_components.ex:682
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:694
+#: lib/lemmings_os_web/components/world_components.ex:700
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:326
+#: lib/lemmings_os_web/live/departments_live.ex:307
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr ""
@@ -882,12 +869,12 @@ msgstr ""
 msgid ".flash_department_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:328
+#: lib/lemmings_os_web/live/departments_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:327
+#: lib/lemmings_os_web/live/departments_live.ex:308
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr ""
@@ -902,7 +889,17 @@ msgstr ""
 msgid ".flash_department_settings_saved"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:310
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:809
+#, elixir-autogen, elixir-format
+msgid ".button_import_lemmings"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:801
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_copy"
 msgstr ""

--- a/priv/gettext/world.pot
+++ b/priv/gettext/world.pot
@@ -34,12 +34,12 @@ msgstr ""
 
 #: lib/lemmings_os/helpers.ex:76
 #: lib/lemmings_os/helpers.ex:90
-#: lib/lemmings_os_web/components/world_components.ex:1071
-#: lib/lemmings_os_web/components/world_components.ex:1101
-#: lib/lemmings_os_web/components/world_components.ex:1118
-#: lib/lemmings_os_web/components/world_components.ex:1135
-#: lib/lemmings_os_web/components/world_components.ex:1139
-#: lib/lemmings_os_web/components/world_components.ex:1160
+#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1075
+#: lib/lemmings_os_web/components/world_components.ex:1092
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1117
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr ""
@@ -49,7 +49,7 @@ msgstr ""
 msgid ".label_not_imported"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:164
+#: lib/lemmings_os_web/components/city_map_components.ex:166
 #, elixir-autogen, elixir-format
 msgid ".aria_city_map"
 msgstr ""
@@ -59,7 +59,7 @@ msgstr ""
 msgid ".aria_city_node"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:35
+#: lib/lemmings_os_web/components/city_map_components.ex:37
 #, elixir-autogen, elixir-format
 msgid ".aria_department_node"
 msgstr ""
@@ -69,8 +69,7 @@ msgstr ""
 msgid ".aria_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:670
-#: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
+#: lib/lemmings_os_web/components/world_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr ""
@@ -81,7 +80,7 @@ msgstr ""
 msgid ".button_import_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:624
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr ""
@@ -102,26 +101,26 @@ msgstr ""
 msgid ".copy_world_tools_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:136
+#: lib/lemmings_os_web/components/city_map_components.ex:138
 #, elixir-autogen, elixir-format
 msgid ".count_running_of_total"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:571
 #: lib/lemmings_os_web/live/departments_live.html.heex:43
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/live/departments_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:572
 #: lib/lemmings_os_web/live/departments_live.html.heex:44
-#: lib/lemmings_os_web/live/departments_live.html.heex:123
+#: lib/lemmings_os_web/live/departments_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr ""
@@ -153,27 +152,27 @@ msgstr ""
 msgid ".label_budgets"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1094
+#: lib/lemmings_os_web/components/world_components.ex:1051
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1090
+#: lib/lemmings_os_web/components/world_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1099
+#: lib/lemmings_os_web/components/world_components.ex:1056
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1083
+#: lib/lemmings_os_web/components/world_components.ex:1040
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:645
+#: lib/lemmings_os_web/components/world_components.ex:639
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr ""
@@ -202,7 +201,7 @@ msgstr ""
 msgid ".label_last_sync"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr ""
@@ -213,7 +212,7 @@ msgstr ""
 msgid ".label_limits"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:1030
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr ""
@@ -240,17 +239,17 @@ msgstr ""
 msgid ".label_profiles"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1146
+#: lib/lemmings_os_web/components/world_components.ex:1103
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1070
+#: lib/lemmings_os_web/components/world_components.ex:1027
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1069
+#: lib/lemmings_os_web/components/world_components.ex:1026
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr ""
@@ -260,7 +259,7 @@ msgstr ""
 msgid ".label_providers"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:644
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr ""
@@ -271,39 +270,43 @@ msgstr ""
 msgid ".label_runtime_defaults"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1155
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1069
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:723
-#: lib/lemmings_os_web/components/world_components.ex:1113
+#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:1070
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:192
+#: lib/lemmings_os_web/components/city_map_components.ex:194
 #, elixir-autogen, elixir-format
 msgid ".map_hint_department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:177
+#: lib/lemmings_os_web/components/map_components.ex:156
+#: lib/lemmings_os_web/components/map_components.ex:202
+#, elixir-autogen, elixir-format
+msgid ".metric_agents"
+msgstr ""
+
+#: lib/lemmings_os_web/components/city_map_components.ex:179
 #: lib/lemmings_os_web/components/map_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".metric_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:181
+#: lib/lemmings_os_web/components/city_map_components.ex:183
 #: lib/lemmings_os_web/components/city_map_components.ex:251
-#: lib/lemmings_os_web/components/map_components.ex:156
-#: lib/lemmings_os_web/components/map_components.ex:202
 #, elixir-autogen, elixir-format
 msgid ".metric_lemmings"
 msgstr ""
@@ -318,47 +321,47 @@ msgstr ""
 msgid ".metric_online"
 msgstr ""
 
-#: lib/lemmings_os_web/components/city_map_components.ex:185
+#: lib/lemmings_os_web/components/city_map_components.ex:187
 #, elixir-autogen, elixir-format
 msgid ".metric_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1121
+#: lib/lemmings_os_web/components/world_components.ex:1078
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1081
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1084
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1130
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:578
-#: lib/lemmings_os_web/components/core_components.ex:581
+#: lib/lemmings_os_web/components/core_components.ex:573
+#: lib/lemmings_os_web/components/core_components.ex:576
 #: lib/lemmings_os_web/components/map_components.ex:205
 #, elixir-autogen, elixir-format
 msgid ".status_degraded"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:579
-#: lib/lemmings_os_web/components/core_components.ex:582
+#: lib/lemmings_os_web/components/core_components.ex:574
+#: lib/lemmings_os_web/components/core_components.ex:577
 #: lib/lemmings_os_web/components/map_components.ex:206
 #, elixir-autogen, elixir-format
 msgid ".status_offline"
 msgstr ""
 
-#: lib/lemmings_os_web/components/core_components.ex:577
-#: lib/lemmings_os_web/components/core_components.ex:580
+#: lib/lemmings_os_web/components/core_components.ex:572
+#: lib/lemmings_os_web/components/core_components.ex:575
 #: lib/lemmings_os_web/components/map_components.ex:204
 #, elixir-autogen, elixir-format
 msgid ".status_online"
@@ -402,7 +405,7 @@ msgid ".title_bootstrap_config"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:565
-#: lib/lemmings_os_web/live/departments_live.html.heex:111
+#: lib/lemmings_os_web/live/departments_live.html.heex:109
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr ""
@@ -427,7 +430,7 @@ msgstr ""
 #: lib/lemmings_os_web/components/world_components.ex:81
 #: lib/lemmings_os_web/components/world_components.ex:297
 #: lib/lemmings_os_web/components/world_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:712
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr ""
@@ -467,7 +470,7 @@ msgstr ""
 msgid ".copy_city_effective_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:713
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/departments_live.html.heex:38
 #, elixir-autogen
 msgid ".title_world_cities"
@@ -525,6 +528,11 @@ msgstr ""
 #: lib/lemmings_os_web/live/settings_live.html.heex:101
 #, elixir-autogen
 msgid ".label_city_slug"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:800
+#, elixir-autogen
+msgid ".label_mock_backed_preview"
 msgstr ""
 
 #: lib/lemmings_os_web/components/world_components.ex:523
@@ -597,7 +605,7 @@ msgstr ""
 msgid ".city_form_node_name_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:708
+#: lib/lemmings_os_web/components/world_components.ex:702
 #: lib/lemmings_os_web/live/cities_live.html.heex:79
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -638,12 +646,12 @@ msgstr ""
 msgid ".city_form_submit_update"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/cities_live.ex:184
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/cities_live.ex:209
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr ""
@@ -659,8 +667,8 @@ msgstr ""
 msgid ".flash_city_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:191
-#: lib/lemmings_os_web/live/cities_live.ex:216
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/cities_live.ex:219
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr ""
@@ -670,7 +678,7 @@ msgstr ""
 msgid ".flash_city_delete_error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:605
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr ""
@@ -685,242 +693,216 @@ msgstr ""
 msgid ".copy_city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:86
+#: lib/lemmings_os_web/live/departments_live.html.heex:84
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:85
-#: lib/lemmings_os_web/live/departments_live.html.heex:104
+#: lib/lemmings_os_web/live/departments_live.html.heex:83
+#: lib/lemmings_os_web/live/departments_live.html.heex:102
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:762
+#: lib/lemmings_os_web/components/world_components.ex:756
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:790
+#: lib/lemmings_os_web/components/world_components.ex:784
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:780
+#: lib/lemmings_os_web/components/world_components.ex:774
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:771
+#: lib/lemmings_os_web/components/world_components.ex:765
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:998
+#: lib/lemmings_os_web/components/world_components.ex:955
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:787
+#: lib/lemmings_os_web/components/world_components.ex:781
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:734
+#: lib/lemmings_os_web/components/world_components.ex:728
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:744
+#: lib/lemmings_os_web/components/world_components.ex:738
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:739
+#: lib/lemmings_os_web/components/world_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:824
+#: lib/lemmings_os_web/components/world_components.ex:806
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:825
+#: lib/lemmings_os_web/components/world_components.ex:807
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:800
+#: lib/lemmings_os_web/components/world_components.ex:795
+#, elixir-autogen, elixir-format
+msgid ".department_lemmings_mock_copy"
+msgstr ""
+
+#: lib/lemmings_os_web/components/world_components.ex:794
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:745
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:752
+#: lib/lemmings_os_web/components/world_components.ex:746
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:730
+#: lib/lemmings_os_web/components/world_components.ex:724
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:893
-#: lib/lemmings_os_web/components/world_components.ex:926
-#: lib/lemmings_os_web/components/world_components.ex:975
+#: lib/lemmings_os_web/components/world_components.ex:850
+#: lib/lemmings_os_web/components/world_components.ex:883
+#: lib/lemmings_os_web/components/world_components.ex:932
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:898
-#: lib/lemmings_os_web/components/world_components.ex:935
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:855
+#: lib/lemmings_os_web/components/world_components.ex:892
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:979
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:978
+#: lib/lemmings_os_web/components/world_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:888
-#: lib/lemmings_os_web/components/world_components.ex:919
-#: lib/lemmings_os_web/components/world_components.ex:969
+#: lib/lemmings_os_web/components/world_components.ex:845
+#: lib/lemmings_os_web/components/world_components.ex:876
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:977
+#: lib/lemmings_os_web/components/world_components.ex:934
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:883
-#: lib/lemmings_os_web/components/world_components.ex:910
-#: lib/lemmings_os_web/components/world_components.ex:960
+#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:836
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:878
+#: lib/lemmings_os_web/components/world_components.ex:835
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:906
+#: lib/lemmings_os_web/components/world_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:905
+#: lib/lemmings_os_web/components/world_components.ex:862
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:946
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:945
+#: lib/lemmings_os_web/components/world_components.ex:902
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:691
+#: lib/lemmings_os_web/components/world_components.ex:685
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:682
+#: lib/lemmings_os_web/components/world_components.ex:676
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:700
+#: lib/lemmings_os_web/components/world_components.ex:694
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:303
+#: lib/lemmings_os_web/live/departments_live.ex:326
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:92
+#: lib/lemmings_os_web/live/departments_live.ex:96
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:305
+#: lib/lemmings_os_web/live/departments_live.ex:328
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:304
+#: lib/lemmings_os_web/live/departments_live.ex:327
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:106
+#: lib/lemmings_os_web/live/departments_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:76
+#: lib/lemmings_os_web/live/departments_live.ex:80
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:306
+#: lib/lemmings_os_web/live/departments_live.ex:329
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
-msgstr ""
-
-#: lib/lemmings_os_web/components/world_components.ex:801
-#, elixir-autogen, elixir-format
-msgid ".department_lemmings_copy"
-msgstr ""
-
-#: lib/lemmings_os_web/components/world_components.ex:809
-#, elixir-autogen
-msgid ".button_import_lemmings"
-msgstr ""
-
-msgid ".import_lemmings_title"
-msgstr ""
-
-msgid ".import_lemmings_copy"
-msgstr ""
-
-msgid ".import_lemmings_label_json"
-msgstr ""
-
-msgid ".import_lemmings_placeholder"
-msgstr ""
-
-msgid ".button_import_cancel"
-msgstr ""
-
-msgid ".button_import_submit"
-msgstr ""
-
-msgid ".button_import_importing"
 msgstr ""

--- a/test/lemmings_os/cities_test.exs
+++ b/test/lemmings_os/cities_test.exs
@@ -1,7 +1,6 @@
 defmodule LemmingsOs.CitiesTest do
   use LemmingsOs.DataCase, async: false
 
-  alias Ecto.NoResultsError
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
 
@@ -41,15 +40,6 @@ defmodule LemmingsOs.CitiesTest do
       # Verify stable ordering: sorted by inserted_at ASC, then id ASC
       [first, second] = cities
       assert {first.inserted_at, first.id} <= {second.inserted_at, second.id}
-    end
-
-    test "S04: accepts world_id string instead of World struct" do
-      world = insert(:world)
-      city = insert(:city, world: world)
-
-      [fetched_city] = Cities.list_cities(world.id)
-
-      assert fetched_city.id == city.id
     end
 
     test "S05: returns empty list for a world with no cities" do
@@ -93,19 +83,19 @@ defmodule LemmingsOs.CitiesTest do
     end
   end
 
-  describe "fetch_city/2 and get_city!/2" do
+  describe "get_city/3" do
     test "S09: fetches a city only within the given world" do
       world = insert(:world)
       city = insert(:city, world: world)
 
-      assert {:ok, fetched_city} = Cities.fetch_city(world, city.id)
+      assert %City{} = fetched_city = Cities.get_city(world, city.id)
       assert fetched_city.id == city.id
     end
 
     test "S10: returns not_found when the city does not exist" do
       world = insert(:world)
 
-      assert {:error, :not_found} = Cities.fetch_city(world, Ecto.UUID.generate())
+      assert Cities.get_city(world, Ecto.UUID.generate()) == nil
     end
 
     test "S11: returns not_found when the city is outside the given world (cross-world isolation)" do
@@ -113,11 +103,7 @@ defmodule LemmingsOs.CitiesTest do
       other_world = insert(:world)
       city = insert(:city, world: other_world)
 
-      assert {:error, :not_found} = Cities.fetch_city(world, city.id)
-
-      assert_raise NoResultsError, fn ->
-        Cities.get_city!(world, city.id)
-      end
+      assert Cities.get_city(world, city.id) == nil
     end
   end
 

--- a/test/lemmings_os/departments_test.exs
+++ b/test/lemmings_os/departments_test.exs
@@ -69,8 +69,10 @@ defmodule LemmingsOs.DepartmentsTest do
       city = insert(:city, world: world)
       department = insert(:department, world: world, city: city)
 
-      assert %Department{} = fetched_department =
-               Departments.get_department(department.id, preload: [:world, :city])
+      fetched_department =
+        Departments.get_department(department.id, preload: [:world, :city])
+
+      assert %Department{} = fetched_department
 
       assert Ecto.assoc_loaded?(fetched_department.world)
       assert Ecto.assoc_loaded?(fetched_department.city)
@@ -85,8 +87,10 @@ defmodule LemmingsOs.DepartmentsTest do
       department = insert(:department, world: world, city: city, slug: "support")
       insert(:department, world: world, city: other_city, slug: "support")
 
-      assert %Department{} = fetched_department =
-               Departments.get_department_by_slug(city, department.slug)
+      fetched_department =
+        Departments.get_department_by_slug(city, department.slug)
+
+      assert %Department{} = fetched_department
 
       assert fetched_department.id == department.id
     end
@@ -132,11 +136,14 @@ defmodule LemmingsOs.DepartmentsTest do
       city = insert(:city, world: world)
       department = insert(:department, world: world, city: city, status: "disabled")
 
-      assert {:ok, draining_department} = Departments.set_department_status(department, "draining")
+      assert {:ok, draining_department} =
+               Departments.set_department_status(department, "draining")
+
       assert draining_department.status == "draining"
 
       assert {:ok, disabled_department} =
                Departments.set_department_status(draining_department, "disabled")
+
       assert disabled_department.status == "disabled"
 
       assert {:ok, active_again_department} =

--- a/test/lemmings_os/departments_test.exs
+++ b/test/lemmings_os/departments_test.exs
@@ -1,14 +1,13 @@
 defmodule LemmingsOs.DepartmentsTest do
   use LemmingsOs.DataCase, async: false
 
-  alias Ecto.NoResultsError
   alias LemmingsOs.Departments
   alias LemmingsOs.Departments.DeleteDeniedError
   alias LemmingsOs.Departments.Department
 
   doctest LemmingsOs.Departments
 
-  describe "list_departments/3" do
+  describe "list_departments/2" do
     test "returns departments for the explicit world/city scope" do
       world = insert(:world)
       city = insert(:city, world: world)
@@ -21,7 +20,7 @@ defmodule LemmingsOs.DepartmentsTest do
       insert(:department, world: world, city: other_city)
       insert(:department, world: other_world, city: other_world_city)
 
-      departments = Departments.list_departments(world, city)
+      departments = Departments.list_departments(city)
 
       assert Enum.sort(Enum.map(departments, & &1.id)) ==
                Enum.sort([department_a.id, department_b.id])
@@ -34,7 +33,7 @@ defmodule LemmingsOs.DepartmentsTest do
       disabled_department = insert(:department, world: world, city: city, status: "disabled")
 
       assert [filtered_department] =
-               Departments.list_departments(world.id, city.id,
+               Departments.list_departments(city,
                  status: "disabled",
                  ids: [disabled_department.id],
                  slug: disabled_department.slug,
@@ -48,36 +47,30 @@ defmodule LemmingsOs.DepartmentsTest do
     end
   end
 
-  describe "fetch/get APIs" do
-    test "fetch_department/2 returns the department by id" do
+  describe "get APIs" do
+    test "get_department/2 returns the department by id" do
       world = insert(:world)
       city = insert(:city, world: world)
       department = insert(:department, world: world, city: city)
 
-      assert {:ok, fetched_department} = Departments.fetch_department(department.id)
+      assert %Department{} = fetched_department = Departments.get_department(department.id)
       assert fetched_department.id == department.id
     end
 
-    test "fetch_department/2 returns not_found when the id is missing" do
+    test "get_department/2 returns nil when the id is missing" do
       _world = insert(:world)
       _city = insert(:city)
 
-      assert {:error, :not_found} = Departments.fetch_department(Ecto.UUID.generate())
+      assert Departments.get_department(Ecto.UUID.generate()) == nil
     end
 
-    test "get_department!/2 raises when missing" do
-      assert_raise NoResultsError, fn ->
-        Departments.get_department!(Ecto.UUID.generate())
-      end
-    end
-
-    test "fetch_department/2 supports explicit preloads" do
+    test "get_department/2 supports explicit preloads" do
       world = insert(:world)
       city = insert(:city, world: world)
       department = insert(:department, world: world, city: city)
 
-      assert {:ok, fetched_department} =
-               Departments.fetch_department(department.id, preload: [:world, :city])
+      assert %Department{} = fetched_department =
+               Departments.get_department(department.id, preload: [:world, :city])
 
       assert Ecto.assoc_loaded?(fetched_department.world)
       assert Ecto.assoc_loaded?(fetched_department.city)
@@ -92,21 +85,20 @@ defmodule LemmingsOs.DepartmentsTest do
       department = insert(:department, world: world, city: city, slug: "support")
       insert(:department, world: world, city: other_city, slug: "support")
 
-      assert {:ok, fetched_department} =
-               Departments.fetch_department_by_slug(city.id, department.slug)
+      assert %Department{} = fetched_department =
+               Departments.get_department_by_slug(city, department.slug)
 
       assert fetched_department.id == department.id
-      assert Departments.get_department_by_slug!(city, department.slug).id == department.id
     end
   end
 
-  describe "create_department/3" do
+  describe "create_department/2" do
     test "creates a department scoped to the given world and city" do
       world = insert(:world)
       city = insert(:city, world: world)
 
       assert {:ok, department} =
-               Departments.create_department(world, city, %{
+               Departments.create_department(city, %{
                  slug: "support",
                  name: "Support",
                  status: "active",
@@ -117,22 +109,9 @@ defmodule LemmingsOs.DepartmentsTest do
       assert department.city_id == city.id
       assert department.tags == ["customer-support", "high-priority"]
     end
-
-    test "rejects creating a department when the city does not belong to the world" do
-      world = insert(:world)
-      other_world = insert(:world)
-      city = insert(:city, world: other_world)
-
-      assert {:error, :city_not_in_world} =
-               Departments.create_department(world.id, city.id, %{
-                 slug: "support",
-                 name: "Support",
-                 status: "active"
-               })
-    end
   end
 
-  describe "update_department/2 and lifecycle wrappers" do
+  describe "update_department/2 and status transitions" do
     test "updates persisted department attributes" do
       world = insert(:world)
       city = insert(:city, world: world)
@@ -148,18 +127,16 @@ defmodule LemmingsOs.DepartmentsTest do
       assert updated_department.notes == "Updated notes"
     end
 
-    test "set_department_status/2 and wrappers delegate through the status path" do
+    test "set_department_status/2 drives lifecycle transitions" do
       world = insert(:world)
       city = insert(:city, world: world)
       department = insert(:department, world: world, city: city, status: "disabled")
 
-      assert {:ok, active_department} = Departments.activate_department(department)
-      assert active_department.status == "active"
-
-      assert {:ok, draining_department} = Departments.drain_department(active_department)
+      assert {:ok, draining_department} = Departments.set_department_status(department, "draining")
       assert draining_department.status == "draining"
 
-      assert {:ok, disabled_department} = Departments.disable_department(draining_department)
+      assert {:ok, disabled_department} =
+               Departments.set_department_status(draining_department, "disabled")
       assert disabled_department.status == "disabled"
 
       assert {:ok, active_again_department} =
@@ -214,7 +191,7 @@ defmodule LemmingsOs.DepartmentsTest do
     test "returns zero counts for worlds without departments" do
       world = insert(:world)
 
-      assert Departments.topology_summary(world.id) == %{
+      assert Departments.topology_summary(world) == %{
                department_count: 0,
                active_department_count: 0
              }

--- a/test/lemmings_os/runtime_city_heartbeat_test.exs
+++ b/test/lemmings_os/runtime_city_heartbeat_test.exs
@@ -69,7 +69,7 @@ defmodule LemmingsOs.Cities.HeartbeatTest do
 
       assert :ok = Heartbeat.heartbeat(pid)
 
-      assert {:ok, world} = Worlds.get_default_world()
+      assert %World{} = world = Worlds.get_default_world()
       [city] = Cities.list_cities(world)
 
       assert city.node_name == "primary@localhost"

--- a/test/lemmings_os/world_cache_test.exs
+++ b/test/lemmings_os/world_cache_test.exs
@@ -13,16 +13,16 @@ defmodule LemmingsOs.Worlds.CacheTest do
     :ok
   end
 
-  describe "fetch_world/1" do
+  describe "get_world/1" do
     test "returns the cached world after the first lookup" do
       world = insert(:world)
 
-      assert {:ok, fetched_world} = Worlds.fetch_world(world.id)
+      assert %World{} = fetched_world = Worlds.get_world(world.id)
       assert fetched_world.id == world.id
 
       Repo.delete!(world)
 
-      assert {:ok, cached_world} = Worlds.fetch_world(world.id)
+      assert %World{} = cached_world = Worlds.get_world(world.id)
       assert cached_world.id == world.id
     end
   end
@@ -31,12 +31,12 @@ defmodule LemmingsOs.Worlds.CacheTest do
     test "returns the cached default world after the first lookup" do
       world = insert(:world)
 
-      assert {:ok, default_world} = Worlds.get_default_world()
+      assert %World{} = default_world = Worlds.get_default_world()
       assert default_world.id == world.id
 
       Repo.delete!(world)
 
-      assert {:ok, cached_default_world} = Worlds.get_default_world()
+      assert %World{} = cached_default_world = Worlds.get_default_world()
       assert cached_default_world.id == world.id
     end
   end
@@ -45,10 +45,10 @@ defmodule LemmingsOs.Worlds.CacheTest do
     test "refreshes cached world and default-world reads after upsert_world/1" do
       world = insert(:world, name: "Before")
 
-      assert {:ok, fetched_world} = Worlds.fetch_world(world.id)
+      assert %World{} = fetched_world = Worlds.get_world(world.id)
       assert fetched_world.name == "Before"
 
-      assert {:ok, default_world} = Worlds.get_default_world()
+      assert %World{} = default_world = Worlds.get_default_world()
       assert default_world.id == world.id
       assert default_world.name == "Before"
 
@@ -62,11 +62,11 @@ defmodule LemmingsOs.Worlds.CacheTest do
 
       assert updated_world.name == "After"
 
-      assert {:ok, refreshed_world} = Worlds.fetch_world(world.id)
+      assert %World{} = refreshed_world = Worlds.get_world(world.id)
       assert refreshed_world.id == world.id
       assert refreshed_world.name == "After"
 
-      assert {:ok, refreshed_default_world} = Worlds.get_default_world()
+      assert %World{} = refreshed_default_world = Worlds.get_default_world()
       assert refreshed_default_world.id == world.id
       assert refreshed_default_world.name == "After"
     end

--- a/test/lemmings_os/worlds_test.exs
+++ b/test/lemmings_os/worlds_test.exs
@@ -61,7 +61,6 @@ defmodule LemmingsOs.Worlds.WorldsTest do
     end
   end
 
-
   describe "get_default_world/0" do
     test "returns the default world when one exists" do
       Repo.delete_all(World)

--- a/test/lemmings_os/worlds_test.exs
+++ b/test/lemmings_os/worlds_test.exs
@@ -1,7 +1,6 @@
 defmodule LemmingsOs.Worlds.WorldsTest do
   use LemmingsOs.DataCase, async: false
 
-  alias Ecto.NoResultsError
   alias LemmingsOs.Config.CostsConfig
   alias LemmingsOs.Config.CostsConfig.Budgets
   alias LemmingsOs.Config.LimitsConfig
@@ -49,35 +48,19 @@ defmodule LemmingsOs.Worlds.WorldsTest do
     end
   end
 
-  describe "fetch_world/1" do
+  describe "get_world/1" do
     test "returns the persisted world" do
       world = insert(:world)
 
-      assert {:ok, fetched_world} = Worlds.fetch_world(world.id)
+      assert %World{} = fetched_world = Worlds.get_world(world.id)
       assert fetched_world.id == world.id
     end
 
     test "returns an error tuple when the world does not exist" do
-      assert {:error, reason} = Worlds.fetch_world(Ecto.UUID.generate())
-      assert reason in [:not_found, :world_not_found]
+      assert Worlds.get_world(Ecto.UUID.generate()) == nil
     end
   end
 
-  describe "get_world!/1" do
-    test "returns the persisted world" do
-      world = insert(:world)
-
-      fetched_world = Worlds.get_world!(world.id)
-
-      assert fetched_world.id == world.id
-    end
-
-    test "raises when the world does not exist" do
-      assert_raise NoResultsError, fn ->
-        Worlds.get_world!(Ecto.UUID.generate())
-      end
-    end
-  end
 
   describe "get_default_world/0" do
     test "returns the default world when one exists" do
@@ -85,15 +68,14 @@ defmodule LemmingsOs.Worlds.WorldsTest do
       world = insert(:world)
       LemmingsOs.Worlds.Cache.invalidate_all()
 
-      assert {:ok, default_world} = Worlds.get_default_world()
+      assert %World{} = default_world = Worlds.get_default_world()
       assert default_world.id == world.id
     end
 
     test "returns an error tuple when no world exists" do
       Repo.delete_all(World)
       LemmingsOs.Worlds.Cache.invalidate_all()
-      assert {:error, reason} = Worlds.get_default_world()
-      assert reason in [:not_found, :world_not_found, :default_world_not_found]
+      assert Worlds.get_default_world() == nil
     end
   end
 


### PR DESCRIPTION
● ## Summary

  Simplifies the context API surface across Worlds, Cities, and Departments — removing redundant fetch/bang pairs, `*_or_*_id` entry points, and lifecycle
   wrapper functions in favour of a consistent, struct-scoped style. Read functions now return `struct | nil`; list functions accept a typed scope
  (`%World{}` or `%City{}`); lifecycle transitions go through `set_*_status/2` directly. All downstream call sites (LiveViews, page-data, snapshot
  modules) and tests are updated to match.

  Also ships the department Lemmings tab backed by real persisted data (replaces the mock preview), and adds `lemming_count` to department cards in the
  Cities page snapshot.

  ## Scope

  - [ ] Bug fix
  - [ ] Feature
  - [x] Refactor
  - [ ] Docs
  - [ ] Chore

  ## Linked Issues

  Related #

  ## Technical Notes

  - **API contract changes** — all public context reads now return `struct | nil` instead of `{:ok, struct} | {:error, :not_found}`. Callers pattern-match
   directly on the struct or `nil`.
  - **List scoping** — `Departments.list_departments/2` accepts `%World{}` or `%City{}` as first argument. The old `list_departments(world, city, opts)`
  arity is gone.
  - **Lifecycle wrappers removed** — `activate_department/1`, `drain_department/1`, `disable_department/1` are gone. All transitions go through
  `set_department_status/2`.
  - **`get_department!/2` removed** — callers updated to `get_department/2` with explicit `nil` guard or `case`.
  - **Department lemmings tab** — `DepartmentsLive` now loads real `Lemmings.list_lemmings(department)` instead of mock preview data. `MockData` alias
  removed from that module.
  - **`lemming_count` in department cards** — `CitiesPageSnapshot.department_card/2` now accepts a counts map (from
  `Lemmings.lemming_counts_by_department/1`) and includes `lemming_count` per card.
  - No migrations, no config changes, no env var changes.

  ## Validation

  - [x] `mix format`
  - [x] `mix test`
  - [x] `mix precommit`
  - [ ] Manual validation completed

  ### Manual validation notes

  - Navigate to `/departments` — city map renders with department cards.
  - Select a department → Overview, Settings tabs render correctly.
  - Select Lemmings tab → shows persisted lemmings (or empty state with create CTA if none).
  - Navigate to `/cities` and select a city — department cards show correct `lemming_count`.
  - Navigate to `/lemmings` — world unavailable state renders when no world is persisted; browse/filter/detail flow works normally when world exists.
  - Navigate to `/lemmings/new?dept=<id>` — scoped create form loads; invalid dept id falls back to unscoped form.

  ## Screenshots / Recordings (if UI changes)

  N/A

  ## Rollout / Rollback

  - Rollout notes: No migrations. Drop-in replacement — no feature flags needed.
  - Rollback notes: Revert the branch. No schema changes to undo.

  ## Checklist

  - [x] Tests added/updated for changed behavior
  - [x] Docs updated (`llms/coding_styles/elixir.md`, `llms/agents/dev_backend_elixir_engineer.md`)
  - [x] No secrets or sensitive data committed
  - [x] Backward compatibility considered — intentional internal API break; all call sites within the repo are updated
