### PR TITLE
Feat/0006 tool runtime mvp

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,4 +6,6 @@ export PORT="${PORT:-${MIX_PORT}}"
 
 export OLLAMA_BASE_URL=http://localhost:11434
 
+export LEMMINGS_RUNTIME_WORKSPACE_ROOT="~/.lemmings/workspace"
+
 [ -f .envrc.custom ] && source .envrc.custom

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,11 @@
 This is a web application written using the Phoenix web framework.
 
+## Assistant communication mode
+
+- Auto-use the `caveman` skill for all assistant responses in this repository
+- Default level is `full`
+- Keep it active until explicitly told `stop caveman` or `normal mode`
+
 ## Project guidelines
 
 - Use `mix precommit` alias when you are done with all changes and fix any pending issues

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -3,6 +3,7 @@
 @source "../css";
 @source "../js";
 @source "../../lib/lemmings_os_web";
+@source inline("hero-document-text hero-pencil-square hero-globe-alt hero-magnifying-glass hero-minus-small");
 
 @plugin "../vendor/heroicons";
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,8 +8,18 @@ parse_optional_integer = fn env_var ->
   end
 end
 
+runtime_workspace_root =
+  System.get_env("LEMMINGS_RUNTIME_WORKSPACE_ROOT") ||
+    Application.get_env(
+      :lemmings_os,
+      :runtime_workspace_root,
+      Path.expand("../priv/runtime/workspace", __DIR__)
+    )
+
 runtime_city_node_name = System.get_env("LEMMINGS_CITY_NODE_NAME") || Atom.to_string(node())
 runtime_city_heartbeat = Application.get_env(:lemmings_os, :runtime_city_heartbeat, [])
+
+config :lemmings_os, :runtime_workspace_root, runtime_workspace_root
 
 config :lemmings_os, :runtime_city,
   node_name: runtime_city_node_name,

--- a/config/test.exs
+++ b/config/test.exs
@@ -28,6 +28,7 @@ config :lemmings_os, :runtime_city_heartbeat_on_startup, false
 config :lemmings_os, :runtime_engine_on_startup, false
 config :lemmings_os, dev_routes: true
 config :lemmings_os, :runtime_dets, directory: Path.expand("../tmp/runtime/dets", __DIR__)
+config :lemmings_os, :runtime_workspace_root, Path.expand("../tmp/runtime/workspace", __DIR__)
 
 config :lemmings_os, :model_runtime,
   provider_module: LemmingsOs.ModelRuntime.Providers.Ollama,

--- a/docs/adr/0004-lemming-execution-model.md
+++ b/docs/adr/0004-lemming-execution-model.md
@@ -183,6 +183,35 @@ The GenServer is responsible for:
 
 The GenServer is **not** the source of truth for all execution data.
 
+### 5.2.1 Simplified Phase 1 execution flow
+
+```mermaid
+flowchart LR
+    User[User request] --> Runtime[LemmingInstances / Runtime boundary]
+    Runtime --> Executor[Per-instance Executor]
+    Executor --> ModelRuntime[ModelRuntime]
+    ModelRuntime --> Provider[LLM provider]
+    Provider --> Executor
+    Executor -->|tool_call| ToolRuntime[Tool Runtime]
+    ToolRuntime --> Executor
+    Executor --> Transcript[(Transcript messages)]
+    Executor --> ToolRows[(Tool execution rows)]
+    Executor -. live only .-> Trace[Executor interaction trace]
+```
+
+Phase 1 should be read as this loop:
+
+1. a user request is persisted and assigned to a `LemmingInstance`
+2. the per-instance `Executor` builds the provider request from:
+   - the frozen config snapshot
+   - the current context history
+   - the current work item
+3. `ModelRuntime` performs the provider call and returns a structured `reply` or `tool_call`
+4. when a `tool_call` is returned, the `Executor` invokes `Tool Runtime`, records a durable tool-execution row, appends the normalized tool result back into context, and loops to the model again
+5. when a final `reply` is returned, the `Executor` persists the assistant transcript message and advances lifecycle state
+
+This loop makes the `Executor` the orchestration owner for one runtime session, while keeping model execution and tool execution behind dedicated boundaries.
+
 ## 5.3 State model
 
 Each Lemming instance behaves as an explicit stateful execution with states such as:
@@ -247,6 +276,18 @@ The GenServer should keep only lightweight runtime coordination state, such as:
 - references to config snapshot, context snapshot, and usage/accounting records
 
 Large or durable concerns must remain outside the process.
+
+The Phase 1 runtime keeps one additional explicitly ephemeral structure in process memory:
+
+- a bounded interaction trace for the live LLM/tool loop used by operator debug surfaces
+
+This trace is:
+
+- owned by the `Executor`
+- live-only and non-authoritative
+- safe to lose on process termination
+- not part of the durable transcript model
+- not a replacement for persisted tool execution rows or transcript messages
 
 ## 5.5 Persisted execution state
 

--- a/docs/adr/0004-lemming-execution-model.md
+++ b/docs/adr/0004-lemming-execution-model.md
@@ -135,11 +135,11 @@ Each execution instance:
 
 The Lemming definition shown in the control plane represents a **Lemming type** or template. Runtime work is performed by **Lemming instances** spawned from that type.
 
-## 4.1 Phase 1 Runtime Slice
+## 4.1 v1 Runtime Contract
 
-This ADR defines the long-term execution model and remains the source of truth for the intended architecture. The Phase 1 runtime slice uses a narrower operational subset rather than the full long-term execution taxonomy.
+This ADR defines the execution model and remains the source of truth for the intended architecture. The v1 runtime contract implements the required execution boundary with a constrained operational taxonomy.
 
-Phase 1 focuses on:
+v1 includes:
 
 - on-demand `LemmingInstance` creation from a durable `Lemming`
 - supervised per-instance executor processes
@@ -147,7 +147,7 @@ Phase 1 focuses on:
 - model execution through `ModelRuntime`
 - no peer delegation, join semantics, or generalized pause/resume workflow
 
-The richer execution model in this ADR remains the intended long-term architecture unless intentionally revised by a later ADR. The Phase 1 runtime slice does not replace that model; it defines an intentionally smaller contract for the first runtime slice.
+Peer delegation, join semantics, and generalized pause/resume workflow are deferred beyond v1. They extend this execution model; they do not replace it.
 
 ---
 
@@ -183,7 +183,7 @@ The GenServer is responsible for:
 
 The GenServer is **not** the source of truth for all execution data.
 
-### 5.2.1 Simplified Phase 1 execution flow
+### 5.2.1 v1 Execution Flow
 
 ```mermaid
 flowchart LR
@@ -199,7 +199,7 @@ flowchart LR
     Executor -. live only .-> Trace[Executor interaction trace]
 ```
 
-Phase 1 should be read as this loop:
+v1 execution follows this loop:
 
 1. a user request is persisted and assigned to a `LemmingInstance`
 2. the per-instance `Executor` builds the provider request from:
@@ -230,9 +230,9 @@ Each Lemming instance behaves as an explicit stateful execution with states such
 
 The exact set of states may evolve, but the execution model is explicitly state-based and resumable.
 
-### Phase 1 status subset
+### v1 Status Subset
 
-The Phase 1 runtime slice uses the following operational statuses:
+The v1 runtime contract uses the following operational statuses:
 
 - `created`
 - `queued`
@@ -242,26 +242,26 @@ The Phase 1 runtime slice uses the following operational statuses:
 - `failed`
 - `expired`
 
-These statuses are a constrained Phase 1 subset of the richer execution model above, not a replacement for it. They collapse several long-term states into operationally simpler buckets:
+These statuses are a constrained v1 subset of the richer execution model above. They collapse several states into operationally simpler buckets:
 
-| Phase 1 status | Long-term interpretation |
+| v1 status | Architectural interpretation |
 |---|---|
-| `created` | persisted instance exists before scheduler admission; the long-term model keeps this as the pre-execution lifecycle boundary |
-| `queued` | ready-to-run work exists and is awaiting admission; later phases may split queue residency from more specialized waiting states |
+| `created` | persisted instance exists before scheduler admission; the model keeps this as the pre-execution lifecycle boundary |
+| `queued` | ready-to-run work exists and is awaiting admission; future extensions may split queue residency from more specialized waiting states |
 | `processing` | coarse operational bucket covering active `running` work and `waiting_model` provider execution |
 | `retrying` | operational form of `retry_backoff`; the instance is retrying the same work item under the configured retry policy |
-| `idle` | reusable waiting bucket used after successful work completion when no queued work remains; later phases may refine this into `waiting_message`, `paused`, or other quiescent states |
-| `failed` | terminal failure state aligned with the long-term `failed` outcome |
-| `expired` | Phase 1 terminal idle-timeout outcome; a specialized operational terminal state that future phases may model with richer terminal-reason semantics |
+| `idle` | reusable waiting bucket used after successful work completion when no queued work remains; future extensions may refine this into `waiting_message`, `paused`, or other quiescent states |
+| `failed` | terminal failure state aligned with the architectural `failed` outcome |
+| `expired` | v1 terminal idle-timeout outcome; future extensions may model it with richer terminal-reason semantics |
 
 The main mapping constraints are therefore:
 
 - `running` and `waiting_model` map to `processing`
 - `retry_backoff` maps to `retrying`
-- `idle` is the deliberate Phase 1 stand-in for reusable waiting states that are not yet split into finer-grained categories
-- `waiting_tool`, `waiting_message`, `paused`, `completed`, and `cancelled` are deferred beyond Phase 1
+- `idle` is the deliberate v1 representation for reusable waiting states that are not yet split into finer-grained categories
+- `waiting_tool`, `waiting_message`, `paused`, `completed`, and `cancelled` are deferred beyond v1
 
-Deferred states remain part of the intended long-term model and should be introduced explicitly in later phases rather than inferred from temporary implementation shortcuts.
+Deferred states remain part of the execution model and must be introduced explicitly rather than inferred from implementation shortcuts.
 
 ## 5.4 Minimal in-process state
 
@@ -277,7 +277,7 @@ The GenServer should keep only lightweight runtime coordination state, such as:
 
 Large or durable concerns must remain outside the process.
 
-The Phase 1 runtime keeps one additional explicitly ephemeral structure in process memory:
+The v1 runtime keeps one additional explicitly ephemeral structure in process memory:
 
 - a bounded interaction trace for the live LLM/tool loop used by operator debug surfaces
 
@@ -323,9 +323,9 @@ Instead, it progresses by:
 
 This keeps the execution model OTP-native, observable, and restart-friendly.
 
-## 5.7 Phase 1 runtime control components
+## 5.7 v1 Runtime Control Components
 
-Phase 1 formalizes a small runtime control layer around each `LemmingInstance`.
+v1 formalizes the runtime control layer around each `LemmingInstance`.
 
 ### Executor
 
@@ -341,13 +341,13 @@ Responsibilities:
 
 ### DepartmentScheduler
 
-Phase 1 introduces a formal **DepartmentScheduler** runtime component. There is one scheduler per active Department.
+v1 introduces a formal **DepartmentScheduler** runtime component. There is one scheduler per active Department.
 
 Responsibilities:
 
 - own scheduling truth for the Department's queued instances
 - react to runtime signals that work is available or capacity was released
-- select the oldest eligible queued instance first in Phase 1
+- select the oldest eligible queued instance first in v1
 - request scarce execution capacity before an executor begins processing
 - remain focused on scheduling responsibility, not Department lifecycle management
 
@@ -363,7 +363,7 @@ Responsibilities:
 - key capacity by the scarce resource, not by organizational scope
 - allow many Departments to contend for the same model endpoint safely
 
-In Phase 1 the pool key is the **resource key**, for example `ollama:llama3.2`. This is intentionally not keyed by Department or City. The bottleneck is the model endpoint itself.
+In v1 the pool key is the **resource key**, for example `ollama:llama3.2`. This is intentionally not keyed by Department or City. The bottleneck is the model endpoint itself.
 
 That resource key must come from the same normalized active-model selection
 contract consumed by `ModelRuntime`. The scheduler does not define its own
@@ -381,11 +381,11 @@ Responsibilities:
 - capture normalized token and usage data
 - keep provider-specific HTTP details outside the executor
 
-`Providers.Ollama` is the first provider implementation for Phase 1. Additional providers extend this boundary; they do not change the executor's orchestration role.
+`Providers.Ollama` is the first provider implementation for v1. Additional providers extend this boundary; they do not change the executor's orchestration role.
 
-## 5.8 Phase 1 boot recovery semantics
+## 5.8 v1 Boot Recovery Semantics
 
-Phase 1 recovery after application restart is intentionally narrow and must be read as an explicit contract, not as a vague promise of general rehydration.
+v1 recovery after application restart is explicitly limited to session attachment and transcript-driven replay. It is not a promise of exact in-flight rehydration.
 
 ### Automatic boot reconciliation
 
@@ -407,7 +407,7 @@ The boot-time contract is:
 - if there is no pending trailing `user` message, the session is reattached as `idle` so it can accept follow-up input again
 - `queued`, `processing`, and `retrying` do not resume from an in-flight provider call; they are treated as recoverable-at-best and collapse either to "resume pending user work" or "reattach idle" depending on transcript state
 
-In other words, Phase 1 automatically recovers **session attachment**, not exact in-flight execution position.
+In other words, v1 automatically recovers **session attachment**, not exact in-flight execution position.
 
 ### States requiring explicit caller or operator action
 
@@ -415,7 +415,7 @@ In other words, Phase 1 automatically recovers **session attachment**, not exact
 - that retry action only succeeds when there is a pending trailing `user` message to replay; otherwise the failure remains terminal
 - `expired` is terminal for the session lifecycle and is not reattached automatically; callers must spawn a new session
 
-This is consistent with the broader Phase 1 design: durable session identity and transcript survive restart, while in-flight execution remains recoverable-at-best until richer rehydration semantics are introduced.
+This is consistent with the v1 contract: durable session identity and transcript survive restart, while in-flight execution remains recoverable-at-best until richer rehydration semantics are introduced.
 
 ---
 

--- a/docs/adr/0005-tool-execution-model.md
+++ b/docs/adr/0005-tool-execution-model.md
@@ -148,6 +148,39 @@ Tools are:
 
 The runtime includes a **Tool Registry** responsible for tracking installed, registered, and enabled tools.
 
+## 4.1 v1 Implementation Constraints
+
+The v1 implementation establishes the Tool Runtime boundary, durable tool history, and operator-visible execution lifecycle while deferring the broader registry, policy, package, MCP, and sandbox-governance layers.
+
+The v1 implementation has the following constraints:
+
+- the executable catalog is fixed in code to these four tools:
+  - `fs.read_text_file`
+  - `fs.write_text_file`
+  - `web.search`
+  - `web.fetch`
+- the `Executor` invokes `LemmingsOs.Tools.Runtime.execute/4` directly after `ModelRuntime` returns a structured `tool_call`
+- tool execution is performed inline in the executor loop for the current runtime session
+- each attempted invocation creates a durable `lemming_instance_tool_executions` row
+- each row is scoped to the `World` and `LemmingInstance`
+- each row stores the tool name, args, status, summary, preview, normalized result or normalized error, timestamps, and duration
+- supported tool execution statuses are `running`, `ok`, and `error`
+- PubSub and telemetry expose lifecycle visibility but do not own tool execution
+- the tools page reads the same fixed catalog used by the runtime
+
+Deferred beyond v1:
+
+- Hex package discovery
+- dynamic tool registration
+- hierarchical tool policy enforcement
+- approvals
+- MCP adapters
+- Docker or external-process sandboxing
+- generic shell or command execution
+- git/worktree tools
+
+The fixed catalog is not the general registry model. It is the v1 catalog contract used to establish that model-selected tool calls cross the controlled execution boundary, produce durable history, and continue the reasoning loop.
+
 ---
 
 # 5. Tool Model
@@ -182,22 +215,24 @@ Lemming Instance
    ↓
 Tool Request
    ↓
-Policy Check
+Catalog and scope check
    ↓
 Tool Adapter Execution
    ↓
 Result
    ↓
-Audit/Event Log
+Durable Tool Execution Row + Runtime Signals
 ```
 
 This boundary ensures that:
 
-- tool permissions can be enforced
-- connection access can be enforced
-- tool usage can be audited
-- resource limits can be applied
+- unsupported tools are rejected before adapter execution
+- instance and World scope are checked before execution
+- tool usage leaves durable runtime history
+- normalized results and errors are returned to the executor
 - failures can be isolated
+
+Hierarchical policy, connection access, resource limits, approvals, and broader audit enforcement are deferred beyond v1. They extend this boundary; they do not replace it.
 
 ---
 
@@ -245,13 +280,13 @@ This architecture ensures that all side effects pass through a controlled runtim
 
 # 8. Tool Invocation Model
 
-From the perspective of a Lemming instance, tool execution is always modeled as asynchronous.
+The Tool Runtime boundary is mandatory. The invocation transport may be direct or asynchronous depending on the tool class, execution duration, and isolation adapter.
 
-A Lemming submits a tool request to the Tool Runtime and later receives completion through a runtime callback event.
+Bounded trusted first-party tools may execute through a direct runtime call. Long-running tools, external runners, approval waits, and callback-driven integrations require an asynchronous invocation contract.
 
-This remains true even when the underlying tool implementation may execute quickly or synchronously internally.
+In both cases, the Lemming interacts with the Tool Runtime rather than with the tool implementation directly.
 
-This model aligns with OTP-style runtime design and provides a consistent contract for:
+The asynchronous invocation contract supports:
 
 - long-running tool calls
 - external callbacks
@@ -259,7 +294,29 @@ This model aligns with OTP-style runtime design and provides a consistent contra
 - waiting states in agent execution
 - audit and event tracing
 
-The runtime may internally optimize specific tool adapters, but that does not change the external contract seen by the Lemming.
+The runtime may optimize specific tool adapters, but adapter optimization must not bypass the Tool Runtime boundary.
+
+## 8.1 v1 Direct Invocation Contract
+
+The v1 implementation uses a direct runtime-call contract. This is the supported v1 execution path and does not weaken the architectural requirement that all external effects pass through the Tool Runtime.
+
+v1 flow:
+
+```text
+Executor
+  -> ModelRuntime returns action = :tool_call
+  -> Executor creates durable tool execution row with status = "running"
+  -> Executor calls Tools.Runtime.execute/4 directly
+  -> Tool Runtime validates fixed catalog membership and scope
+  -> Tool adapter executes
+  -> Executor updates the same durable row to "ok" or "error"
+  -> Executor appends a normalized tool-result context message
+  -> Executor calls ModelRuntime again until final reply or bounded failure
+```
+
+PubSub is used only to notify LiveViews that a persisted tool row changed. It is not the tool execution transport.
+
+Asynchronous callbacks for long-running tools, approval waits, external runners, and richer supervision semantics are deferred beyond v1 and must preserve the same Tool Runtime boundary.
 
 ---
 

--- a/docs/adr/0016-tool-execution-isolation-model.md
+++ b/docs/adr/0016-tool-execution-isolation-model.md
@@ -212,6 +212,32 @@ Primary isolation mechanisms include:
 
 These protections ensure that tools cannot access host resources beyond what is explicitly permitted.
 
+## 4.1 v1 Implementation Constraints
+
+The v1 implementation enforces the filesystem work-area boundary for trusted first-party tools. Stronger process, network, and resource isolation remain part of the architecture and are deferred beyond v1.
+
+The v1 implementation has the following constraints:
+
+- only four first-party tools are executable: `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch`
+- all four tools run in-process as reviewed first-party Elixir code
+- each spawned runtime session gets a dedicated work area under the configured runtime workspace root
+- filesystem tools resolve paths relative to `<workspace_root>/<department_id>/<lemming_id>`
+- tool-visible filesystem paths are normalized to `/workspace/<department_id>/<lemming_id>/...`
+- filesystem tools reject absolute paths and paths that escape the work area
+- web tools use `Req` and validate `http` or `https` URL shape
+
+Deferred beyond v1:
+
+- external OS process runners
+- Docker sandboxing
+- MCP execution
+- command allowlists
+- kernel-level network sandboxing
+- per-tool resource limits
+- approval waits
+
+These constraints do not change the isolation decision. They define the v1 implementation stage for trusted first-party tools before untrusted package execution is supported.
+
 ---
 
 # 5. Isolation Layers
@@ -606,7 +632,7 @@ This ensures that all runtime governance decisions are evaluated before the tool
 
 The isolation model provides several critical protections.
 
-Tools cannot:
+Untrusted or external-process tools cannot:
 
 - access arbitrary host filesystem paths
 - read runtime configuration files
@@ -621,7 +647,9 @@ As a result:
 - secret exposure risk is reduced
 - resource exhaustion attacks are limited
 
-The BEAM runtime remains isolated from tool execution failures.
+Trusted first-party in-process tools are the explicit exception described in section 6.1 and section 4.1. They still pass through Tool Runtime validation and observability, but they do not provide the same process-isolation guarantee as external-process tools.
+
+For external-process tools, the BEAM runtime remains isolated from tool execution failures.
 
 ---
 

--- a/docs/adr/0018-audit-log-event-model.md
+++ b/docs/adr/0018-audit-log-event-model.md
@@ -274,7 +274,37 @@ Telemetry events are intended to answer:
 - how long it took
 - where performance or reliability problems exist
 
-## 5.3 Shared Envelope, Distinct Semantics
+## 5.3 Tool Runtime v1 Events
+
+The v1 Tool Runtime implementation emits operational signals through the existing structured logger, in-memory activity log, PubSub, and Elixir Telemetry. Durable canonical audit events for tool execution are not supported yet.
+
+Implemented v1 signals:
+
+- structured log event `instance.executor.tool_execution.started`
+- structured log event `instance.executor.tool_execution.completed`
+- structured log event `instance.executor.tool_execution.failed`
+- telemetry event `[:lemmings_os, :runtime, :tool_execution, :started]`
+- telemetry event `[:lemmings_os, :runtime, :tool_execution, :completed]`
+- telemetry event `[:lemmings_os, :runtime, :tool_execution, :failed]`
+- PubSub notification `:tool_execution_upserted` for instance transcript refresh
+- in-memory activity-log entries in the `tool_execution` category
+
+Telemetry metadata includes the hierarchy and tool identity needed for runtime diagnostics:
+
+- `world_id`
+- `city_id`
+- `department_id`
+- `lemming_id`
+- `instance_id`
+- `tool_execution_id`
+- `tool_name`
+- `tool_status`
+- `duration_ms`
+- `reason` on failure
+
+The durable v1 history is the `lemming_instance_tool_executions` table, not the platform audit-event table. That table is runtime history scoped to one instance; it supports transcript reconstruction and operator inspection but does not replace the canonical append-only audit envelope.
+
+## 5.4 Shared Envelope, Distinct Semantics
 
 Audit and telemetry use the same base envelope so that infrastructure remains simple and query patterns remain consistent.
 

--- a/docs/adr/0021-core-domain-schema.md
+++ b/docs/adr/0021-core-domain-schema.md
@@ -41,6 +41,7 @@ LemmingsOS adopts a canonical relational core domain schema centered on the foll
 - `lemmings`
 - `lemming_instances`
 - `lemming_instance_messages`
+- `lemming_instance_tool_executions`
 - `tool_registry`
 - `tool_policies`
 
@@ -52,27 +53,29 @@ The model distinguishes clearly between:
 - **agent entities** - `lemmings`
 - **runtime entities** - `lemming_instances`
 - **runtime transcript entities** - `lemming_instance_messages`
+- **runtime tool history entities** - `lemming_instance_tool_executions`
 - **governance entities** - `tool_registry`, `tool_policies`
 
 If the product later introduces a reusable template layer, that layer must be modeled as an explicit extension of the core schema, not as a replacement for `lemmings` or `lemming_instances`.
 
-## 3.1 Phase 1 Runtime Slice
+## 3.1 v1 Runtime Schema Contract
 
-This ADR defines the intended core schema. The Phase 1 runtime slice adopts a narrower runtime schema contract that is still part of the canonical architecture.
+This ADR defines the intended core schema. The v1 runtime schema contract is part of the canonical architecture and identifies which runtime tables and fields are required by the v1 implementation.
 
-Phase 1 runtime scope:
+v1 runtime scope:
 
 - `lemming_instances` records runtime session identity, hierarchy scope, lifecycle status, frozen config snapshot, and temporal markers
 - `lemming_instance_messages` stores the durable transcript for each runtime session
+- `lemming_instance_tool_executions` stores durable history for attempted tool calls
 - the first user request is stored as the first `lemming_instance_messages` row, not duplicated on `lemming_instances`
 
-Deferred beyond Phase 1:
+Deferred beyond v1:
 
 - parent/child instance lineage for delegation workflows
 - generalized checkpoint metadata columns on the relational runtime record
 - any separate opaque `instance_ref` beyond the UUID primary key, and only if future routing or interop needs justify it
 
-In Phase 1, `lemming_instances.id` acts as the runtime `instance_ref`.
+In v1, `lemming_instances.id` is the stable runtime reference.
 
 ---
 
@@ -112,6 +115,7 @@ erDiagram
 
     LEMMINGS ||--o{ LEMMING_INSTANCES : executes_as
     LEMMING_INSTANCES ||--o{ LEMMING_INSTANCE_MESSAGES : contains
+    LEMMING_INSTANCES ||--o{ LEMMING_INSTANCE_TOOL_EXECUTIONS : records
 
     TOOL_REGISTRY ||--o{ TOOL_POLICIES : governed_by
 
@@ -207,6 +211,22 @@ erDiagram
         jsonb usage
     }
 
+    LEMMING_INSTANCE_TOOL_EXECUTIONS {
+        uuid id
+        uuid lemming_instance_id
+        uuid world_id
+        string tool_name
+        string status
+        jsonb args
+        jsonb result
+        jsonb error
+        text summary
+        text preview
+        timestamp started_at
+        timestamp completed_at
+        integer duration_ms
+    }
+
     TOOL_REGISTRY {
         uuid id
         string name
@@ -233,20 +253,20 @@ The Mermaid diagram above represents the canonical relational model for the runt
 
 Operational timestamp columns such as `inserted_at` and `updated_at` are expected additions to runtime tables. They do not change the core schema contract described here.
 
-## 5.1 Phase 1 runtime table contract
+## 5.1 v1 Runtime Table Contract
 
-The Phase 1 runtime slice treats the runtime tables below as the canonical schema contract for the first runtime engine milestone. This section is normative for Phase 1.
+The v1 runtime implementation treats the runtime tables below as the required schema contract. This section is normative for v1.
 
 ### `lemming_instances`
 
-Phase 1 columns:
+v1 columns:
 
 - `id` - UUID primary key and stable runtime identity
 - `lemming_id` - foreign key to the durable `lemmings` row
 - `world_id` - World isolation scope
 - `city_id` - City execution locality scope
 - `department_id` - Department scheduling scope
-- `status` - runtime lifecycle status using the Phase 1 subset from ADR-0004: `created`, `queued`, `processing`, `retrying`, `idle`, `failed`, `expired`
+- `status` - runtime lifecycle status using the v1 subset from ADR-0004: `created`, `queued`, `processing`, `retrying`, `idle`, `failed`, `expired`
 - `config_snapshot` - frozen resolved runtime configuration captured at spawn time
 - `started_at` - runtime process birth time
 - `last_activity_at` - last meaningful runtime transition
@@ -254,22 +274,22 @@ Phase 1 columns:
 - `inserted_at` - durable record creation time
 - `updated_at` - last row mutation time
 
-Deferred beyond Phase 1:
+Deferred beyond v1:
 
 - `instance_ref` - not required while the UUID primary key is the stable runtime identity
 - `parent_instance_id` - reserved for future delegation and lineage workflows
 - `last_checkpoint_at` - deferred until rehydration becomes an active runtime feature
 
-These deferred fields remain valid future extensions, but they are not part of the Phase 1 contract and must not be implied by the schema today.
+These deferred fields remain valid future extensions, but they are not part of the v1 contract and must not be implied by the schema today.
 
 ### `lemming_instance_messages`
 
-Phase 1 columns:
+v1 columns:
 
 - `id` - UUID primary key
 - `lemming_instance_id` - foreign key to the owning runtime session
 - `world_id` - World isolation scope for transcript queries
-- `role` - transcript role, with Phase 1 values `user` and `assistant`
+- `role` - transcript role, with v1 values `user` and `assistant`
 - `content` - durable transcript content
 - `provider` - provider name for assistant messages when applicable
 - `model` - model identifier for assistant messages when applicable
@@ -283,7 +303,7 @@ Phase 1 columns:
 
 `total_tokens` and `usage` are intentional compatibility cushions. They allow the schema to preserve useful provider accounting data without forcing every provider to match a prematurely rigid normalized shape. Application logic must remain valid when either field is absent.
 
-For Phase 1, that first user input has a deliberate dual representation:
+In v1, that first user input has a deliberate dual representation:
 
 - durable representation: the first `lemming_instance_messages` row with `role = "user"`
 - ephemeral execution representation: the first in-memory work item queued for the executor
@@ -291,6 +311,30 @@ For Phase 1, that first user input has a deliberate dual representation:
 This is intentional. The transcript row is the durable record. The work item is
 the runtime execution unit. The executor does not consume work directly from the
 message table.
+
+### `lemming_instance_tool_executions`
+
+v1 columns:
+
+- `id` - UUID primary key
+- `lemming_instance_id` - foreign key to the owning runtime session
+- `world_id` - World isolation scope for tool-history queries
+- `tool_name` - fixed v1 catalog identifier
+- `status` - tool lifecycle status with v1 values `running`, `ok`, and `error`
+- `args` - normalized tool arguments as received by the Tool Runtime
+- `result` - normalized successful result payload
+- `error` - normalized error payload with stable `code`, `message`, and `details`
+- `summary` - compact human-readable summary for transcript cards
+- `preview` - compact preview text for transcript cards
+- `started_at` - tool execution start time
+- `completed_at` - tool execution completion or failure time
+- `duration_ms` - elapsed wall-clock duration in milliseconds
+- `inserted_at` - durable record creation time
+- `updated_at` - last row mutation time
+
+`lemming_instance_tool_executions` is runtime history, not a transcript message role. The message table remains limited to user-visible conversation turns, while tool execution rows record external-effect attempts and are merged into session timelines by read models.
+
+Rows are created as `running` before adapter execution and updated to `ok` or `error` after the direct runtime call returns. Rows are also used to reconstruct historical tool cards after page reload.
 
 ---
 
@@ -396,7 +440,7 @@ Recommendations:
 - database `id` remains the durable primary key
 - runtime PIDs or node-local process identifiers must never be treated as canonical durable identity
 
-Phase 1 explicitly uses the UUID primary key as the stable runtime identity. An additional opaque `instance_ref` is an optional future extension only if routing or interop needs justify it; it is not implied by the current design and is not part of the Phase 1 runtime slice.
+v1 uses the UUID primary key as the stable runtime identity. An additional opaque `instance_ref` is an optional future extension only if routing or interop needs justify it; it is not implied by the current design and is not part of the v1 runtime contract.
 
 ## Hierarchy References Always Stored
 
@@ -430,6 +474,8 @@ The core runtime relationships are:
 - `lemming_instances` belong to `departments`, `cities`, and `worlds`
 - `lemming_instance_messages` belong to `lemming_instances`
 - `lemming_instance_messages` also belong to `worlds`
+- `lemming_instance_tool_executions` belong to `lemming_instances`
+- `lemming_instance_tool_executions` also belong to `worlds`
 - `tool_policies` reference `tool_registry`
 - `tool_policies` attach to hierarchy scopes and optionally to Lemmings or runtime instances
 
@@ -474,11 +520,15 @@ The schema should be indexed according to common runtime, audit, routing, and co
 - `lemming_instances(lemming_id)`
 - `lemming_instance_messages(world_id)`
 - `lemming_instance_messages(lemming_instance_id)`
+- `lemming_instance_tool_executions(world_id)`
+- `lemming_instance_tool_executions(lemming_instance_id)`
 
 ### Runtime state indexes
 
 - `lemming_instances(status)`
 - `lemming_instance_messages(role)`
+- `lemming_instance_tool_executions(status)`
+- `lemming_instance_tool_executions(tool_name)`
 - `cities(status)`
 - `departments(status)`
 
@@ -490,7 +540,7 @@ The schema should be indexed according to common runtime, audit, routing, and co
 - unique composite index on `lemmings(department_id, slug)`
 - unique index on `tool_registry.slug`
 
-Phase 1 does not require a unique `instance_ref` index because the UUID primary key is the stable runtime identifier. If `instance_ref` is introduced later, it should be treated as an optional extension justified by routing or interop needs, and its uniqueness contract must be defined explicitly at that time.
+v1 does not require a unique `instance_ref` index because the UUID primary key is the stable runtime identifier. If `instance_ref` is introduced later, it should be treated as an optional extension justified by routing or interop needs, and its uniqueness contract must be defined explicitly at that time.
 
 ### Policy indexes
 
@@ -519,7 +569,7 @@ The schema supports direct operational inspection.
 
 The domain schema does not replace audit tables, but it gives them stable foreign keys and scope references.
 
-## Runtime table semantics for Phase 1
+## Runtime Table Semantics for v1
 
 `lemming_instances` temporal markers have explicit semantics:
 
@@ -534,6 +584,8 @@ the executor has not initialized yet. In that window, `inserted_at` is set and
 
 `lemming_instance_messages` is the canonical transcript table for runtime sessions. The initial user request belongs there, not on the instance row.
 
+`lemming_instance_tool_executions` is the canonical runtime-history table for v1 tool attempts. It is queried alongside messages to render compact transcript tool cards and raw interaction views, but it does not change the `user` / `assistant` transcript role taxonomy.
+
 ---
 
 # 11. Implementation Notes
@@ -547,6 +599,7 @@ LemmingsOs.Departments.Department
 LemmingsOs.Lemmings.Lemming
 LemmingsOs.LemmingInstances.LemmingInstance
 LemmingsOs.LemmingInstances.Message
+LemmingsOs.LemmingInstances.ToolExecution
 LemmingsOs.ToolRegistry.Tool
 LemmingsOs.ToolPolicies.ToolPolicy
 ```

--- a/docs/adr/0024-observability-and-monitoring-model.md
+++ b/docs/adr/0024-observability-and-monitoring-model.md
@@ -250,6 +250,16 @@ Possible metrics include:
 - queue depth
 - failure rates
 
+The v1 Tool Runtime implementation emits concrete telemetry metrics for the fixed tool catalog:
+
+- `lemmings_os.runtime.tool_execution.started.count`
+- `lemmings_os.runtime.tool_execution.completed.count`
+- `lemmings_os.runtime.tool_execution.failed.count`
+- `lemmings_os.runtime.tool_execution.completed.duration_ms`
+- `lemmings_os.runtime.tool_execution.failed.duration_ms`
+
+These metrics are emitted from executor-owned lifecycle transitions and tagged with hierarchy metadata plus `tool_name` and `tool_execution_id`. They measure runtime execution visibility only. The broader audit store, approval workflow, policy engine, and sandbox-resource metrics are deferred beyond v1.
+
 Operators may export these metrics to systems such as:
 
 - Prometheus
@@ -330,4 +340,3 @@ Telemetry hooks may emit metrics and integrate with Phoenix LiveDashboard when a
 ## Mitigations
 
 Optional telemetry exporters and log collectors can be integrated when deeper observability is required without modifying the core runtime architecture.
-

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,7 +89,7 @@ Responsibilities:
 
 ### Runtime engine layer
 
-The Phase 1 runtime engine is a formal architectural layer. It sits below contexts and above infrastructure.
+The v1 runtime engine is a formal architectural layer. It sits below contexts and above infrastructure.
 
 #### Executor
 
@@ -113,7 +113,7 @@ Responsibilities:
 
 - one scheduler per active Department
 - own scheduling truth for queued instances in that Department
-- select the oldest eligible instance first in Phase 1
+- select the oldest eligible instance first in v1
 - request scarce execution capacity before the executor begins processing
 
 Namespace clarification:
@@ -133,7 +133,7 @@ Responsibilities:
 - key capacity by resource key, not by Department or City
 - allow many Departments to contend safely for the same model endpoint
 
-Phase 1 resource keys look like `ollama:llama3.2`. The scarce thing is the model endpoint itself, so the pool is keyed by resource identity rather than organization.
+v1 resource keys look like `ollama:llama3.2`. The scarce thing is the model endpoint itself, so the pool is keyed by resource identity rather than organization.
 
 The key detail is where that resource key comes from: scheduler admission and
 model execution both read the same normalized active-model contract from the
@@ -154,12 +154,43 @@ Responsibilities:
 - validate structured output
 - normalize provider, model, token, and usage metadata
 
-`ModelRuntime` is the dedicated model execution boundary. It is parallel to future Tool Runtime concerns, not a helper hidden inside `LemmingInstances`.
+`ModelRuntime` is the dedicated model execution boundary. It is parallel to the Tool Runtime boundary, not a helper hidden inside `LemmingInstances`.
 
-For Phase 1, `ModelRuntime` shares the same active-model selection contract used
+For v1, `ModelRuntime` shares the same active-model selection contract used
 by the scheduler: `config_snapshot.model_runtime.{profile, provider, model,
 resource_key}`. This avoids drift between admission control and actual provider
 execution.
+
+#### Tool Runtime
+
+Current implementation references:
+
+- `LemmingsOs.Tools.Catalog`
+- `LemmingsOs.Tools.Runtime`
+- `LemmingsOs.Tools.Adapters.Filesystem`
+- `LemmingsOs.Tools.Adapters.Web`
+- `LemmingsOs.LemmingTools`
+- `LemmingsOs.LemmingInstances.ToolExecution`
+
+Responsibilities:
+
+- expose the fixed v1 catalog to both runtime and UI
+- accept direct executor calls for supported tool names
+- validate catalog membership and World/instance scope
+- execute the four v1 adapters only
+- normalize success and error payloads
+- persist per-invocation history through `lemming_instance_tool_executions`
+
+The executable v1 catalog is exactly:
+
+- `fs.read_text_file`
+- `fs.write_text_file`
+- `web.search`
+- `web.fetch`
+
+The executor owns orchestration. It creates a `running` tool-execution row, calls `Tools.Runtime.execute/4`, updates that same row to `ok` or `error`, broadcasts the changed row, appends a normalized tool-result context message, then calls `ModelRuntime` again until a final reply or bounded failure.
+
+This is a direct runtime-call path. PubSub is only a UI update mechanism, not a tool transport.
 
 #### Runtime state stores
 
@@ -188,6 +219,7 @@ Responsibilities:
 - broadcast scheduler and per-instance runtime signals
 - expose runtime status for read models and diagnostics
 - emit structured lifecycle and failure events with hierarchy metadata
+- emit tool-execution lifecycle telemetry and activity-log entries
 
 ---
 
@@ -231,7 +263,7 @@ Executor
   -> queue empty => idle
 ```
 
-The Phase 1 runtime status taxonomy is:
+The v1 runtime status taxonomy is:
 
 - `created`
 - `queued`
@@ -241,7 +273,24 @@ The Phase 1 runtime status taxonomy is:
 - `failed`
 - `expired`
 
-This is the deliberate Phase 1 subset of the richer execution taxonomy defined in ADR-0004.
+This is the deliberate v1 subset of the richer execution taxonomy defined in ADR-0004.
+
+### Tool-call flow
+
+```text
+Executor
+  -> ModelRuntime returns structured action = tool_call
+  -> lemming_instance_tool_executions row inserted with status = running
+  -> Tools.Runtime.execute/4 validates fixed catalog and World scope
+  -> adapter executes
+  -> same tool row updated to status = ok or error
+  -> PubSub broadcasts :tool_execution_upserted
+  -> telemetry and activity log record lifecycle outcome
+  -> normalized tool result is appended to model context
+  -> Executor asks ModelRuntime for the next action
+```
+
+This loop is the supported v1 tool-call path. Approval waits, MCP, Docker sandboxing, dynamic tool discovery, generic command execution, and hierarchical tool policy enforcement are deferred beyond v1.
 
 ---
 
@@ -260,7 +309,7 @@ Durable relational records:
 - `lemming_instances`
 - `lemming_instance_messages`
 
-Phase 1 runtime columns of note:
+v1 runtime columns of note:
 
 ```text
 lemming_instances
@@ -272,9 +321,14 @@ lemming_instance_messages
   id, lemming_instance_id, world_id, role, content,
   provider, model, input_tokens, output_tokens, total_tokens, usage,
   inserted_at
+
+lemming_instance_tool_executions
+  id, lemming_instance_id, world_id, tool_name, status, args,
+  result, error, summary, preview, started_at, completed_at,
+  duration_ms, inserted_at, updated_at
 ```
 
-Deferred beyond Phase 1:
+Deferred beyond v1:
 
 - `instance_ref`
 - `parent_instance_id`
@@ -289,9 +343,12 @@ Active runtime state:
 - retry count and retry metadata
 - prompt-assembly context
 - active runtime status snapshot
+- live-only executor interaction trace for raw model/tool debugging
 
 The executor consumes work from this ephemeral queue. It does not treat the
 `lemming_instance_messages` table as its execution queue.
+
+The interaction trace is non-authoritative and safe to lose on process termination. Durable session history comes from `lemming_instance_messages` and `lemming_instance_tool_executions`.
 
 ### DETS
 
@@ -302,7 +359,7 @@ Best-effort idle snapshots:
 - deleted on expiry or other successful cleanup paths
 - failure-tolerant; snapshot failure does not fail the runtime session
 
-Automatic rehydration from DETS is explicitly out of scope for Phase 1.
+Automatic rehydration from DETS is deferred beyond v1.
 
 ---
 
@@ -313,7 +370,7 @@ Automatic rehydration from DETS is explicitly out of scope for Phase 1.
 - the runtime session remains represented by its durable `lemming_instances` row
 - supervision can restart the executor process
 - runtime state recovery is bounded by the persisted row and any available idle snapshot
-- Phase 1 does not promise full automatic rehydration from DETS
+- v1 does not support full automatic rehydration from DETS
 
 ### Retry exhaustion
 
@@ -332,11 +389,11 @@ Automatic rehydration from DETS is explicitly out of scope for Phase 1.
 
 - City liveness is derived from `last_seen_at` freshness
 - the administrative City `status` is not rewritten automatically by heartbeat loss
-- idle DETS snapshots remain a future extension point for recovery, not a Phase 1 operator guarantee
+- idle DETS snapshots remain a future extension point for recovery, not a v1 operator guarantee
 
 ### Boot recovery contract
 
-After application restart, Phase 1 recovery is intentionally limited.
+After application restart, v1 recovery is intentionally limited.
 
 - `recover_created_sessions/1` performs a bounded best-effort sweep of persisted instances in `created`, `queued`, `processing`, `retrying`, and `idle`
 - if the latest transcript row is a pending `user` message, the runtime reattaches the session and replays that pending work by normalizing the durable state back to `created` and queueing it again
@@ -345,7 +402,7 @@ After application restart, Phase 1 recovery is intentionally limited.
 - `failed` is not auto-recovered at boot; it requires explicit `retry_session/2`
 - `expired` is terminal and requires a new spawn rather than reattach
 
-For a new reader, the practical rule is simple: Phase 1 preserves durable session identity and transcript across restart, but not exact in-flight provider execution state.
+For a new reader, the practical rule is simple: v1 preserves durable session identity and transcript across restart, but not exact in-flight provider execution state.
 
 ---
 
@@ -366,9 +423,9 @@ For a new reader, the practical rule is simple: Phase 1 preserves durable sessio
 
 ## Future work
 
-- richer execution taxonomy beyond the Phase 1 subset
+- richer execution taxonomy beyond the v1 subset
 - explicit rehydration from DETS idle snapshots
 - delegation and lineage tracking across runtime sessions
 - broader model provider set beyond `Providers.Ollama`
-- future Tool Runtime concerns layered beside `ModelRuntime`
+- broader Tool Runtime governance beyond the fixed four-tool v1 catalog
 - distributed runtime coordination across multiple Cities

--- a/lib/lemmings_os/lemming_instances.ex
+++ b/lib/lemmings_os/lemming_instances.ex
@@ -590,26 +590,39 @@ defmodule LemmingsOs.LemmingInstances do
         {:error, :path_outside_workspace}
 
       true ->
-        workspace_root = workspace_root()
-        work_area_root = Path.join([workspace_root, department_id, lemming_id])
-        absolute_path = Path.expand(relative_path, work_area_root)
-
-        if path_within_root?(absolute_path, work_area_root) do
-          {:ok,
-           %{
-             absolute_path: absolute_path,
-             relative_path: Path.relative_to(absolute_path, work_area_root)
-           }}
-        else
-          {:error, :path_outside_workspace}
-        end
+        resolve_valid_artifact_path(department_id, lemming_id, relative_path)
     end
   end
 
   def artifact_absolute_path(_instance, _relative_path), do: {:error, :invalid_path}
 
+  defp resolve_valid_artifact_path(department_id, lemming_id, relative_path) do
+    workspace_root = workspace_root() |> Path.expand()
+    work_area_root = Path.join([workspace_root, department_id, lemming_id])
+    absolute_path = Path.expand(relative_path, work_area_root)
+
+    if path_within_root?(absolute_path, work_area_root) do
+      build_artifact_path_info(work_area_root, absolute_path)
+    else
+      {:error, :path_outside_workspace}
+    end
+  end
+
+  defp build_artifact_path_info(work_area_root, absolute_path) do
+    normalized_relative_path = Path.relative_to(absolute_path, work_area_root)
+
+    with :ok <- validate_no_symlink_components(work_area_root, normalized_relative_path) do
+      {:ok,
+       %{
+         absolute_path: absolute_path,
+         relative_path: normalized_relative_path
+       }}
+    end
+  end
+
   defp create_work_area(work_area_path) when is_binary(work_area_path) do
     workspace_root()
+    |> Path.expand()
     |> Path.join(work_area_path)
     |> File.mkdir_p()
     |> case do
@@ -644,7 +657,9 @@ defmodule LemmingsOs.LemmingInstances do
   end
 
   defp work_area_absolute_path(work_area_path) do
-    Path.join(workspace_root(), work_area_path)
+    workspace_root()
+    |> Path.expand()
+    |> Path.join(work_area_path)
   end
 
   defp path_within_root?(absolute_path, root_path)
@@ -654,6 +669,33 @@ defmodule LemmingsOs.LemmingInstances do
 
     normalized_absolute == normalized_root or
       String.starts_with?(normalized_absolute, normalized_root <> "/")
+  end
+
+  defp validate_no_symlink_components(root_path, relative_path)
+       when is_binary(root_path) and is_binary(relative_path) do
+    root_path
+    |> Path.expand()
+    |> validate_no_symlink_components(Path.split(relative_path))
+  end
+
+  defp validate_no_symlink_components(_current_path, []), do: :ok
+
+  defp validate_no_symlink_components(current_path, [segment | rest]) do
+    next_path = Path.join(current_path, segment)
+
+    case File.lstat(next_path) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        {:error, :path_outside_workspace}
+
+      {:ok, _stat} ->
+        validate_no_symlink_components(next_path, rest)
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp persist_user_message(%LemmingInstance{} = instance, request_text) do

--- a/lib/lemmings_os/lemming_instances.ex
+++ b/lib/lemmings_os/lemming_instances.ex
@@ -572,6 +572,42 @@ defmodule LemmingsOs.LemmingInstances do
     Path.join([department_id, lemming_id])
   end
 
+  @doc """
+  Resolves a workspace-relative artifact path for an instance into an absolute path.
+  """
+  @spec artifact_absolute_path(LemmingInstance.t(), String.t()) ::
+          {:ok, %{absolute_path: String.t(), relative_path: String.t()}} | {:error, term()}
+  def artifact_absolute_path(
+        %LemmingInstance{department_id: department_id, lemming_id: lemming_id},
+        relative_path
+      )
+      when is_binary(department_id) and is_binary(lemming_id) and is_binary(relative_path) do
+    cond do
+      relative_path == "" ->
+        {:error, :invalid_path}
+
+      Path.type(relative_path) == :absolute ->
+        {:error, :path_outside_workspace}
+
+      true ->
+        workspace_root = workspace_root()
+        work_area_root = Path.join([workspace_root, department_id, lemming_id])
+        absolute_path = Path.expand(relative_path, work_area_root)
+
+        if path_within_root?(absolute_path, work_area_root) do
+          {:ok,
+           %{
+             absolute_path: absolute_path,
+             relative_path: Path.relative_to(absolute_path, work_area_root)
+           }}
+        else
+          {:error, :path_outside_workspace}
+        end
+    end
+  end
+
+  def artifact_absolute_path(_instance, _relative_path), do: {:error, :invalid_path}
+
   defp create_work_area(work_area_path) when is_binary(work_area_path) do
     workspace_root()
     |> Path.join(work_area_path)
@@ -609,6 +645,15 @@ defmodule LemmingsOs.LemmingInstances do
 
   defp work_area_absolute_path(work_area_path) do
     Path.join(workspace_root(), work_area_path)
+  end
+
+  defp path_within_root?(absolute_path, root_path)
+       when is_binary(absolute_path) and is_binary(root_path) do
+    normalized_absolute = Path.expand(absolute_path)
+    normalized_root = Path.expand(root_path)
+
+    normalized_absolute == normalized_root or
+      String.starts_with?(normalized_absolute, normalized_root <> "/")
   end
 
   defp persist_user_message(%LemmingInstance{} = instance, request_text) do
@@ -669,8 +714,11 @@ defmodule LemmingsOs.LemmingInstances do
       retry_count: Map.get(state, :retry_count, 0),
       max_retries: Map.get(state, :max_retries, 3),
       queue_depth: runtime_queue_depth(Map.get(state, :queue)),
+      tool_iteration_count: Map.get(state, :tool_iteration_count, 0),
       current_item: Map.get(state, :current_item),
+      context_messages: normalize_context_messages(Map.get(state, :context_messages)),
       last_error: Map.get(state, :last_error),
+      internal_error_details: Map.get(state, :internal_error_details),
       status: runtime_status(Map.get(state, :status)),
       started_at: Map.get(state, :started_at),
       last_activity_at: Map.get(state, :last_activity_at)
@@ -683,6 +731,9 @@ defmodule LemmingsOs.LemmingInstances do
 
   defp runtime_queue_depth(queue) when is_list(queue), do: length(queue)
   defp runtime_queue_depth(_queue), do: 0
+
+  defp normalize_context_messages(messages) when is_list(messages), do: messages
+  defp normalize_context_messages(_messages), do: []
 
   defp runtime_status(status) when is_atom(status), do: Atom.to_string(status)
   defp runtime_status(status) when is_binary(status), do: status

--- a/lib/lemmings_os/lemming_instances.ex
+++ b/lib/lemmings_os/lemming_instances.ex
@@ -17,12 +17,12 @@ defmodule LemmingsOs.LemmingInstances do
   alias LemmingsOs.LemmingInstances.ConfigSnapshot
   alias LemmingsOs.LemmingInstances.DetsStore
   alias LemmingsOs.LemmingInstances.EtsStore
-  alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.LemmingInstances.Executor
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.LemmingInstances.Message
-  alias LemmingsOs.LemmingInstances.Telemetry
   alias LemmingsOs.LemmingInstances.PubSub
+  alias LemmingsOs.LemmingInstances.Telemetry
+  alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.Repo
   alias LemmingsOs.Runtime.ActivityLog
   alias LemmingsOs.Worlds.World
@@ -79,62 +79,51 @@ defmodule LemmingsOs.LemmingInstances do
           |> snapshot_value()
           |> ConfigSnapshot.enrich()
 
-        transaction =
-          Multi.new()
-          |> Multi.insert(
-            :instance,
-            LemmingInstance.create_changeset(%LemmingInstance{}, %{
-              lemming_id: lemming.id,
-              world_id: lemming.world_id,
-              city_id: lemming.city_id,
-              department_id: lemming.department_id,
-              status: "created",
-              config_snapshot: config_snapshot
-            })
-          )
-          |> Multi.insert(:message, fn %{instance: instance} ->
-            Message.changeset(%Message{}, %{
-              lemming_instance_id: instance.id,
-              world_id: instance.world_id,
-              role: "user",
-              content: first_request_text
-            })
-          end)
+        work_area_path = build_work_area_path(lemming)
 
-        case Repo.transaction(transaction) do
-          {:ok, %{instance: instance, message: message}} ->
-            Logger.info("runtime instance spawned",
-              event: "instance.spawn",
-              instance_id: instance.id,
-              lemming_id: instance.lemming_id,
-              world_id: instance.world_id,
-              city_id: instance.city_id,
-              department_id: instance.department_id,
-              message_id: message.id,
-              status: instance.status
+        with :ok <- create_work_area(work_area_path),
+             {:ok, %{instance: instance, message: message}} <-
+               persist_spawn(
+                 lemming,
+                 config_snapshot,
+                 first_request_text
+               ) do
+          Logger.info("runtime instance spawned",
+            event: "instance.spawn",
+            instance_id: instance.id,
+            lemming_id: instance.lemming_id,
+            world_id: instance.world_id,
+            city_id: instance.city_id,
+            department_id: instance.department_id,
+            message_id: message.id,
+            status: instance.status,
+            path: work_area_path
+          )
+
+          _ =
+            Telemetry.execute(
+              [:lemmings_os, :instance, :created],
+              %{count: 1},
+              Telemetry.instance_metadata(instance, %{
+                status: instance.status,
+                message_id: message.id,
+                work_area_path: work_area_path
+              })
             )
 
-            _ =
-              Telemetry.execute(
-                [:lemmings_os, :instance, :created],
-                %{count: 1},
-                Telemetry.instance_metadata(instance, %{
-                  status: instance.status,
-                  message_id: message.id
-                })
-              )
+          _ =
+            ActivityLog.record(:runtime, "instance", "Runtime instance spawned", %{
+              instance_id: instance.id,
+              lemming_id: instance.lemming_id,
+              message_id: message.id,
+              work_area_path: work_area_path
+            })
 
-            _ =
-              ActivityLog.record(:runtime, "instance", "Runtime instance spawned", %{
-                instance_id: instance.id,
-                lemming_id: instance.lemming_id,
-                message_id: message.id
-              })
-
-            {:ok, instance}
-
-          {:error, _step, reason, _changes} ->
-            {:error, reason}
+          {:ok, instance}
+        else
+          {:error, _reason} = error ->
+            cleanup_work_area(work_area_path)
+            error
         end
     end
   end
@@ -478,19 +467,23 @@ defmodule LemmingsOs.LemmingInstances do
   end
 
   defp filter_query(query, [{:status, status} | rest]),
-    do: filter_query(from(item in query, where: item.status == ^status), rest)
+    do: filter_query(from(item in query, where: field(item, ^:status) == ^status), rest)
 
   defp filter_query(query, [{:statuses, statuses} | rest]) when is_list(statuses),
-    do: filter_query(from(item in query, where: item.status in ^statuses), rest)
+    do: filter_query(from(item in query, where: field(item, ^:status) in ^statuses), rest)
 
   defp filter_query(query, [{:lemming_id, lemming_id} | rest]),
-    do: filter_query(from(item in query, where: item.lemming_id == ^lemming_id), rest)
+    do: filter_query(from(item in query, where: field(item, ^:lemming_id) == ^lemming_id), rest)
 
   defp filter_query(query, [{:department_id, department_id} | rest]),
-    do: filter_query(from(item in query, where: item.department_id == ^department_id), rest)
+    do:
+      filter_query(
+        from(item in query, where: field(item, ^:department_id) == ^department_id),
+        rest
+      )
 
   defp filter_query(query, [{:ids, ids} | rest]) when is_list(ids),
-    do: filter_query(from(item in query, where: item.id in ^ids), rest)
+    do: filter_query(from(item in query, where: field(item, ^:id) in ^ids), rest)
 
   defp filter_query(query, [{:preload, preloads} | rest]),
     do: filter_query(preload(query, ^preloads), rest)
@@ -542,6 +535,81 @@ defmodule LemmingsOs.LemmingInstances do
 
   defp snapshot_value(list) when is_list(list), do: Enum.map(list, &snapshot_value/1)
   defp snapshot_value(value), do: value
+
+  defp persist_spawn(lemming, config_snapshot, first_request_text) do
+    Multi.new()
+    |> Multi.insert(
+      :instance,
+      LemmingInstance.create_changeset(%LemmingInstance{}, %{
+        lemming_id: lemming.id,
+        world_id: lemming.world_id,
+        city_id: lemming.city_id,
+        department_id: lemming.department_id,
+        status: "created",
+        config_snapshot: config_snapshot
+      })
+    )
+    |> Multi.insert(:message, fn %{instance: instance} ->
+      Message.changeset(%Message{}, %{
+        lemming_instance_id: instance.id,
+        world_id: instance.world_id,
+        role: "user",
+        content: first_request_text
+      })
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, %{instance: instance, message: message}} ->
+        {:ok, %{instance: instance, message: message}}
+
+      {:error, _step, reason, _changes} ->
+        {:error, reason}
+    end
+  end
+
+  defp build_work_area_path(%Lemming{department_id: department_id, id: lemming_id})
+       when is_binary(department_id) and is_binary(lemming_id) do
+    Path.join([department_id, lemming_id])
+  end
+
+  defp create_work_area(work_area_path) when is_binary(work_area_path) do
+    workspace_root()
+    |> Path.join(work_area_path)
+    |> File.mkdir_p()
+    |> case do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.error("runtime instance work area could not be created",
+          event: "instance.work_area.create_failed",
+          path: work_area_path,
+          reason: inspect(reason)
+        )
+
+        {:error, :work_area_unavailable}
+    end
+  end
+
+  defp cleanup_work_area(work_area_path) when is_binary(work_area_path) do
+    work_area_path
+    |> work_area_absolute_path()
+    |> File.rm_rf()
+
+    :ok
+  end
+
+  defp workspace_root do
+    Application.get_env(
+      :lemmings_os,
+      :runtime_workspace_root,
+      Path.expand("../../../priv/runtime/workspace", __DIR__)
+    )
+  end
+
+  defp work_area_absolute_path(work_area_path) do
+    Path.join(workspace_root(), work_area_path)
+  end
 
   defp persist_user_message(%LemmingInstance{} = instance, request_text) do
     %Message{}

--- a/lib/lemmings_os/lemming_instances/executor.ex
+++ b/lib/lemmings_os/lemming_instances/executor.ex
@@ -794,7 +794,10 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp continue_tool_loop(state) do
     next_iteration_count = state.tool_iteration_count + 1
+    continue_tool_loop(state, next_iteration_count)
+  end
 
+  defp continue_tool_loop(state, next_iteration_count) do
     if next_iteration_count >= max_tool_iterations(state.config_snapshot) do
       handle_model_retry(
         %{state | tool_iteration_count: next_iteration_count},
@@ -808,7 +811,21 @@ defmodule LemmingsOs.LemmingInstances.Executor do
     end
   end
 
-  defp create_tool_execution(state, tool_name, tool_args, started_at) do
+  defp create_tool_execution(
+         %{tools_context_mod: nil} = state,
+         _tool_name,
+         _tool_args,
+         _started_at
+       ) do
+    {:error, :tool_execution_unavailable, state}
+  end
+
+  defp create_tool_execution(
+         %{tools_context_mod: tools_context} = state,
+         tool_name,
+         tool_args,
+         started_at
+       ) do
     tool_attrs = %{
       tool_name: tool_name,
       status: "running",
@@ -816,50 +833,53 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       started_at: started_at
     }
 
-    tools_context = state.tools_context_mod
+    with true <- module_loaded_and_exports?(tools_context, :create_tool_execution, 3),
+         {:ok, tool_execution} <-
+           tools_context.create_tool_execution(
+             runtime_world_struct(state),
+             state.instance,
+             tool_attrs
+           ) do
+      log_tool_lifecycle(state, :started, tool_execution)
+      emit_tool_telemetry(state, :started, tool_execution)
+      record_tool_activity(:runtime, state, :started, tool_execution)
 
-    cond do
-      is_nil(tools_context) ->
+      _ =
+        PubSub.broadcast_tool_execution_upserted(
+          state.instance_id,
+          tool_execution.id,
+          tool_execution.status
+        )
+
+      {:ok, tool_execution}
+    else
+      false ->
         {:error, :tool_execution_unavailable, state}
 
-      module_loaded_and_exports?(tools_context, :create_tool_execution, 3) ->
-        case tools_context.create_tool_execution(
-               runtime_world_struct(state),
-               state.instance,
-               tool_attrs
-             ) do
-          {:ok, tool_execution} ->
-            _ =
-              PubSub.broadcast_tool_execution_upserted(
-                state.instance_id,
-                tool_execution.id,
-                tool_execution.status
-              )
-
-            {:ok, tool_execution}
-
-          {:error, reason} ->
-            {:error, {:tool_execution_create_failed, reason}, state}
-        end
-
-      true ->
-        {:error, :tool_execution_unavailable, state}
+      {:error, reason} ->
+        {:error, {:tool_execution_create_failed, reason}, state}
     end
   end
 
   defp execute_tool_runtime(state, world, tool_name, tool_args) do
     tool_runtime_mod = state.tool_runtime_mod
 
-    if module_loaded_and_exports?(tool_runtime_mod, :execute, 4) do
-      tool_runtime_mod.execute(world, state.instance, tool_name, tool_args)
-    else
-      {:error,
-       %{
-         tool_name: tool_name,
-         code: "tool.runtime.unavailable",
-         message: "Tool runtime is unavailable",
-         details: %{}
-       }}
+    execute_tool_runtime(tool_runtime_mod, state, world, tool_name, tool_args)
+  end
+
+  defp execute_tool_runtime(tool_runtime_mod, state, world, tool_name, tool_args) do
+    case module_loaded_and_exports?(tool_runtime_mod, :execute, 4) do
+      true ->
+        tool_runtime_mod.execute(world, state.instance, tool_name, tool_args)
+
+      false ->
+        {:error,
+         %{
+           tool_name: tool_name,
+           code: "tool.runtime.unavailable",
+           message: "Tool runtime is unavailable",
+           details: %{}
+         }}
     end
   end
 
@@ -876,7 +896,16 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       duration_ms: max(duration_ms, 0)
     }
 
-    update_tool_execution(state, tool_execution, attrs)
+    case update_tool_execution(state, tool_execution, attrs) do
+      {:ok, updated_tool_execution, next_state} ->
+        log_tool_lifecycle(next_state, :completed, updated_tool_execution)
+        emit_tool_telemetry(next_state, :completed, updated_tool_execution)
+        record_tool_activity(:runtime, next_state, :completed, updated_tool_execution)
+        {:ok, updated_tool_execution, next_state}
+
+      {:error, reason, next_state} ->
+        {:error, reason, next_state}
+    end
   end
 
   defp persist_tool_error(state, tool_execution, execution_error, started_at) do
@@ -896,39 +925,49 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       duration_ms: max(duration_ms, 0)
     }
 
-    update_tool_execution(state, tool_execution, attrs)
+    case update_tool_execution(state, tool_execution, attrs) do
+      {:ok, updated_tool_execution, next_state} ->
+        log_tool_lifecycle(next_state, :failed, updated_tool_execution)
+        emit_tool_telemetry(next_state, :failed, updated_tool_execution)
+        record_tool_activity(:error, next_state, :failed, updated_tool_execution)
+        {:ok, updated_tool_execution, next_state}
+
+      {:error, reason, next_state} ->
+        {:error, reason, next_state}
+    end
   end
 
-  defp update_tool_execution(state, tool_execution, attrs) do
-    tools_context = state.tools_context_mod
+  defp update_tool_execution(%{tools_context_mod: nil} = state, _tool_execution, _attrs) do
+    {:error, :tool_execution_unavailable, state}
+  end
 
-    cond do
-      is_nil(tools_context) ->
+  defp update_tool_execution(
+         %{tools_context_mod: tools_context} = state,
+         tool_execution,
+         attrs
+       ) do
+    with true <- module_loaded_and_exports?(tools_context, :update_tool_execution, 4),
+         {:ok, updated_tool_execution} <-
+           tools_context.update_tool_execution(
+             runtime_world_struct(state),
+             state.instance,
+             tool_execution,
+             attrs
+           ) do
+      _ =
+        PubSub.broadcast_tool_execution_upserted(
+          state.instance_id,
+          updated_tool_execution.id,
+          updated_tool_execution.status
+        )
+
+      {:ok, updated_tool_execution, state}
+    else
+      false ->
         {:error, :tool_execution_unavailable, state}
 
-      module_loaded_and_exports?(tools_context, :update_tool_execution, 4) ->
-        case tools_context.update_tool_execution(
-               runtime_world_struct(state),
-               state.instance,
-               tool_execution,
-               attrs
-             ) do
-          {:ok, updated_tool_execution} ->
-            _ =
-              PubSub.broadcast_tool_execution_upserted(
-                state.instance_id,
-                updated_tool_execution.id,
-                updated_tool_execution.status
-              )
-
-            {:ok, updated_tool_execution, state}
-
-          {:error, reason} ->
-            {:error, {:tool_execution_update_failed, reason}, state}
-        end
-
-      true ->
-        {:error, :tool_execution_unavailable, state}
+      {:error, reason} ->
+        {:error, {:tool_execution_update_failed, reason}, state}
     end
   end
 
@@ -977,6 +1016,118 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       details: %{reason: inspect(other)}
     }
   end
+
+  defp log_tool_lifecycle(state, :started, tool_execution) do
+    Logger.info("executor tool execution started",
+      event: "instance.executor.tool_execution.started",
+      operation: tool_execution.tool_name,
+      status: tool_execution.status,
+      instance_id: state.instance_id,
+      lemming_id: instance_lemming_id(state.instance),
+      world_id: instance_world_id(state.instance),
+      city_id: instance_city_id(state.instance),
+      department_id: state.department_id,
+      current_item_id: current_item_id(state.current_item)
+    )
+  end
+
+  defp log_tool_lifecycle(state, :completed, tool_execution) do
+    Logger.info("executor tool execution completed",
+      event: "instance.executor.tool_execution.completed",
+      operation: tool_execution.tool_name,
+      status: tool_execution.status,
+      instance_id: state.instance_id,
+      lemming_id: instance_lemming_id(state.instance),
+      world_id: instance_world_id(state.instance),
+      city_id: instance_city_id(state.instance),
+      department_id: state.department_id,
+      current_item_id: current_item_id(state.current_item)
+    )
+  end
+
+  defp log_tool_lifecycle(state, :failed, tool_execution) do
+    Logger.warning("executor tool execution failed",
+      event: "instance.executor.tool_execution.failed",
+      operation: tool_execution.tool_name,
+      status: tool_execution.status,
+      reason: tool_error_reason(tool_execution.error),
+      instance_id: state.instance_id,
+      lemming_id: instance_lemming_id(state.instance),
+      world_id: instance_world_id(state.instance),
+      city_id: instance_city_id(state.instance),
+      department_id: state.department_id,
+      current_item_id: current_item_id(state.current_item)
+    )
+  end
+
+  defp emit_tool_telemetry(state, :started, tool_execution) do
+    _ =
+      Telemetry.execute(
+        [:lemmings_os, :runtime, :tool_execution, :started],
+        %{count: 1},
+        Telemetry.tool_execution_metadata(
+          state.instance,
+          tool_execution,
+          %{instance_id: state.instance_id}
+        )
+      )
+
+    :ok
+  end
+
+  defp emit_tool_telemetry(state, :completed, tool_execution) do
+    _ =
+      Telemetry.execute(
+        [:lemmings_os, :runtime, :tool_execution, :completed],
+        %{count: 1, duration_ms: tool_execution.duration_ms || 0},
+        Telemetry.tool_execution_metadata(
+          state.instance,
+          tool_execution,
+          %{instance_id: state.instance_id}
+        )
+      )
+
+    :ok
+  end
+
+  defp emit_tool_telemetry(state, :failed, tool_execution) do
+    _ =
+      Telemetry.execute(
+        [:lemmings_os, :runtime, :tool_execution, :failed],
+        %{count: 1, duration_ms: tool_execution.duration_ms || 0},
+        Telemetry.tool_execution_metadata(
+          state.instance,
+          tool_execution,
+          %{
+            instance_id: state.instance_id,
+            reason: tool_error_reason(tool_execution.error)
+          }
+        )
+      )
+
+    :ok
+  end
+
+  defp record_tool_activity(type, state, phase, tool_execution) do
+    _ =
+      ActivityLog.record(type, "tool_execution", "Tool #{phase}", %{
+        instance_id: state.instance_id,
+        lemming_id: instance_lemming_id(state.instance),
+        world_id: instance_world_id(state.instance),
+        city_id: instance_city_id(state.instance),
+        department_id: state.department_id,
+        tool_execution_id: tool_execution.id,
+        tool_name: tool_execution.tool_name,
+        status: tool_execution.status,
+        reason: tool_error_reason(tool_execution.error)
+      })
+
+    :ok
+  end
+
+  defp tool_error_reason(%{"code" => code}) when is_binary(code), do: code
+  defp tool_error_reason(%{code: code}) when is_binary(code), do: code
+  defp tool_error_reason(_error), do: nil
 
   defp module_loaded_and_exports?(module, function_name, arity)
        when is_atom(module) and is_atom(function_name) and is_integer(arity) do
@@ -1274,19 +1425,21 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp persist_status(%{context_mod: nil} = state, _attrs), do: state
 
-  defp persist_status(%{context_mod: context_mod} = state, attrs) do
-    instance = state.instance
+  defp persist_status(
+         %{context_mod: context_mod, instance: %LemmingInstance{} = instance} = state,
+         attrs
+       ) do
     status = Map.get(attrs, :status, state.status)
 
-    if function_exported?(context_mod, :update_status, 3) and match?(%LemmingInstance{}, instance) do
-      case context_mod.update_status(instance, status, attrs) do
-        {:ok, updated_instance} -> %{state | instance: updated_instance}
-        {:error, _changeset} -> state
-      end
+    with true <- module_loaded_and_exports?(context_mod, :update_status, 3),
+         {:ok, updated_instance} <- context_mod.update_status(instance, status, attrs) do
+      %{state | instance: updated_instance}
     else
-      state
+      _other -> state
     end
   end
+
+  defp persist_status(state, _attrs), do: state
 
   defp broadcast_status(state) do
     metadata = %{
@@ -1528,19 +1681,25 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   defp maybe_load_context_messages(%{context_mod: nil} = state), do: state
   defp maybe_load_context_messages(%{load_context_messages?: false} = state), do: state
 
-  defp maybe_load_context_messages(%{context_mod: context_mod, instance: instance} = state) do
-    if function_exported?(context_mod, :list_messages, 2) and match?(%LemmingInstance{}, instance) do
-      messages =
-        context_mod.list_messages(instance, [])
-        |> Enum.map(fn message ->
-          %{role: message.role, content: message.content}
-        end)
+  defp maybe_load_context_messages(
+         %{context_mod: context_mod, instance: %LemmingInstance{} = instance} = state
+       ) do
+    case module_loaded_and_exports?(context_mod, :list_messages, 2) do
+      true ->
+        messages =
+          context_mod.list_messages(instance, [])
+          |> Enum.map(fn message ->
+            %{role: message.role, content: message.content}
+          end)
 
-      %{state | context_messages: messages}
-    else
-      state
+        %{state | context_messages: messages}
+
+      false ->
+        state
     end
   end
+
+  defp maybe_load_context_messages(state), do: state
 
   defp resolve_instance_id(opts) do
     cond do

--- a/lib/lemmings_os/lemming_instances/executor.ex
+++ b/lib/lemmings_os/lemming_instances/executor.ex
@@ -36,6 +36,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   @default_max_retries 3
   @default_max_tool_iterations 8
   @default_model_timeout_ms 120_000
+  @max_model_steps 40
 
   @statuses ~w(created queued processing retrying idle failed expired)
   @status_atoms Map.new(@statuses, &{&1, String.to_atom(&1)})
@@ -45,6 +46,16 @@ defmodule LemmingsOs.LemmingInstances.Executor do
           content: String.t(),
           origin: :user,
           inserted_at: DateTime.t()
+        }
+
+  @type finalization_context :: %{
+          tool_name: String.t(),
+          tool_status: String.t(),
+          tool_result_payload: map(),
+          original_goal: String.t(),
+          completed_action: String.t() | nil,
+          artifacts_created: [String.t()],
+          remaining_work: [String.t()]
         }
 
   @type state :: %{
@@ -59,9 +70,15 @@ defmodule LemmingsOs.LemmingInstances.Executor do
           retry_count: non_neg_integer(),
           max_retries: pos_integer(),
           context_messages: [map()],
+          phase: :action_selection | :finalizing,
+          finalization_context: finalization_context() | nil,
+          finalization_repair_attempted?: boolean(),
           tool_iteration_count: non_neg_integer(),
+          model_step_count: non_neg_integer(),
+          model_steps: [map()],
           last_error: String.t() | nil,
           internal_error_details: map() | String.t() | nil,
+          active_model_step: map() | nil,
           model_task_pid: pid() | nil,
           model_task_monitor_ref: reference() | nil,
           model_task_ref: reference() | nil,
@@ -367,9 +384,15 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         retry_count: 0,
         max_retries: max_retries(config_snapshot),
         context_messages: [],
+        phase: :action_selection,
+        finalization_context: nil,
+        finalization_repair_attempted?: false,
         tool_iteration_count: 0,
+        model_step_count: 0,
+        model_steps: [],
         last_error: nil,
         internal_error_details: nil,
+        active_model_step: nil,
         model_task_pid: nil,
         model_task_monitor_ref: nil,
         model_task_ref: nil,
@@ -465,6 +488,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       retry_count: state.retry_count,
       max_retries: state.max_retries,
       tool_iteration_count: state.tool_iteration_count,
+      model_step_count: state.model_step_count,
       queue_depth: :queue.len(state.queue),
       last_error: state.last_error,
       internal_error_details: state.internal_error_details
@@ -483,8 +507,10 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       retry_count: state.retry_count,
       max_retries: state.max_retries,
       tool_iteration_count: state.tool_iteration_count,
+      model_step_count: state.model_step_count,
       current_item_id: current_item_id(state.current_item),
       current_resource_key: state.current_resource_key,
+      model_steps: state.model_steps,
       last_error: state.last_error,
       internal_error_details: state.internal_error_details,
       started_at: state.started_at,
@@ -555,9 +581,15 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   end
 
   @impl true
-  def handle_info({:model_result, instance_id, model_task_ref, result}, state) do
+  def handle_info({:model_result, instance_id, model_task_ref, started_at, result}, state) do
     if instance_id == state.instance_id and model_task_ref == state.model_task_ref do
-      {:noreply, state |> clear_model_task_tracking() |> handle_model_result(result)}
+      state =
+        state
+        |> clear_model_task_tracking()
+        |> finalize_model_step(result, started_at)
+        |> handle_model_result(result)
+
+      {:noreply, state}
     else
       {:noreply, state}
     end
@@ -570,6 +602,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         state
         |> terminate_model_task()
         |> clear_model_task_tracking()
+        |> finalize_model_step({:error, :model_timeout})
         |> handle_model_retry(:model_timeout)
 
       {:noreply, state}
@@ -630,6 +663,9 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         |> cancel_idle_timer()
         |> Map.put(:queue, queue)
         |> Map.put(:current_item, item)
+        |> Map.put(:phase, :action_selection)
+        |> Map.put(:finalization_context, nil)
+        |> Map.put(:finalization_repair_attempted?, false)
         |> Map.put(:retry_count, 0)
         |> transition_to("processing")
         |> put_runtime_state()
@@ -663,6 +699,9 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       |> Map.put(:queue, queue)
       |> Map.put(:current_item, nil)
       |> Map.put(:current_resource_key, nil)
+      |> Map.put(:phase, :action_selection)
+      |> Map.put(:finalization_context, nil)
+      |> Map.put(:finalization_repair_attempted?, false)
       |> Map.put(:retry_count, 0)
       |> Map.put(:last_error, nil)
       |> Map.put(:internal_error_details, nil)
@@ -678,20 +717,24 @@ defmodule LemmingsOs.LemmingInstances.Executor do
          state,
          {:ok, %LemmingsOs.ModelRuntime.Response{action: :reply} = response}
        ) do
-    state =
-      state
-      |> Map.put(:last_error, nil)
-      |> Map.put(:internal_error_details, nil)
-
-    case persist_assistant_message(state, response) do
-      {:ok, next_state} ->
+    case maybe_repair_empty_final_response(state, response) do
+      {:repair, next_state} ->
         next_state
-        |> clear_current_item()
-        |> advance_after_success()
+        |> clear_active_model_step()
+        |> start_execution()
 
-      {:error, reason, next_state} ->
-        handle_model_retry(next_state, {:assistant_message_persist_failed, reason})
+      :continue ->
+        finalize_model_reply(state, response)
     end
+  end
+
+  defp handle_model_result(
+         %{phase: :finalizing} = state,
+         {:ok, %LemmingsOs.ModelRuntime.Response{action: :tool_call}}
+       ) do
+    state
+    |> clear_active_model_step()
+    |> maybe_repair_finalization(:unexpected_tool_call_during_finalization)
   end
 
   defp handle_model_result(
@@ -704,24 +747,34 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       |> Map.put(:internal_error_details, nil)
 
     case execute_tool_call(state, response) do
-      {:ok, next_state} ->
-        continue_tool_loop(next_state)
+      {:ok, next_state, _tool_execution} ->
+        next_state
+        |> clear_active_model_step()
+        |> continue_after_tool_outcome()
 
       {:error, reason, next_state} ->
-        handle_model_retry(next_state, reason)
+        next_state
+        |> clear_active_model_step()
+        |> handle_model_retry(reason)
     end
   end
 
   defp handle_model_result(state, {:ok, _response}) do
-    handle_model_retry(state, :invalid_provider_response)
+    state
+    |> clear_active_model_step()
+    |> handle_model_retry(:invalid_provider_response)
   end
 
   defp handle_model_result(state, {:error, reason}) do
-    handle_model_retry(state, reason)
+    state
+    |> clear_active_model_step()
+    |> maybe_repair_finalization(reason)
   end
 
   defp handle_model_result(state, _unexpected) do
-    handle_model_retry(state, :unexpected_model_result)
+    state
+    |> clear_active_model_step()
+    |> handle_model_retry(:unexpected_model_result)
   end
 
   defp handle_model_retry(state, reason) do
@@ -755,8 +808,10 @@ defmodule LemmingsOs.LemmingInstances.Executor do
        )
        when is_binary(tool_name) and is_map(tool_args) do
     started_at = state.now_fun.()
+    state = append_tool_call_context(state, tool_name, tool_args)
 
-    with {:ok, tool_execution} <- create_tool_execution(state, tool_name, tool_args, started_at),
+    with {:ok, tool_execution, state} <-
+           create_tool_execution(state, tool_name, tool_args, started_at),
          {:ok, world} <- runtime_world(state) do
       state
       |> persist_tool_outcome(
@@ -785,17 +840,113 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   end
 
   defp normalize_tool_outcome_result({:ok, updated_tool_execution, next_state}) do
-    {:ok, append_tool_result_context(next_state, updated_tool_execution)}
+    {:ok, append_tool_result_context(next_state, updated_tool_execution), updated_tool_execution}
   end
 
   defp normalize_tool_outcome_result({:error, reason, next_state}) do
     {:error, reason, next_state}
   end
 
+  defp continue_after_tool_outcome(state) do
+    case state.finalization_context do
+      %{tool_status: "ok"} -> start_finalization_phase(state)
+      _finalization_context -> continue_tool_loop(state)
+    end
+  end
+
   defp continue_tool_loop(state) do
     next_iteration_count = state.tool_iteration_count + 1
     continue_tool_loop(state, next_iteration_count)
   end
+
+  defp finalize_model_reply(state, response) do
+    state =
+      state
+      |> Map.put(:last_error, nil)
+      |> Map.put(:internal_error_details, nil)
+
+    case persist_assistant_message(state, response) do
+      {:ok, next_state} ->
+        next_state
+        |> clear_active_model_step()
+        |> clear_current_item()
+        |> advance_after_success()
+
+      {:error, reason, next_state} ->
+        handle_model_retry(next_state, {:assistant_message_persist_failed, reason})
+    end
+  end
+
+  defp maybe_repair_empty_final_response(state, response) do
+    if state.phase == :finalizing and blank_reply?(response.reply) and
+         not state.finalization_repair_attempted? do
+      {:repair, schedule_finalization_repair(state, :empty_final_response)}
+    else
+      :continue
+    end
+  end
+
+  defp maybe_repair_finalization(%{phase: :finalizing} = state, reason) do
+    cond do
+      repairable_finalization_reason?(reason) and not state.finalization_repair_attempted? ->
+        state
+        |> schedule_finalization_repair(reason)
+        |> start_execution()
+
+      repairable_finalization_reason?(reason) ->
+        fail_without_retry(state, reason)
+
+      true ->
+        handle_model_retry(state, reason)
+    end
+  end
+
+  defp maybe_repair_finalization(state, reason), do: handle_model_retry(state, reason)
+
+  defp schedule_finalization_repair(state, reason) do
+    state
+    |> Map.put(:finalization_repair_attempted?, true)
+    |> Map.put(:last_error, nil)
+    |> Map.put(:internal_error_details, nil)
+    |> put_in([:finalization_context, :repair_reason], inspect(reason))
+    |> put_runtime_state()
+  end
+
+  defp start_finalization_phase(state) do
+    next_iteration_count = state.tool_iteration_count + 1
+
+    state
+    |> Map.put(:phase, :finalizing)
+    |> Map.put(:tool_iteration_count, next_iteration_count)
+    |> Map.put(:retry_count, 0)
+    |> Map.put(:last_error, nil)
+    |> Map.put(:internal_error_details, nil)
+    |> put_runtime_state()
+    |> start_execution()
+  end
+
+  defp fail_without_retry(state, reason) do
+    state
+    |> Map.put(:retry_count, state.max_retries)
+    |> Map.put(:last_error, last_error_message(reason))
+    |> Map.put(:internal_error_details, internal_error_details(reason))
+    |> release_resource()
+    |> cleanup_snapshot()
+    |> transition_to("failed", %{stopped_at: state.now_fun.()})
+    |> put_runtime_state()
+  end
+
+  defp repairable_finalization_reason?({:invalid_structured_output, _metadata}), do: true
+  defp repairable_finalization_reason?(:invalid_structured_output), do: true
+  defp repairable_finalization_reason?({:unknown_action, _metadata}), do: true
+  defp repairable_finalization_reason?(:unknown_action), do: true
+  defp repairable_finalization_reason?(:provider_error), do: true
+  defp repairable_finalization_reason?(:invalid_provider_response), do: true
+  defp repairable_finalization_reason?(:unexpected_tool_call_during_finalization), do: true
+  defp repairable_finalization_reason?(_reason), do: false
+
+  defp blank_reply?(reply) when is_binary(reply), do: Helpers.blank?(reply)
+  defp blank_reply?(_reply), do: true
 
   defp continue_tool_loop(state, next_iteration_count) do
     if next_iteration_count >= max_tool_iterations(state.config_snapshot) do
@@ -840,6 +991,8 @@ defmodule LemmingsOs.LemmingInstances.Executor do
              state.instance,
              tool_attrs
            ) do
+      state = maybe_attach_tool_execution_to_model_step(state, tool_execution)
+
       log_tool_lifecycle(state, :started, tool_execution)
       emit_tool_telemetry(state, :started, tool_execution)
       record_tool_activity(:runtime, state, :started, tool_execution)
@@ -851,7 +1004,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
           tool_execution.status
         )
 
-      {:ok, tool_execution}
+      {:ok, tool_execution, state}
     else
       false ->
         {:error, :tool_execution_unavailable, state}
@@ -971,38 +1124,205 @@ defmodule LemmingsOs.LemmingInstances.Executor do
     end
   end
 
+  defp create_model_step(state, attrs) do
+    model_step = attrs
+
+    state = %{
+      state
+      | model_steps: append_capped_model_step(state.model_steps, model_step),
+        active_model_step: model_step
+    }
+
+    _ =
+      PubSub.broadcast_model_step_upserted(
+        state.instance_id,
+        Integer.to_string(model_step.step_index),
+        model_step.status
+      )
+
+    {:ok, state}
+  end
+
+  defp update_model_step(%{active_model_step: nil} = state, _attrs), do: state
+
+  defp update_model_step(%{active_model_step: active_model_step} = state, attrs) do
+    updated_model_step =
+      active_model_step
+      |> Map.merge(attrs)
+
+    model_steps =
+      Enum.map(state.model_steps, fn
+        %{step_index: step_index} when step_index == updated_model_step.step_index ->
+          updated_model_step
+
+        model_step ->
+          model_step
+      end)
+
+    _ =
+      PubSub.broadcast_model_step_upserted(
+        state.instance_id,
+        Integer.to_string(updated_model_step.step_index),
+        updated_model_step.status
+      )
+
+    %{state | model_steps: model_steps, active_model_step: updated_model_step}
+  end
+
+  defp maybe_attach_tool_execution_to_model_step(
+         %{active_model_step: nil} = state,
+         _tool_execution
+       ),
+       do: state
+
+  defp maybe_attach_tool_execution_to_model_step(
+         state,
+         tool_execution
+       ) do
+    update_model_step(state, %{tool_execution_id: tool_execution.id})
+  end
+
+  defp clear_active_model_step(state), do: %{state | active_model_step: nil}
+
+  defp append_capped_model_step(model_steps, model_step) do
+    model_steps
+    |> Kernel.++([model_step])
+    |> Enum.take(-@max_model_steps)
+  end
+
+  defp append_tool_call_context(state, tool_name, tool_args) do
+    tool_call_message = %{
+      role: "assistant",
+      content: "Assistant requested tool #{tool_name} with arguments: #{Jason.encode!(tool_args)}"
+    }
+
+    %{state | context_messages: state.context_messages ++ [tool_call_message]}
+  end
+
   defp append_tool_result_context(state, tool_execution) do
+    tool_payload = tool_result_payload(tool_execution)
+
     tool_message = %{
       role: "assistant",
       content:
-        "Tool #{tool_execution.tool_name} status=#{tool_execution.status} result=#{Jason.encode!(tool_result_payload(tool_execution))}"
+        "As response to your previous tool request, the runtime executed #{tool_execution.tool_name}. Tool result for #{tool_execution.tool_name}: status=#{tool_execution.status} payload=#{Jason.encode!(tool_payload)}. Decide what to do next."
     }
 
-    %{state | context_messages: state.context_messages ++ [tool_message]}
+    %{
+      state
+      | context_messages: state.context_messages ++ [tool_message],
+        finalization_context: build_finalization_context(state, tool_execution, tool_payload),
+        finalization_repair_attempted?: false
+    }
+  end
+
+  defp build_finalization_context(state, tool_execution, tool_payload) do
+    %{
+      tool_name: tool_execution.tool_name,
+      tool_status: tool_execution.status,
+      tool_result_payload: tool_payload,
+      original_goal: state.current_item.content,
+      completed_action: tool_execution.summary,
+      artifacts_created: Map.get(tool_payload, :artifacts_created, []),
+      important_details: Map.get(tool_payload, :important_details, []),
+      remaining_work: Map.get(tool_payload, :remaining_work, [])
+    }
   end
 
   defp tool_result_payload(%{status: "ok"} = tool_execution) do
+    result = tool_execution.result || %{}
+
     %{
-      summary: tool_execution.summary,
-      preview: tool_execution.preview,
-      result: tool_execution.result
+      ok: true,
+      action_taken: tool_execution.summary,
+      artifacts_created: tool_result_artifacts(result),
+      important_details: tool_result_details(result, tool_execution),
+      remaining_work: [],
+      preview: truncate_tool_preview(tool_execution.preview)
     }
   end
 
   defp tool_result_payload(%{status: "error"} = tool_execution) do
     %{
-      summary: tool_execution.summary,
+      ok: false,
+      action_taken: tool_execution.summary,
+      artifacts_created: [],
+      important_details: [],
+      remaining_work: ["Review tool error and decide the next step."],
       error: tool_execution.error
     }
   end
 
   defp tool_result_payload(tool_execution) do
+    result = tool_execution.result || %{}
+
     %{
-      summary: tool_execution.summary,
-      result: tool_execution.result,
+      ok: tool_execution.status == "ok",
+      action_taken: tool_execution.summary,
+      artifacts_created: tool_result_artifacts(result),
+      important_details: tool_result_details(result, tool_execution),
+      remaining_work: [],
+      preview: truncate_tool_preview(tool_execution.preview),
       error: tool_execution.error
     }
   end
+
+  defp tool_result_path(%{"path" => path}) when is_binary(path), do: path
+  defp tool_result_path(%{path: path}) when is_binary(path), do: path
+  defp tool_result_path(_result), do: nil
+
+  defp tool_result_artifacts(result) do
+    case tool_result_path(result) do
+      path when is_binary(path) -> [path]
+      _path -> []
+    end
+  end
+
+  defp tool_result_details(result, tool_execution) do
+    [
+      tool_result_workspace_path(result),
+      tool_result_root_path(result),
+      tool_result_bytes_detail(result),
+      tool_execution.preview
+    ]
+    |> Enum.filter(&present_detail?/1)
+    |> Enum.take(4)
+  end
+
+  defp tool_result_workspace_path(%{"workspace_path" => workspace_path})
+       when is_binary(workspace_path),
+       do: "Workspace path: #{workspace_path}"
+
+  defp tool_result_workspace_path(%{workspace_path: workspace_path})
+       when is_binary(workspace_path),
+       do: "Workspace path: #{workspace_path}"
+
+  defp tool_result_workspace_path(_result), do: nil
+
+  defp tool_result_root_path(%{"root_path" => root_path}) when is_binary(root_path),
+    do: "Root path: #{root_path}"
+
+  defp tool_result_root_path(%{root_path: root_path}) when is_binary(root_path),
+    do: "Root path: #{root_path}"
+
+  defp tool_result_root_path(_result), do: nil
+
+  defp tool_result_bytes_detail(%{"bytes" => bytes}) when is_integer(bytes),
+    do: "Bytes written: #{bytes}"
+
+  defp tool_result_bytes_detail(%{bytes: bytes}) when is_integer(bytes),
+    do: "Bytes written: #{bytes}"
+
+  defp tool_result_bytes_detail(_result), do: nil
+
+  defp present_detail?(value) when is_binary(value), do: value != ""
+  defp present_detail?(_value), do: false
+
+  defp truncate_tool_preview(preview) when is_binary(preview) do
+    String.slice(preview, 0, 160)
+  end
+
+  defp truncate_tool_preview(_preview), do: nil
 
   defp normalize_tool_error(%{code: code, message: message} = error)
        when is_binary(code) and is_binary(message) do
@@ -1157,7 +1477,15 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   end
 
   defp clear_current_item(state) do
-    %{state | current_item: nil, retry_count: 0, tool_iteration_count: 0}
+    %{
+      state
+      | current_item: nil,
+        retry_count: 0,
+        tool_iteration_count: 0,
+        phase: :action_selection,
+        finalization_context: nil,
+        finalization_repair_attempted?: false
+    }
   end
 
   defp enqueue_work_item(state, content, opts) do
@@ -1182,7 +1510,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
       context_messages =
         if append_to_context? do
-          state.context_messages ++ [%{role: "user", content: content}]
+          state.context_messages ++ [%{role: "user", content: content, request_id: item.id}]
         else
           state.context_messages
         end
@@ -1204,6 +1532,33 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   defp maybe_cancel_idle(state, "queued"), do: cancel_idle_timer(state)
   defp maybe_cancel_idle(state, _status), do: state
 
+  defp start_model_step(state) do
+    started_at = state.now_fun.()
+    step_index = state.model_step_count + 1
+
+    attrs = %{
+      step_index: step_index,
+      status: "running",
+      request_payload: current_model_request_payload(state),
+      response_payload: nil,
+      parsed_output: nil,
+      error: nil,
+      tool_execution_id: nil,
+      provider: nil,
+      model: nil,
+      input_tokens: nil,
+      output_tokens: nil,
+      total_tokens: nil,
+      usage: nil,
+      started_at: started_at
+    }
+
+    case create_model_step(state, attrs) do
+      {:ok, next_state} ->
+        {%{next_state | model_step_count: step_index}, started_at}
+    end
+  end
+
   defp start_execution(state) do
     Logger.info("executor starting model task",
       event: "instance.executor.model_start",
@@ -1221,13 +1576,14 @@ defmodule LemmingsOs.LemmingInstances.Executor do
     parent = self()
     instance_id = state.instance_id
     model_task_ref = make_ref()
+    {state, started_at} = start_model_step(state)
 
     {:ok, model_task_pid} =
       Task.start(fn ->
         Logger.metadata(instance_id: instance_id, department_id: state.department_id)
         result = safe_execute_model(state)
 
-        send(parent, {:model_result, instance_id, model_task_ref, result})
+        send(parent, {:model_result, instance_id, model_task_ref, started_at, result})
       end)
 
     model_task_monitor_ref = Process.monitor(model_task_pid)
@@ -1269,12 +1625,31 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp terminate_model_task(state), do: state
 
+  defp finalize_model_step(state, result, completed_at \\ nil)
+
+  defp finalize_model_step(%{active_model_step: nil} = state, _result, _completed_at), do: state
+
+  defp finalize_model_step(
+         %{active_model_step: active_model_step} = state,
+         result,
+         completed_at
+       ) do
+    completed_at = completed_at || state.now_fun.()
+    duration_ms = DateTime.diff(completed_at, active_model_step.started_at, :millisecond)
+
+    attrs =
+      result
+      |> model_step_result_attrs(completed_at, duration_ms)
+
+    update_model_step(%{state | active_model_step: active_model_step}, attrs)
+  end
+
   defp safe_execute_model(state) do
     execute_model(
       state.model_mod,
       state.config_snapshot,
       state.context_messages,
-      state.current_item
+      current_model_request_item(state)
     )
   rescue
     exception ->
@@ -1323,6 +1698,198 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
       {:error, :model_crash}
   end
+
+  defp current_model_request_payload(state) do
+    case LemmingsOs.ModelRuntime.debug_request(
+           state.config_snapshot,
+           state.context_messages,
+           current_model_request_item(state)
+         ) do
+      {:ok, payload} -> sanitize_json_map(payload)
+      {:error, reason} -> %{"error" => inspect(reason)}
+    end
+  end
+
+  defp current_model_request_item(%{phase: :finalizing} = state) do
+    %{content: build_post_tool_success_prompt(state)}
+  end
+
+  defp current_model_request_item(state), do: state.current_item
+
+  defp build_post_tool_success_prompt(state) do
+    finalization_context = state.finalization_context || %{}
+    original_goal = Map.get(finalization_context, :original_goal) || state.current_item.content
+    completed_action = Map.get(finalization_context, :completed_action) || "Tool completed"
+    artifacts_created = Map.get(finalization_context, :artifacts_created, [])
+    important_details = Map.get(finalization_context, :important_details, [])
+    remaining_work = Map.get(finalization_context, :remaining_work, [])
+    repair_reason = Map.get(finalization_context, :repair_reason)
+
+    repair_section =
+      if is_binary(repair_reason) do
+        [
+          "Repair Notice:",
+          "- Your previous post-tool response was empty, invalid, or not usable.",
+          "- Repair reason: #{repair_reason}",
+          "- Return a concise final user-facing answer now."
+        ]
+      else
+        []
+      end
+
+    [
+      "Finalization Phase:",
+      "- The last tool execution completed successfully.",
+      "- You must now produce the final user-facing response.",
+      "- The response must not be empty.",
+      "",
+      "Original user goal:",
+      original_goal,
+      "",
+      "Last completed action:",
+      completed_action,
+      "",
+      "Artifacts created:",
+      bullet_list_or_none(artifacts_created),
+      "",
+      "Important details:",
+      bullet_list_or_none(important_details),
+      "",
+      "Remaining work:",
+      bullet_list_or_none(remaining_work),
+      "",
+      "Response rule:",
+      "- If the task is complete, summarize what was done and mention the created artifacts.",
+      "- If more work is needed, explain the next step clearly for the user.",
+      "- Do not request another tool call in this phase.",
+      "- Return action=reply with a useful final answer for the user.",
+      "",
+      repair_section
+    ]
+    |> List.flatten()
+    |> Enum.reject(&Helpers.blank?/1)
+    |> Enum.join("\n")
+  end
+
+  defp bullet_list_or_none([]), do: "- none"
+  defp bullet_list_or_none(values), do: Enum.map_join(values, "\n", &"- #{&1}")
+
+  defp model_step_result_attrs(
+         {:ok, %LemmingsOs.ModelRuntime.Response{} = response},
+         completed_at,
+         duration_ms
+       ) do
+    %{
+      status: "ok",
+      response_payload: sanitize_json_map(response.raw),
+      parsed_output: sanitize_json_map(parsed_output(response)),
+      provider: response.provider,
+      model: response.model,
+      input_tokens: response.input_tokens,
+      output_tokens: response.output_tokens,
+      total_tokens: response.total_tokens,
+      usage: sanitize_json_map(response.usage),
+      completed_at: completed_at,
+      duration_ms: max(duration_ms, 0)
+    }
+  end
+
+  defp model_step_result_attrs({:error, reason}, completed_at, duration_ms) do
+    error_payload = model_step_error_payload(reason)
+
+    %{
+      status: "error",
+      response_payload: model_step_error_response_payload(error_payload),
+      parsed_output: model_step_error_parsed_output(error_payload),
+      provider: Map.get(error_payload, "provider"),
+      model: Map.get(error_payload, "model"),
+      error: error_payload,
+      completed_at: completed_at,
+      duration_ms: max(duration_ms, 0)
+    }
+  end
+
+  defp model_step_result_attrs(_result, completed_at, duration_ms) do
+    %{
+      status: "error",
+      error: %{"reason" => "unexpected_model_result"},
+      completed_at: completed_at,
+      duration_ms: max(duration_ms, 0)
+    }
+  end
+
+  defp parsed_output(%LemmingsOs.ModelRuntime.Response{action: :reply} = response) do
+    %{"action" => "reply", "reply" => response.reply}
+  end
+
+  defp parsed_output(%LemmingsOs.ModelRuntime.Response{action: :tool_call} = response) do
+    %{
+      "action" => "tool_call",
+      "tool_name" => response.tool_name,
+      "args" => sanitize_json_map(response.tool_args)
+    }
+  end
+
+  defp sanitize_json_map(nil), do: nil
+  defp sanitize_json_map(value), do: sanitize_json_term(value)
+
+  defp sanitize_json_term(nil), do: nil
+
+  defp sanitize_json_term(value) when is_binary(value) or is_boolean(value) or is_number(value),
+    do: value
+
+  defp sanitize_json_term(value) when is_atom(value), do: Atom.to_string(value)
+  defp sanitize_json_term(%DateTime{} = value), do: DateTime.to_iso8601(value)
+  defp sanitize_json_term(%NaiveDateTime{} = value), do: NaiveDateTime.to_iso8601(value)
+  defp sanitize_json_term(%Date{} = value), do: Date.to_iso8601(value)
+  defp sanitize_json_term(%Time{} = value), do: Time.to_iso8601(value)
+
+  defp sanitize_json_term(%_{} = value) do
+    value
+    |> Map.from_struct()
+    |> Map.delete(:__meta__)
+    |> sanitize_json_term()
+  end
+
+  defp sanitize_json_term(value) when is_map(value) do
+    Map.new(value, fn {key, nested_value} ->
+      {to_string(key), sanitize_json_term(nested_value)}
+    end)
+  end
+
+  defp sanitize_json_term(value) when is_list(value) do
+    Enum.map(value, &sanitize_json_term/1)
+  end
+
+  defp sanitize_json_term(value) when is_tuple(value) do
+    %{"tuple" => value |> Tuple.to_list() |> Enum.map(&sanitize_json_term/1)}
+  end
+
+  defp sanitize_json_term(value), do: inspect(value)
+
+  defp model_step_error_payload({kind, metadata})
+       when kind in [:invalid_structured_output, :unknown_action] and is_map(metadata) do
+    metadata
+    |> sanitize_json_map()
+    |> Map.put("kind", Atom.to_string(kind))
+    |> Map.put_new("reason", Atom.to_string(kind))
+  end
+
+  defp model_step_error_payload(reason) do
+    %{"reason" => inspect(reason)}
+  end
+
+  defp model_step_error_response_payload(%{"raw" => raw}) when is_map(raw), do: raw
+  defp model_step_error_response_payload(_error_payload), do: nil
+
+  defp model_step_error_parsed_output(%{"content" => content}) when is_binary(content) do
+    case Jason.decode(content) do
+      {:ok, parsed} -> sanitize_json_map(parsed)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp model_step_error_parsed_output(_error_payload), do: nil
 
   defp execute_model(nil, config_snapshot, context_messages, current_item) do
     LemmingsOs.ModelRuntime.run(config_snapshot, context_messages, current_item)
@@ -1670,6 +2237,9 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       tool_iteration_count: state.tool_iteration_count,
       max_retries: state.max_retries,
       context_messages: state.context_messages,
+      phase: state.phase,
+      finalization_context: state.finalization_context,
+      finalization_repair_attempted?: state.finalization_repair_attempted?,
       last_error: state.last_error,
       internal_error_details: state.internal_error_details,
       status: status_atom(state.status),
@@ -1777,7 +2347,13 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   defp last_error_message(:invalid_structured_output),
     do: "Model returned invalid structured output."
 
+  defp last_error_message({:invalid_structured_output, _metadata}),
+    do: "Model returned invalid structured output."
+
   defp last_error_message(:unknown_action),
+    do: "Model returned an unsupported action."
+
+  defp last_error_message({:unknown_action, _metadata}),
     do: "Model returned an unsupported action."
 
   defp last_error_message(:missing_model),
@@ -1842,6 +2418,18 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp internal_error_details({:provider_invalid_response, metadata}) when is_map(metadata) do
     Map.put(metadata, :kind, :provider_invalid_response)
+  end
+
+  defp internal_error_details({:invalid_structured_output, metadata}) when is_map(metadata) do
+    metadata
+    |> sanitize_json_map()
+    |> Map.put("kind", "invalid_structured_output")
+  end
+
+  defp internal_error_details({:unknown_action, metadata}) when is_map(metadata) do
+    metadata
+    |> sanitize_json_map()
+    |> Map.put("kind", "unknown_action")
   end
 
   defp internal_error_details({:assistant_message_persist_failed, reason}) do

--- a/lib/lemmings_os/lemming_instances/executor.ex
+++ b/lib/lemmings_os/lemming_instances/executor.ex
@@ -26,11 +26,15 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   alias LemmingsOs.LemmingInstances.ResourcePool
   alias LemmingsOs.LemmingInstances.RuntimeTableOwner
   alias LemmingsOs.LemmingInstances.Telemetry
+  alias LemmingsOs.LemmingTools
   alias LemmingsOs.Repo
   alias LemmingsOs.Runtime.ActivityLog
+  alias LemmingsOs.Tools.Runtime, as: ToolsRuntime
+  alias LemmingsOs.Worlds.World
 
   @runtime_table :lemming_instance_runtime
   @default_max_retries 3
+  @default_max_tool_iterations 8
   @default_model_timeout_ms 120_000
 
   @statuses ~w(created queued processing retrying idle failed expired)
@@ -55,6 +59,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
           retry_count: non_neg_integer(),
           max_retries: pos_integer(),
           context_messages: [map()],
+          tool_iteration_count: non_neg_integer(),
           last_error: String.t() | nil,
           internal_error_details: map() | String.t() | nil,
           model_task_pid: pid() | nil,
@@ -73,6 +78,8 @@ defmodule LemmingsOs.LemmingInstances.Executor do
           pool_mod: module() | nil,
           model_mod: module() | nil,
           message_persist_mod: module() | nil,
+          tools_context_mod: module() | nil,
+          tool_runtime_mod: module() | nil,
           pubsub_mod: module() | nil,
           pubsub_name: atom(),
           load_context_messages?: boolean(),
@@ -360,6 +367,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         retry_count: 0,
         max_retries: max_retries(config_snapshot),
         context_messages: [],
+        tool_iteration_count: 0,
         last_error: nil,
         internal_error_details: nil,
         model_task_pid: nil,
@@ -379,6 +387,8 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         pool_mod: Keyword.get(opts, :pool_mod, ResourcePool),
         model_mod: Keyword.get(opts, :model_mod, LemmingsOs.ModelRuntime),
         message_persist_mod: Keyword.get(opts, :message_persist_mod),
+        tools_context_mod: Keyword.get(opts, :tools_context_mod, LemmingTools),
+        tool_runtime_mod: Keyword.get(opts, :tool_runtime_mod, ToolsRuntime),
         pubsub_mod: Keyword.get(opts, :pubsub_mod, Phoenix.PubSub),
         pubsub_name: Keyword.get(opts, :pubsub_name, LemmingsOs.PubSub),
         now_fun: now_fun
@@ -454,6 +464,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       status: state.status,
       retry_count: state.retry_count,
       max_retries: state.max_retries,
+      tool_iteration_count: state.tool_iteration_count,
       queue_depth: :queue.len(state.queue),
       last_error: state.last_error,
       internal_error_details: state.internal_error_details
@@ -471,6 +482,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       queue_depth: :queue.len(state.queue),
       retry_count: state.retry_count,
       max_retries: state.max_retries,
+      tool_iteration_count: state.tool_iteration_count,
       current_item_id: current_item_id(state.current_item),
       current_resource_key: state.current_resource_key,
       last_error: state.last_error,
@@ -662,7 +674,10 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp retry_failed(state), do: state
 
-  defp handle_model_result(state, {:ok, %LemmingsOs.ModelRuntime.Response{} = response}) do
+  defp handle_model_result(
+         state,
+         {:ok, %LemmingsOs.ModelRuntime.Response{action: :reply} = response}
+       ) do
     state =
       state
       |> Map.put(:last_error, nil)
@@ -676,6 +691,24 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
       {:error, reason, next_state} ->
         handle_model_retry(next_state, {:assistant_message_persist_failed, reason})
+    end
+  end
+
+  defp handle_model_result(
+         state,
+         {:ok, %LemmingsOs.ModelRuntime.Response{action: :tool_call} = response}
+       ) do
+    state =
+      state
+      |> Map.put(:last_error, nil)
+      |> Map.put(:internal_error_details, nil)
+
+    case execute_tool_call(state, response) do
+      {:ok, next_state} ->
+        continue_tool_loop(next_state)
+
+      {:error, reason, next_state} ->
+        handle_model_retry(next_state, reason)
     end
   end
 
@@ -716,6 +749,240 @@ defmodule LemmingsOs.LemmingInstances.Executor do
     end
   end
 
+  defp execute_tool_call(
+         state,
+         %LemmingsOs.ModelRuntime.Response{tool_name: tool_name, tool_args: tool_args}
+       )
+       when is_binary(tool_name) and is_map(tool_args) do
+    started_at = state.now_fun.()
+
+    with {:ok, tool_execution} <- create_tool_execution(state, tool_name, tool_args, started_at),
+         {:ok, world} <- runtime_world(state) do
+      state
+      |> persist_tool_outcome(
+        tool_execution,
+        execute_tool_runtime(state, world, tool_name, tool_args),
+        started_at
+      )
+      |> normalize_tool_outcome_result()
+    else
+      {:error, reason, next_state} ->
+        {:error, reason, next_state}
+
+      {:error, reason} ->
+        {:error, reason, state}
+    end
+  end
+
+  defp execute_tool_call(state, _response), do: {:error, :invalid_structured_output, state}
+
+  defp persist_tool_outcome(state, tool_execution, {:ok, execution_result}, started_at) do
+    persist_tool_success(state, tool_execution, execution_result, started_at)
+  end
+
+  defp persist_tool_outcome(state, tool_execution, {:error, execution_error}, started_at) do
+    persist_tool_error(state, tool_execution, execution_error, started_at)
+  end
+
+  defp normalize_tool_outcome_result({:ok, updated_tool_execution, next_state}) do
+    {:ok, append_tool_result_context(next_state, updated_tool_execution)}
+  end
+
+  defp normalize_tool_outcome_result({:error, reason, next_state}) do
+    {:error, reason, next_state}
+  end
+
+  defp continue_tool_loop(state) do
+    next_iteration_count = state.tool_iteration_count + 1
+
+    if next_iteration_count >= max_tool_iterations(state.config_snapshot) do
+      handle_model_retry(
+        %{state | tool_iteration_count: next_iteration_count},
+        :tool_iteration_limit_reached
+      )
+    else
+      state
+      |> Map.put(:tool_iteration_count, next_iteration_count)
+      |> put_runtime_state()
+      |> start_execution()
+    end
+  end
+
+  defp create_tool_execution(state, tool_name, tool_args, started_at) do
+    tool_attrs = %{
+      tool_name: tool_name,
+      status: "running",
+      args: tool_args,
+      started_at: started_at
+    }
+
+    tools_context = state.tools_context_mod
+
+    cond do
+      is_nil(tools_context) ->
+        {:error, :tool_execution_unavailable, state}
+
+      module_loaded_and_exports?(tools_context, :create_tool_execution, 3) ->
+        case tools_context.create_tool_execution(
+               runtime_world_struct(state),
+               state.instance,
+               tool_attrs
+             ) do
+          {:ok, tool_execution} ->
+            _ =
+              PubSub.broadcast_tool_execution_upserted(
+                state.instance_id,
+                tool_execution.id,
+                tool_execution.status
+              )
+
+            {:ok, tool_execution}
+
+          {:error, reason} ->
+            {:error, {:tool_execution_create_failed, reason}, state}
+        end
+
+      true ->
+        {:error, :tool_execution_unavailable, state}
+    end
+  end
+
+  defp execute_tool_runtime(state, world, tool_name, tool_args) do
+    tool_runtime_mod = state.tool_runtime_mod
+
+    if module_loaded_and_exports?(tool_runtime_mod, :execute, 4) do
+      tool_runtime_mod.execute(world, state.instance, tool_name, tool_args)
+    else
+      {:error,
+       %{
+         tool_name: tool_name,
+         code: "tool.runtime.unavailable",
+         message: "Tool runtime is unavailable",
+         details: %{}
+       }}
+    end
+  end
+
+  defp persist_tool_success(state, tool_execution, execution_result, started_at) do
+    completed_at = state.now_fun.()
+    duration_ms = DateTime.diff(completed_at, started_at, :millisecond)
+
+    attrs = %{
+      status: "ok",
+      result: execution_result.result,
+      summary: execution_result.summary,
+      preview: execution_result.preview,
+      completed_at: completed_at,
+      duration_ms: max(duration_ms, 0)
+    }
+
+    update_tool_execution(state, tool_execution, attrs)
+  end
+
+  defp persist_tool_error(state, tool_execution, execution_error, started_at) do
+    normalized_error = normalize_tool_error(execution_error)
+    completed_at = state.now_fun.()
+    duration_ms = DateTime.diff(completed_at, started_at, :millisecond)
+
+    attrs = %{
+      status: "error",
+      error: %{
+        code: normalized_error.code,
+        message: normalized_error.message,
+        details: normalized_error.details
+      },
+      summary: normalized_error.message,
+      completed_at: completed_at,
+      duration_ms: max(duration_ms, 0)
+    }
+
+    update_tool_execution(state, tool_execution, attrs)
+  end
+
+  defp update_tool_execution(state, tool_execution, attrs) do
+    tools_context = state.tools_context_mod
+
+    cond do
+      is_nil(tools_context) ->
+        {:error, :tool_execution_unavailable, state}
+
+      module_loaded_and_exports?(tools_context, :update_tool_execution, 4) ->
+        case tools_context.update_tool_execution(
+               runtime_world_struct(state),
+               state.instance,
+               tool_execution,
+               attrs
+             ) do
+          {:ok, updated_tool_execution} ->
+            _ =
+              PubSub.broadcast_tool_execution_upserted(
+                state.instance_id,
+                updated_tool_execution.id,
+                updated_tool_execution.status
+              )
+
+            {:ok, updated_tool_execution, state}
+
+          {:error, reason} ->
+            {:error, {:tool_execution_update_failed, reason}, state}
+        end
+
+      true ->
+        {:error, :tool_execution_unavailable, state}
+    end
+  end
+
+  defp append_tool_result_context(state, tool_execution) do
+    tool_message = %{
+      role: "assistant",
+      content:
+        "Tool #{tool_execution.tool_name} status=#{tool_execution.status} result=#{Jason.encode!(tool_result_payload(tool_execution))}"
+    }
+
+    %{state | context_messages: state.context_messages ++ [tool_message]}
+  end
+
+  defp tool_result_payload(%{status: "ok"} = tool_execution) do
+    %{
+      summary: tool_execution.summary,
+      preview: tool_execution.preview,
+      result: tool_execution.result
+    }
+  end
+
+  defp tool_result_payload(%{status: "error"} = tool_execution) do
+    %{
+      summary: tool_execution.summary,
+      error: tool_execution.error
+    }
+  end
+
+  defp tool_result_payload(tool_execution) do
+    %{
+      summary: tool_execution.summary,
+      result: tool_execution.result,
+      error: tool_execution.error
+    }
+  end
+
+  defp normalize_tool_error(%{code: code, message: message} = error)
+       when is_binary(code) and is_binary(message) do
+    %{code: code, message: message, details: Map.get(error, :details, %{})}
+  end
+
+  defp normalize_tool_error(other) do
+    %{
+      code: "tool.runtime.error",
+      message: "Tool execution failed",
+      details: %{reason: inspect(other)}
+    }
+  end
+
+  defp module_loaded_and_exports?(module, function_name, arity)
+       when is_atom(module) and is_atom(function_name) and is_integer(arity) do
+    Code.ensure_loaded?(module) and function_exported?(module, function_name, arity)
+  end
+
   defp advance_after_success(state) do
     state = release_resource(state)
 
@@ -739,7 +1006,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   end
 
   defp clear_current_item(state) do
-    %{state | current_item: nil, retry_count: 0}
+    %{state | current_item: nil, retry_count: 0, tool_iteration_count: 0}
   end
 
   defp enqueue_work_item(state, content, opts) do
@@ -1247,6 +1514,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       resource_key:
         state.current_resource_key || ConfigSnapshot.resource_key(state.config_snapshot),
       retry_count: state.retry_count,
+      tool_iteration_count: state.tool_iteration_count,
       max_retries: state.max_retries,
       context_messages: state.context_messages,
       last_error: state.last_error,
@@ -1305,6 +1573,17 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   defp instance_lemming_id(%{lemming_id: lemming_id}), do: lemming_id
   defp instance_lemming_id(_instance), do: nil
 
+  defp runtime_world_struct(state) do
+    %World{id: instance_world_id(state.instance)}
+  end
+
+  defp runtime_world(state) do
+    case instance_world_id(state.instance) do
+      world_id when is_binary(world_id) -> {:ok, %World{id: world_id}}
+      _world_id -> {:error, :invalid_world_scope}
+    end
+  end
+
   defp current_item_id(%{id: id}) when is_binary(id), do: id
   defp current_item_id(_current_item), do: nil
 
@@ -1360,6 +1639,21 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   defp last_error_message(:invalid_provider_response),
     do: "Model provider returned an invalid response payload."
 
+  defp last_error_message(:tool_execution_unavailable),
+    do: "Tool execution persistence is unavailable."
+
+  defp last_error_message({:tool_execution_create_failed, _reason}),
+    do: "Tool execution could not be persisted."
+
+  defp last_error_message({:tool_execution_update_failed, _reason}),
+    do: "Tool execution could not be updated."
+
+  defp last_error_message(:tool_iteration_limit_reached),
+    do: "Tool iteration limit reached before final reply."
+
+  defp last_error_message(:invalid_world_scope),
+    do: "Runtime world scope is invalid."
+
   defp last_error_message(:unexpected_model_result),
     do: "Executor received an unexpected model result."
 
@@ -1393,6 +1687,14 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp internal_error_details({:assistant_message_persist_failed, reason}) do
     %{kind: :assistant_message_persist_failed, reason: inspect(reason)}
+  end
+
+  defp internal_error_details({:tool_execution_create_failed, reason}) do
+    %{kind: :tool_execution_create_failed, reason: inspect(reason)}
+  end
+
+  defp internal_error_details({:tool_execution_update_failed, reason}) do
+    %{kind: :tool_execution_update_failed, reason: inspect(reason)}
   end
 
   defp internal_error_details(reason) when is_atom(reason), do: %{kind: reason}
@@ -1475,6 +1777,10 @@ defmodule LemmingsOs.LemmingInstances.Executor do
     runtime_config_value(config_snapshot, :max_retries) ||
       runtime_config_value(config_snapshot, :max_attempts) ||
       @default_max_retries
+  end
+
+  defp max_tool_iterations(config_snapshot) do
+    runtime_config_value(config_snapshot, :max_tool_iterations) || @default_max_tool_iterations
   end
 
   defp model_timeout_ms(config_snapshot) do

--- a/lib/lemmings_os/lemming_instances/lemming_instance.ex
+++ b/lib/lemmings_os/lemming_instances/lemming_instance.ex
@@ -11,6 +11,7 @@ defmodule LemmingsOs.LemmingInstances.LemmingInstance do
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.LemmingInstances.Message
+  alias LemmingsOs.LemmingInstances.ToolExecution
   alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.Worlds.World
 
@@ -38,6 +39,7 @@ defmodule LemmingsOs.LemmingInstances.LemmingInstance do
           stopped_at: DateTime.t() | nil,
           last_activity_at: DateTime.t() | nil,
           messages: [Message.t()] | Ecto.Association.NotLoaded.t(),
+          tool_executions: [ToolExecution.t()] | Ecto.Association.NotLoaded.t(),
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
@@ -54,6 +56,7 @@ defmodule LemmingsOs.LemmingInstances.LemmingInstance do
     belongs_to :city, City
     belongs_to :department, Department
     has_many :messages, Message
+    has_many :tool_executions, ToolExecution
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/lemmings_os/lemming_instances/pubsub.ex
+++ b/lib/lemmings_os/lemming_instances/pubsub.ex
@@ -212,6 +212,20 @@ defmodule LemmingsOs.LemmingInstances.PubSub do
   end
 
   @doc """
+  Broadcasts that a model-step lifecycle row was created or updated.
+  """
+  @spec broadcast_model_step_upserted(binary(), binary(), binary()) :: :ok | {:error, term()}
+  def broadcast_model_step_upserted(instance_id, model_step_id, status)
+      when is_binary(instance_id) and is_binary(model_step_id) and is_binary(status) do
+    Phoenix.PubSub.broadcast(
+      @pubsub_server,
+      instance_messages_topic(instance_id),
+      {:model_step_upserted,
+       %{instance_id: instance_id, model_step_id: model_step_id, status: status}}
+    )
+  end
+
+  @doc """
   Broadcasts a scheduler admission signal to an executor.
 
   ## Examples

--- a/lib/lemmings_os/lemming_instances/pubsub.ex
+++ b/lib/lemmings_os/lemming_instances/pubsub.ex
@@ -198,6 +198,20 @@ defmodule LemmingsOs.LemmingInstances.PubSub do
   end
 
   @doc """
+  Broadcasts that a tool execution lifecycle row was created or updated.
+  """
+  @spec broadcast_tool_execution_upserted(binary(), binary(), binary()) :: :ok | {:error, term()}
+  def broadcast_tool_execution_upserted(instance_id, tool_execution_id, status)
+      when is_binary(instance_id) and is_binary(tool_execution_id) and is_binary(status) do
+    Phoenix.PubSub.broadcast(
+      @pubsub_server,
+      instance_messages_topic(instance_id),
+      {:tool_execution_upserted,
+       %{instance_id: instance_id, tool_execution_id: tool_execution_id, status: status}}
+    )
+  end
+
+  @doc """
   Broadcasts a scheduler admission signal to an executor.
 
   ## Examples

--- a/lib/lemmings_os/lemming_instances/telemetry.ex
+++ b/lib/lemmings_os/lemming_instances/telemetry.ex
@@ -95,6 +95,23 @@ defmodule LemmingsOs.LemmingInstances.Telemetry do
   end
 
   @doc """
+  Builds tool-execution metadata with full hierarchy and tool identity keys.
+  """
+  @spec tool_execution_metadata(map() | struct() | nil, map(), map()) :: metadata()
+  def tool_execution_metadata(instance, tool_execution, extra \\ %{})
+      when is_map(tool_execution) and is_map(extra) do
+    instance
+    |> instance_metadata(%{
+      tool_name: fetch(tool_execution, :tool_name),
+      tool_execution_id: fetch(tool_execution, :id),
+      tool_status: fetch(tool_execution, :status),
+      duration_ms: fetch(tool_execution, :duration_ms),
+      reason: Map.get(extra, :reason)
+    })
+    |> Map.merge(extra)
+  end
+
+  @doc """
   Normalizes internal reasons into stable telemetry-friendly tokens.
   """
   @spec reason_token(term()) :: String.t() | nil

--- a/lib/lemmings_os/lemming_instances/tool_execution.ex
+++ b/lib/lemmings_os/lemming_instances/tool_execution.ex
@@ -1,0 +1,144 @@
+defmodule LemmingsOs.LemmingInstances.ToolExecution do
+  @moduledoc """
+  Persisted durable tool-execution record for a runtime instance.
+  """
+
+  use Ecto.Schema
+  use Gettext, backend: LemmingsOs.Gettext
+
+  import Ecto.Changeset
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Worlds.World
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @statuses ~w(running ok error)
+  @required ~w(lemming_instance_id world_id tool_name status args)a
+  @optional ~w(result error summary preview started_at completed_at duration_ms)a
+  @update_fields ~w(status result error summary preview started_at completed_at duration_ms)a
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t() | nil,
+          lemming_instance_id: Ecto.UUID.t() | nil,
+          lemming_instance: LemmingInstance.t() | Ecto.Association.NotLoaded.t() | nil,
+          world_id: Ecto.UUID.t() | nil,
+          world: World.t() | Ecto.Association.NotLoaded.t() | nil,
+          tool_name: String.t() | nil,
+          status: String.t() | nil,
+          args: map() | nil,
+          result: map() | nil,
+          error: map() | nil,
+          summary: String.t() | nil,
+          preview: String.t() | nil,
+          started_at: DateTime.t() | nil,
+          completed_at: DateTime.t() | nil,
+          duration_ms: non_neg_integer() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "lemming_instance_tool_executions" do
+    field :tool_name, :string
+    field :status, :string, default: "running"
+    field :args, :map
+    field :result, :map
+    field :error, :map
+    field :summary, :string
+    field :preview, :string
+    field :started_at, :utc_datetime
+    field :completed_at, :utc_datetime
+    field :duration_ms, :integer
+
+    belongs_to :lemming_instance, LemmingInstance
+    belongs_to :world, World
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Builds the changeset for creating a durable tool-execution record.
+
+  ## Examples
+
+      iex> changeset =
+      ...>   LemmingsOs.LemmingInstances.ToolExecution.create_changeset(
+      ...>     %LemmingsOs.LemmingInstances.ToolExecution{},
+      ...>     %{
+      ...>       lemming_instance_id: Ecto.UUID.generate(),
+      ...>       world_id: Ecto.UUID.generate(),
+      ...>       tool_name: "fs.read_text_file",
+      ...>       status: "running",
+      ...>       args: %{"path" => "notes.txt"}
+      ...>     }
+      ...>   )
+      iex> changeset.valid?
+      true
+  """
+  @spec create_changeset(t(), map()) :: Ecto.Changeset.t()
+  def create_changeset(tool_execution, attrs) do
+    tool_execution
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required, message: dgettext("errors", ".required"))
+    |> validate_inclusion(:status, @statuses, message: dgettext("errors", ".invalid_choice"))
+    |> validate_maps()
+    |> validate_number(:duration_ms,
+      greater_than_or_equal_to: 0,
+      message: dgettext("errors", ".invalid_value")
+    )
+    |> assoc_constraint(:lemming_instance)
+    |> assoc_constraint(:world)
+    |> foreign_key_constraint(:lemming_instance_id)
+    |> foreign_key_constraint(:world_id)
+  end
+
+  @doc """
+  Builds the changeset for updating a durable tool-execution record.
+
+  ## Examples
+
+      iex> changeset =
+      ...>   LemmingsOs.LemmingInstances.ToolExecution.update_changeset(
+      ...>     %LemmingsOs.LemmingInstances.ToolExecution{},
+      ...>     %{status: "ok", result: %{"content" => "done"}, duration_ms: 12}
+      ...>   )
+      iex> changeset.valid?
+      true
+  """
+  @spec update_changeset(t(), map()) :: Ecto.Changeset.t()
+  def update_changeset(tool_execution, attrs) do
+    tool_execution
+    |> cast(attrs, @update_fields)
+    |> validate_inclusion(:status, @statuses, message: dgettext("errors", ".invalid_choice"))
+    |> validate_maps()
+    |> validate_number(:duration_ms,
+      greater_than_or_equal_to: 0,
+      message: dgettext("errors", ".invalid_value")
+    )
+  end
+
+  @doc """
+  Canonical persisted status values for tool executions.
+  """
+  @spec statuses() :: [String.t()]
+  def statuses, do: @statuses
+
+  defp validate_maps(changeset) do
+    changeset
+    |> validate_map_field(:args)
+    |> validate_map_field(:result)
+    |> validate_map_field(:error)
+  end
+
+  defp validate_map_field(changeset, field) do
+    validate_change(changeset, field, &map_field_errors/2)
+  end
+
+  defp map_field_errors(_field, value) when is_map(value), do: []
+  defp map_field_errors(_field, nil), do: []
+
+  defp map_field_errors(field, _value) do
+    [{field, dgettext("errors", ".invalid_value_type")}]
+  end
+end

--- a/lib/lemmings_os/lemming_tools.ex
+++ b/lib/lemmings_os/lemming_tools.ex
@@ -1,0 +1,252 @@
+defmodule LemmingsOs.LemmingTools do
+  @moduledoc """
+  World-scoped persistence boundary for lemming tool executions.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.LemmingInstances.ToolExecution
+  alias LemmingsOs.Repo
+  alias LemmingsOs.Worlds.World
+
+  @doc """
+  Creates a durable tool-execution record for a runtime instance in a World scope.
+
+  ## Examples
+
+      iex> world = LemmingsOs.Factory.insert(:world)
+      iex> city = LemmingsOs.Factory.insert(:city, world: world)
+      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
+      iex> lemming =
+      ...>   LemmingsOs.Factory.insert(:lemming,
+      ...>     world: world,
+      ...>     city: city,
+      ...>     department: department,
+      ...>     status: "active"
+      ...>   )
+      iex> {:ok, instance} = LemmingsOs.LemmingInstances.spawn_instance(lemming, "Summarize the roadmap")
+      iex> {:ok, %LemmingsOs.LemmingInstances.ToolExecution{status: "running"}} =
+      ...>   LemmingsOs.LemmingTools.create_tool_execution(
+      ...>     world,
+      ...>     instance,
+      ...>     %{
+      ...>       tool_name: "fs.read_text_file",
+      ...>       status: "running",
+      ...>       args: %{"path" => "notes.txt"}
+      ...>     }
+      ...>   )
+  """
+  @spec create_tool_execution(World.t(), LemmingInstance.t(), map()) ::
+          {:ok, ToolExecution.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def create_tool_execution(world, instance, attrs \\ %{})
+
+  def create_tool_execution(
+        %World{id: world_id},
+        %LemmingInstance{id: instance_id, world_id: world_id},
+        attrs
+      )
+      when is_binary(instance_id) and is_map(attrs) do
+    %ToolExecution{}
+    |> ToolExecution.create_changeset(
+      Map.merge(attrs, %{lemming_instance_id: instance_id, world_id: world_id})
+    )
+    |> Repo.insert()
+  end
+
+  def create_tool_execution(_, _, _), do: {:error, :not_found}
+
+  @doc """
+  Returns persisted tool executions for an instance in chronological order.
+
+  ## Examples
+
+      iex> world = LemmingsOs.Factory.insert(:world)
+      iex> city = LemmingsOs.Factory.insert(:city, world: world)
+      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
+      iex> lemming =
+      ...>   LemmingsOs.Factory.insert(:lemming,
+      ...>     world: world,
+      ...>     city: city,
+      ...>     department: department,
+      ...>     status: "active"
+      ...>   )
+      iex> {:ok, instance} = LemmingsOs.LemmingInstances.spawn_instance(lemming, "Summarize the roadmap")
+      iex> {:ok, tool_execution} =
+      ...>   LemmingsOs.LemmingTools.create_tool_execution(
+      ...>     world,
+      ...>     instance,
+      ...>     %{
+      ...>       tool_name: "fs.read_text_file",
+      ...>       status: "running",
+      ...>       args: %{"path" => "notes.txt"}
+      ...>     }
+      ...>   )
+      iex> [listed_execution] = LemmingsOs.LemmingTools.list_tool_executions(world, instance)
+      iex> listed_execution.id == tool_execution.id
+      true
+  """
+  @spec list_tool_executions(World.t(), LemmingInstance.t(), keyword()) :: [ToolExecution.t()]
+  def list_tool_executions(world, instance, opts \\ [])
+
+  def list_tool_executions(
+        %World{id: world_id},
+        %LemmingInstance{id: instance_id, world_id: world_id},
+        opts
+      )
+      when is_binary(instance_id) and is_list(opts) do
+    ToolExecution
+    |> where(
+      [tool_execution],
+      tool_execution.lemming_instance_id == ^instance_id and tool_execution.world_id == ^world_id
+    )
+    |> filter_query(opts)
+    |> order_by([tool_execution], asc: tool_execution.inserted_at, asc: tool_execution.id)
+    |> Repo.all()
+  end
+
+  def list_tool_executions(_, _, _), do: []
+
+  @doc """
+  Returns a persisted tool-execution record constrained to the given World and instance.
+
+  ## Examples
+
+      iex> world = LemmingsOs.Factory.insert(:world)
+      iex> city = LemmingsOs.Factory.insert(:city, world: world)
+      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
+      iex> lemming =
+      ...>   LemmingsOs.Factory.insert(:lemming,
+      ...>     world: world,
+      ...>     city: city,
+      ...>     department: department,
+      ...>     status: "active"
+      ...>   )
+      iex> {:ok, instance} = LemmingsOs.LemmingInstances.spawn_instance(lemming, "Summarize the roadmap")
+      iex> {:ok, tool_execution} =
+      ...>   LemmingsOs.LemmingTools.create_tool_execution(
+      ...>     world,
+      ...>     instance,
+      ...>     %{
+      ...>       tool_name: "fs.read_text_file",
+      ...>       status: "running",
+      ...>       args: %{"path" => "notes.txt"}
+      ...>     }
+      ...>   )
+      iex> {:ok, %LemmingsOs.LemmingInstances.ToolExecution{id: id}} =
+      ...>   LemmingsOs.LemmingTools.get_tool_execution(world, instance, tool_execution.id)
+      iex> id == tool_execution.id
+      true
+  """
+  @spec get_tool_execution(World.t(), LemmingInstance.t(), Ecto.UUID.t(), keyword()) ::
+          {:ok, ToolExecution.t()} | {:error, :not_found}
+  def get_tool_execution(world, instance, tool_execution_id, opts \\ [])
+
+  def get_tool_execution(
+        %World{id: world_id},
+        %LemmingInstance{id: instance_id, world_id: world_id},
+        tool_execution_id,
+        opts
+      )
+      when is_binary(instance_id) and is_binary(tool_execution_id) and is_list(opts) do
+    ToolExecution
+    |> where(
+      [tool_execution],
+      tool_execution.id == ^tool_execution_id and
+        tool_execution.lemming_instance_id == ^instance_id and
+        tool_execution.world_id == ^world_id
+    )
+    |> filter_query(opts)
+    |> Repo.one()
+    |> normalize_tool_execution_result()
+  end
+
+  def get_tool_execution(_, _, _, _), do: {:error, :not_found}
+
+  @doc """
+  Updates a persisted tool-execution record in a World and instance scope.
+
+  ## Examples
+
+      iex> world = LemmingsOs.Factory.insert(:world)
+      iex> city = LemmingsOs.Factory.insert(:city, world: world)
+      iex> department = LemmingsOs.Factory.insert(:department, world: world, city: city)
+      iex> lemming =
+      ...>   LemmingsOs.Factory.insert(:lemming,
+      ...>     world: world,
+      ...>     city: city,
+      ...>     department: department,
+      ...>     status: "active"
+      ...>   )
+      iex> {:ok, instance} = LemmingsOs.LemmingInstances.spawn_instance(lemming, "Summarize the roadmap")
+      iex> {:ok, tool_execution} =
+      ...>   LemmingsOs.LemmingTools.create_tool_execution(
+      ...>     world,
+      ...>     instance,
+      ...>     %{
+      ...>       tool_name: "fs.read_text_file",
+      ...>       status: "running",
+      ...>       args: %{"path" => "notes.txt"}
+      ...>     }
+      ...>   )
+      iex> {:ok, %LemmingsOs.LemmingInstances.ToolExecution{status: "ok"}} =
+      ...>   LemmingsOs.LemmingTools.update_tool_execution(
+      ...>     world,
+      ...>     instance,
+      ...>     tool_execution,
+      ...>     %{status: "ok", result: %{"content" => "notes"}}
+      ...>   )
+  """
+  @spec update_tool_execution(World.t(), LemmingInstance.t(), ToolExecution.t(), map()) ::
+          {:ok, ToolExecution.t()} | {:error, Ecto.Changeset.t() | :not_found}
+  def update_tool_execution(world, instance, tool_execution, attrs \\ %{})
+
+  def update_tool_execution(
+        %World{id: world_id},
+        %LemmingInstance{id: instance_id, world_id: world_id},
+        %ToolExecution{
+          id: tool_execution_id,
+          lemming_instance_id: instance_id,
+          world_id: world_id
+        } =
+          tool_execution,
+        attrs
+      )
+      when is_binary(tool_execution_id) and is_map(attrs) do
+    tool_execution
+    |> ToolExecution.update_changeset(attrs)
+    |> Repo.update()
+  end
+
+  def update_tool_execution(_, _, _, _), do: {:error, :not_found}
+
+  defp filter_query(query, [{:status, status} | rest]),
+    do: filter_query(from(item in query, where: field(item, ^:status) == ^status), rest)
+
+  defp filter_query(query, [{:statuses, statuses} | rest]) when is_list(statuses),
+    do: filter_query(from(item in query, where: field(item, ^:status) in ^statuses), rest)
+
+  defp filter_query(query, [{:lemming_instance_id, lemming_instance_id} | rest]),
+    do:
+      filter_query(
+        from(item in query, where: field(item, ^:lemming_instance_id) == ^lemming_instance_id),
+        rest
+      )
+
+  defp filter_query(query, [{:tool_name, tool_name} | rest]),
+    do: filter_query(from(item in query, where: field(item, ^:tool_name) == ^tool_name), rest)
+
+  defp filter_query(query, [{:ids, ids} | rest]) when is_list(ids),
+    do: filter_query(from(item in query, where: field(item, ^:id) in ^ids), rest)
+
+  defp filter_query(query, [{:preload, preloads} | rest]),
+    do: filter_query(preload(query, ^preloads), rest)
+
+  defp filter_query(query, [_ | rest]), do: filter_query(query, rest)
+  defp filter_query(query, []), do: query
+
+  defp normalize_tool_execution_result(nil), do: {:error, :not_found}
+
+  defp normalize_tool_execution_result(%ToolExecution{} = tool_execution),
+    do: {:ok, tool_execution}
+end

--- a/lib/lemmings_os/model_runtime.ex
+++ b/lib/lemmings_os/model_runtime.ex
@@ -14,8 +14,10 @@ defmodule LemmingsOs.ModelRuntime do
   Return JSON only with this shape:
 
   {"action":"reply","reply":"visible user-facing text"}
+  or
+  {"action":"tool_call","tool_name":"fs.read_text_file","args":{"path":"notes.txt"}}
 
-  Only the "reply" action is supported in v1.
+  Only "reply" and "tool_call" actions are supported in this MVP.
   """
 
   @runtime_rules """
@@ -68,10 +70,13 @@ defmodule LemmingsOs.ModelRuntime do
        when is_map(provider_response) do
     with {:ok, content} <- provider_content(provider_response),
          {:ok, parsed} <- Jason.decode(content),
-         {:ok, reply} <- parse_structured_output(parsed) do
+         {:ok, action_payload} <- parse_structured_output(parsed) do
       {:ok,
        Response.new(
-         reply: reply,
+         action: action_payload.action,
+         reply: action_payload.reply,
+         tool_name: action_payload.tool_name,
+         tool_args: action_payload.tool_args,
          provider: provider_label(provider_response),
          model: response_field(provider_response, :model) || requested_model,
          input_tokens: response_field(provider_response, :input_tokens),
@@ -94,11 +99,27 @@ defmodule LemmingsOs.ModelRuntime do
     if Helpers.blank?(reply) do
       {:error, :invalid_structured_output}
     else
-      {:ok, reply}
+      {:ok, %{action: :reply, reply: reply, tool_name: nil, tool_args: nil}}
     end
   end
 
   defp parse_structured_output(%{"action" => "reply"}), do: {:error, :invalid_structured_output}
+
+  defp parse_structured_output(%{
+         "action" => "tool_call",
+         "tool_name" => tool_name,
+         "args" => args
+       })
+       when is_binary(tool_name) and is_map(args) do
+    if Helpers.blank?(tool_name) do
+      {:error, :invalid_structured_output}
+    else
+      {:ok, %{action: :tool_call, reply: nil, tool_name: tool_name, tool_args: args}}
+    end
+  end
+
+  defp parse_structured_output(%{"action" => "tool_call"}),
+    do: {:error, :invalid_structured_output}
 
   defp parse_structured_output(%{"action" => action}) when is_binary(action),
     do: {:error, :unknown_action}

--- a/lib/lemmings_os/model_runtime.ex
+++ b/lib/lemmings_os/model_runtime.ex
@@ -9,6 +9,7 @@ defmodule LemmingsOs.ModelRuntime do
   alias LemmingsOs.LemmingInstances.ConfigSnapshot
   alias LemmingsOs.ModelRuntime.Providers.Ollama
   alias LemmingsOs.ModelRuntime.Response
+  alias LemmingsOs.Tools.Catalog
 
   @structured_output_contract """
   Return JSON only with this shape:
@@ -16,8 +17,6 @@ defmodule LemmingsOs.ModelRuntime do
   {"action":"reply","reply":"visible user-facing text"}
   or
   {"action":"tool_call","tool_name":"fs.read_text_file","args":{"path":"notes.txt"}}
-
-  Only "reply" and "tool_call" actions are supported in this MVP.
   """
 
   @runtime_rules """
@@ -58,6 +57,26 @@ defmodule LemmingsOs.ModelRuntime do
 
   def run(_config_snapshot, _history, _current_request), do: {:error, :invalid_request}
 
+  @doc """
+  Builds the exact provider request payload that would be sent to the model.
+
+  This is intended for operator/debug surfaces that need to inspect the
+  assembled system prompt, normalized history, and current request before the
+  provider call happens.
+  """
+  @spec debug_request(map(), [map()], map() | String.t()) ::
+          {:ok, %{provider: String.t() | nil, model: String.t(), request: map()}}
+          | {:error, term()}
+  def debug_request(config_snapshot, history, current_request)
+      when is_map(config_snapshot) and is_list(history) do
+    with {:ok, model} <- resolve_model(config_snapshot),
+         {:ok, request} <- build_request(config_snapshot, history, current_request, model) do
+      {:ok, %{provider: provider_hint_label(config_snapshot), model: model, request: request}}
+    end
+  end
+
+  def debug_request(_config_snapshot, _history, _current_request), do: {:error, :invalid_request}
+
   @doc false
   @spec structured_output_contract() :: String.t()
   def structured_output_contract, do: @structured_output_contract
@@ -86,8 +105,11 @@ defmodule LemmingsOs.ModelRuntime do
          raw: response_field(provider_response, :raw) || provider_response
        )}
     else
-      {:error, :unknown_action} -> {:error, :unknown_action}
-      {:error, _reason} -> {:error, :invalid_structured_output}
+      {:error, :unknown_action} ->
+        {:error, unknown_action_error(provider_response, requested_model)}
+
+      {:error, reason} ->
+        {:error, invalid_structured_output_error(provider_response, requested_model, reason)}
     end
   end
 
@@ -136,11 +158,33 @@ defmodule LemmingsOs.ModelRuntime do
     end
   end
 
+  defp invalid_structured_output_error(provider_response, requested_model, reason) do
+    {:invalid_structured_output,
+     %{
+       reason: inspect(reason),
+       provider: provider_label(provider_response),
+       model: response_field(provider_response, :model) || requested_model,
+       content: response_field(provider_response, :content),
+       raw: response_field(provider_response, :raw) || provider_response
+     }}
+  end
+
+  defp unknown_action_error(provider_response, requested_model) do
+    {:unknown_action,
+     %{
+       provider: provider_label(provider_response),
+       model: response_field(provider_response, :model) || requested_model,
+       content: response_field(provider_response, :content),
+       raw: response_field(provider_response, :raw) || provider_response
+     }}
+  end
+
   defp build_request(config_snapshot, history, current_request, model) do
     with {:ok, current_message} <- normalize_current_message(current_request) do
       messages =
         config_snapshot
         |> build_messages(history, current_message)
+        |> Enum.map(&provider_message/1)
 
       {:ok, %{model: model, messages: messages, format: "json"}}
     end
@@ -151,46 +195,216 @@ defmodule LemmingsOs.ModelRuntime do
     normalized_history = normalize_history(history)
 
     messages =
-      case List.last(normalized_history) do
-        ^current_message -> normalized_history
-        _ -> normalized_history ++ [current_message]
+      if current_message_in_history?(normalized_history, current_message) do
+        normalized_history
+      else
+        normalized_history ++ [current_message]
       end
 
     [system_message | messages]
   end
 
+  defp current_message_in_history?(history, %{request_id: request_id})
+       when is_binary(request_id) and request_id != "" do
+    Enum.any?(history, &(&1.request_id == request_id))
+  end
+
+  defp current_message_in_history?(history, current_message) do
+    List.last(history) == current_message
+  end
+
   defp system_message(config_snapshot) do
     [
-      instructions_from_snapshot(config_snapshot),
-      @structured_output_contract,
-      @runtime_rules
+      platform_runtime_context(),
+      configured_identity_message(config_snapshot),
+      available_tools_message(config_snapshot),
+      loop_state_semantics_message(),
+      @runtime_rules,
+      immediate_response_instruction(),
+      important_output_contract()
     ]
     |> Enum.reject(&Helpers.blank?/1)
     |> Enum.join("\n\n")
   end
 
+  defp platform_runtime_context do
+    """
+    Platform Runtime Context:
+    - You are running as a Lemming agent inside a multi-agent application runtime.
+    - Your administrator configures your identity, purpose, and expertise.
+    - The runtime adds tool availability, execution rules, and loop-state context.
+    - On each turn, choose exactly one next action: either return a final user-facing reply or request one tool call.
+    - When a tool call is returned, the app executes it and sends the result back in later assistant-context messages.
+    - If the latest tool result already satisfies the request, return a final reply instead of repeating the same successful tool call.
+    """
+  end
+
+  defp configured_identity_message(config_snapshot) do
+    identity_lines =
+      [
+        configured_identity_name(config_snapshot),
+        configured_identity_description(config_snapshot),
+        configured_identity_instructions(config_snapshot)
+      ]
+      |> Enum.reject(&Helpers.blank?/1)
+
+    case identity_lines do
+      [] ->
+        nil
+
+      lines ->
+        Enum.join(["Configured Lemming Identity:" | lines], "\n")
+    end
+  end
+
+  defp configured_identity_name(config_snapshot) do
+    case response_field(config_snapshot, :name) do
+      name when is_binary(name) and name != "" -> "Name: #{name}"
+      _name -> nil
+    end
+  end
+
+  defp configured_identity_description(config_snapshot) do
+    case response_field(config_snapshot, :description) do
+      description when is_binary(description) and description != "" ->
+        "Description: #{description}"
+
+      _description ->
+        nil
+    end
+  end
+
+  defp configured_identity_instructions(config_snapshot) do
+    case instructions_from_snapshot(config_snapshot) do
+      instructions when is_binary(instructions) and instructions != "" ->
+        "Instructions:\n#{instructions}"
+
+      _instructions ->
+        nil
+    end
+  end
+
+  defp available_tools_message(config_snapshot) do
+    tool_lines =
+      config_snapshot
+      |> available_tools()
+      |> Enum.map_join("\n", fn tool ->
+        "- #{tool.id}: #{tool.description}"
+      end)
+
+    [
+      "Available Tools:",
+      tool_lines,
+      "For file creation or file updates, use fs.write_text_file.",
+      "After a successful tool call, prefer returning a final reply instead of repeating the same tool call with the same arguments."
+    ]
+    |> Enum.join("\n")
+  end
+
+  defp loop_state_semantics_message do
+    """
+    Loop State Semantics:
+    - Prior assistant tool decisions appear in assistant-context messages.
+    - `Assistant requested tool <tool_name> with arguments: <json>` means you already chose that tool on a prior turn.
+    - `Tool result for <tool_name>: status=<status> payload=<json>` means the runtime executed your prior tool request and is returning the outcome to you now.
+    - Treat those assistant-context messages as prior execution history, not as new user requests.
+    - Use the configured identity, the original user request, and the latest tool result to decide the next action.
+    """
+  end
+
+  defp immediate_response_instruction do
+    """
+    Immediate Response Instruction:
+    - Read the conversation messages below and decide the next action now.
+    - If the latest tool result already satisfies the user request, return a final `reply`.
+    - If another tool action is still required, return one `tool_call`.
+    - Do not explain your reasoning.
+    - Do not add any text before or after the JSON object.
+    - Return exactly one JSON object matching the output contract below.
+    """
+  end
+
+  defp important_output_contract do
+    """
+    IMPORTANT: RESPOND WITH JSON ONLY.
+
+    Decide what to do next by returning exactly one of these two JSON shapes:
+
+    {"action":"reply","reply":"visible user-facing text"}
+    or
+    {"action":"tool_call","tool_name":"fs.read_text_file","args":{"path":"notes.txt"}}
+
+    Option A: final reply to the user.
+    Option B: one tool call for the runtime to execute.
+    """
+  end
+
+  defp available_tools(config_snapshot) do
+    catalog_tools = Catalog.list_tools()
+    allowed_tools = tools_config_list(config_snapshot, :allowed_tools)
+    denied_tools = MapSet.new(tools_config_list(config_snapshot, :denied_tools))
+
+    catalog_tools
+    |> maybe_filter_allowed_tools(allowed_tools)
+    |> Enum.reject(&MapSet.member?(denied_tools, &1.id))
+  end
+
+  defp maybe_filter_allowed_tools(tool_names, []), do: tool_names
+
+  defp maybe_filter_allowed_tools(tools, allowed_tools) do
+    Enum.filter(tools, &(&1.id in allowed_tools))
+  end
+
+  defp tools_config_list(config_snapshot, field) do
+    config_snapshot
+    |> tools_config_value(field)
+    |> normalize_tool_name_list()
+  end
+
+  defp tools_config_value(config_snapshot, field) do
+    config_snapshot
+    |> response_field(:tools_config)
+    |> case do
+      tools_config when is_map(tools_config) -> response_field(tools_config, field)
+      _tools_config -> nil
+    end
+  end
+
+  defp normalize_tool_name_list(tool_names) when is_list(tool_names) do
+    Enum.filter(tool_names, &is_binary/1)
+  end
+
+  defp normalize_tool_name_list(_tool_names), do: []
+
   defp normalize_history(history) do
     history
     |> Enum.flat_map(fn
-      %{role: role, content: content} when is_binary(content) ->
-        maybe_message(role, content)
+      %{role: role, content: content} = message when is_binary(content) ->
+        maybe_message(role, content, message)
 
-      %{"role" => role, "content" => content} when is_binary(content) ->
-        maybe_message(role, content)
+      %{"role" => role, "content" => content} = message when is_binary(content) ->
+        maybe_message(role, content, message)
 
       _ ->
         []
     end)
   end
 
-  defp maybe_message("system", _content), do: []
-  defp maybe_message(:system, _content), do: []
+  defp maybe_message("system", _content, _message), do: []
+  defp maybe_message(:system, _content, _message), do: []
 
-  defp maybe_message(role, content) when role in ["user", "assistant", :user, :assistant] do
-    [%{role: normalize_role(role), content: content}]
+  defp maybe_message(role, content, message)
+       when role in ["user", "assistant", :user, :assistant] do
+    [
+      %{
+        role: normalize_role(role),
+        content: content,
+        request_id: request_id(message)
+      }
+    ]
   end
 
-  defp maybe_message(_role, _content), do: []
+  defp maybe_message(_role, _content, _message), do: []
 
   defp normalize_role(role) when role in [:user, "user"], do: "user"
   defp normalize_role(role) when role in [:assistant, "assistant"], do: "assistant"
@@ -198,22 +412,30 @@ defmodule LemmingsOs.ModelRuntime do
   defp normalize_current_message(%{content: nil}), do: {:error, :invalid_request}
   defp normalize_current_message(%{content: ""}), do: {:error, :invalid_request}
 
-  defp normalize_current_message(%{content: content}) when is_binary(content),
-    do: {:ok, %{role: "user", content: content}}
+  defp normalize_current_message(%{content: content} = message) when is_binary(content),
+    do: {:ok, %{role: "user", content: content, request_id: request_id(message)}}
 
   defp normalize_current_message(%{"content" => nil}), do: {:error, :invalid_request}
   defp normalize_current_message(%{"content" => ""}), do: {:error, :invalid_request}
 
-  defp normalize_current_message(%{"content" => content}) when is_binary(content),
-    do: {:ok, %{role: "user", content: content}}
+  defp normalize_current_message(%{"content" => content} = message) when is_binary(content),
+    do: {:ok, %{role: "user", content: content, request_id: request_id(message)}}
 
   defp normalize_current_message(nil), do: {:error, :invalid_request}
   defp normalize_current_message(""), do: {:error, :invalid_request}
 
   defp normalize_current_message(content) when is_binary(content),
-    do: {:ok, %{role: "user", content: content}}
+    do: {:ok, %{role: "user", content: content, request_id: nil}}
 
   defp normalize_current_message(_other), do: {:error, :invalid_request}
+
+  defp provider_message(message), do: Map.take(message, [:role, :content])
+
+  defp request_id(%{request_id: request_id}) when is_binary(request_id), do: request_id
+  defp request_id(%{"request_id" => request_id}) when is_binary(request_id), do: request_id
+  defp request_id(%{id: id}) when is_binary(id), do: id
+  defp request_id(%{"id" => id}) when is_binary(id), do: id
+  defp request_id(_message), do: nil
 
   defp instructions_from_snapshot(config_snapshot) do
     response_field(config_snapshot, :instructions) ||
@@ -280,6 +502,14 @@ defmodule LemmingsOs.ModelRuntime do
 
   defp response_field(map, key) when is_map(map) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp provider_hint_label(config_snapshot) do
+    case provider_hint(config_snapshot) do
+      provider when is_atom(provider) -> Atom.to_string(provider)
+      provider when is_binary(provider) -> provider
+      _provider -> nil
+    end
   end
 
   defp nested_field(map, [key | rest]) when is_map(map) do

--- a/lib/lemmings_os/model_runtime/response.ex
+++ b/lib/lemmings_os/model_runtime/response.ex
@@ -3,9 +3,12 @@ defmodule LemmingsOs.ModelRuntime.Response do
   Validated model runtime response.
   """
 
-  @enforce_keys [:reply, :provider, :model, :raw]
+  @enforce_keys [:action, :provider, :model, :raw]
   defstruct [
+    :action,
     :reply,
+    :tool_name,
+    :tool_args,
     :provider,
     :model,
     :input_tokens,
@@ -16,7 +19,10 @@ defmodule LemmingsOs.ModelRuntime.Response do
   ]
 
   @type t :: %__MODULE__{
-          reply: String.t(),
+          action: :reply | :tool_call,
+          reply: String.t() | nil,
+          tool_name: String.t() | nil,
+          tool_args: map() | nil,
           provider: String.t(),
           model: String.t() | nil,
           input_tokens: integer() | nil,
@@ -32,6 +38,7 @@ defmodule LemmingsOs.ModelRuntime.Response do
   ## Examples
 
       iex> response = LemmingsOs.ModelRuntime.Response.new(
+      ...>   action: :reply,
       ...>   reply: "hello",
       ...>   provider: "ollama",
       ...>   model: "llama3.2",

--- a/lib/lemmings_os/runtime/status.ex
+++ b/lib/lemmings_os/runtime/status.ex
@@ -10,6 +10,7 @@ defmodule LemmingsOs.Runtime.Status do
   alias LemmingsOs.LemmingInstances.EtsStore
   alias LemmingsOs.LemmingInstances.Executor
   alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.LemmingInstances.ToolExecution
   alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.LemmingInstances.ResourcePool
   alias LemmingsOs.Repo
@@ -61,13 +62,18 @@ defmodule LemmingsOs.Runtime.Status do
       |> latest_first()
       |> maybe_take(recent_limit)
 
+    tool_executions =
+      recent_tool_executions(recent_limit)
+      |> attach_tool_execution_labels(labels.instance_labels)
+
     %{
       overview: overview,
       services: service_rows(overview.services),
       executors: executors,
       schedulers: schedulers,
       pools: pools,
-      runtime_entries: runtime_entries
+      runtime_entries: runtime_entries,
+      tool_executions: tool_executions
     }
   end
 
@@ -294,6 +300,19 @@ defmodule LemmingsOs.Runtime.Status do
     end)
   end
 
+  defp attach_tool_execution_labels(tool_executions, instance_labels) do
+    Enum.map(tool_executions, fn tool_execution ->
+      labels = Map.get(instance_labels, tool_execution.instance_id, %{})
+
+      tool_execution
+      |> Map.put(:display_label, Map.get(labels, :display_label, tool_execution.instance_id))
+      |> Map.put(
+        :department_label,
+        Map.get(labels, :department_label, tool_execution.department_id)
+      )
+    end)
+  end
+
   defp runtime_labels(executors, runtime_entries) do
     instance_ids =
       executors
@@ -418,6 +437,39 @@ defmodule LemmingsOs.Runtime.Status do
   defp latest_sort_value(%{last_activity_at: %DateTime{} = value}), do: value
   defp latest_sort_value(%{started_at: %DateTime{} = value}), do: value
   defp latest_sort_value(_entry), do: ~U[1970-01-01 00:00:00Z]
+
+  defp recent_tool_executions(limit) do
+    query =
+      ToolExecution
+      |> join(:inner, [tool_execution], instance in LemmingInstance,
+        on: tool_execution.lemming_instance_id == instance.id
+      )
+      |> order_by([tool_execution, _instance], desc: tool_execution.inserted_at)
+      |> order_by([tool_execution, _instance], desc: tool_execution.id)
+      |> maybe_limit_tool_execution_query(limit)
+      |> select([tool_execution, instance], %{
+        id: tool_execution.id,
+        instance_id: tool_execution.lemming_instance_id,
+        department_id: instance.department_id,
+        tool_name: tool_execution.tool_name,
+        status: tool_execution.status,
+        summary: tool_execution.summary,
+        duration_ms: tool_execution.duration_ms,
+        started_at: tool_execution.started_at,
+        completed_at: tool_execution.completed_at,
+        inserted_at: tool_execution.inserted_at
+      })
+
+    Repo.all(query)
+  rescue
+    _ -> []
+  end
+
+  defp maybe_limit_tool_execution_query(query, limit) when is_integer(limit) and limit >= 0 do
+    limit(query, ^limit)
+  end
+
+  defp maybe_limit_tool_execution_query(query, _limit), do: query
 
   defp maybe_take(entries, limit) when is_integer(limit) and limit >= 0,
     do: Enum.take(entries, limit)

--- a/lib/lemmings_os/tools/adapters/filesystem.ex
+++ b/lib/lemmings_os/tools/adapters/filesystem.ex
@@ -33,15 +33,23 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
           {:ok, success_result()} | {:error, error_result()}
   def read_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
     with {:ok, relative_path} <- validate_read_args(args),
-         {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}} <-
+         {:ok,
+          %{
+            absolute_path: absolute_path,
+            relative_path: normalized_relative_path,
+            root_path: root_path,
+            workspace_path: workspace_path
+          }} <-
            resolve_workspace_path(instance, relative_path),
          {:ok, content} <- read_utf8_file(absolute_path) do
       {:ok,
        %{
-         summary: "Read file #{workspace_path}",
+         summary: "Read file #{normalized_relative_path}",
          preview: String.slice(content, 0, 280),
          result: %{
-           path: workspace_path,
+           path: normalized_relative_path,
+           root_path: root_path,
+           workspace_path: workspace_path,
            content: content,
            bytes: byte_size(content)
          }
@@ -61,23 +69,32 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
       iex> LemmingsOs.Tools.Adapters.Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
       {:ok,
       %{result: %{bytes: 5,
-  path: "/workspace/department-1/lemming-1/notes.txt"},
-  summary: "Wrote file /workspace/department-1/lemming-1/notes.txt", preview: "hello"}}
+  path: "notes.txt", root_path: "/workspace/department-1/lemming-1",
+  workspace_path: "/workspace/department-1/lemming-1/notes.txt"},
+  summary: "Wrote file notes.txt", preview: "hello"}}
   """
   @spec write_text_file(LemmingInstance.t(), map()) ::
           {:ok, success_result()} | {:error, error_result()}
   def write_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
     with {:ok, {relative_path, content}} <- validate_write_args(args),
-         {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}} <-
+         {:ok,
+          %{
+            absolute_path: absolute_path,
+            relative_path: normalized_relative_path,
+            root_path: root_path,
+            workspace_path: workspace_path
+          }} <-
            resolve_workspace_path(instance, relative_path),
          :ok <- ensure_parent_directory(absolute_path),
          :ok <- write_utf8_file(absolute_path, content) do
       {:ok,
        %{
-         summary: "Wrote file #{workspace_path}",
+         summary: "Wrote file #{normalized_relative_path}",
          preview: String.slice(content, 0, 280),
          result: %{
-           path: workspace_path,
+           path: normalized_relative_path,
+           root_path: root_path,
+           workspace_path: workspace_path,
            bytes: byte_size(content)
          }
        }}
@@ -124,15 +141,17 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
       absolute_path = Path.expand(relative_path, work_area_root)
 
       if path_within_root?(absolute_path, work_area_root) do
-        workspace_path =
-          Path.join([
-            "/workspace",
-            department_id,
-            lemming_id,
-            Path.relative_to(absolute_path, work_area_root)
-          ])
+        root_path = Path.join(["/workspace", department_id, lemming_id])
+        normalized_relative_path = Path.relative_to(absolute_path, work_area_root)
+        workspace_path = Path.join([root_path, normalized_relative_path])
 
-        {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}}
+        {:ok,
+         %{
+           absolute_path: absolute_path,
+           relative_path: normalized_relative_path,
+           root_path: root_path,
+           workspace_path: workspace_path
+         }}
       else
         {:error,
          %{

--- a/lib/lemmings_os/tools/adapters/filesystem.ex
+++ b/lib/lemmings_os/tools/adapters/filesystem.ex
@@ -136,30 +136,7 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
        )
        when is_binary(department_id) and is_binary(lemming_id) and is_binary(relative_path) do
     with :ok <- validate_relative_path(relative_path) do
-      workspace_root = workspace_root()
-      work_area_root = Path.join([workspace_root, department_id, lemming_id])
-      absolute_path = Path.expand(relative_path, work_area_root)
-
-      if path_within_root?(absolute_path, work_area_root) do
-        root_path = Path.join(["/workspace", department_id, lemming_id])
-        normalized_relative_path = Path.relative_to(absolute_path, work_area_root)
-        workspace_path = Path.join([root_path, normalized_relative_path])
-
-        {:ok,
-         %{
-           absolute_path: absolute_path,
-           relative_path: normalized_relative_path,
-           root_path: root_path,
-           workspace_path: workspace_path
-         }}
-      else
-        {:error,
-         %{
-           code: "tool.fs.path_outside_workspace",
-           message: "Path escapes workspace boundary",
-           details: %{path: relative_path}
-         }}
-      end
+      resolve_valid_workspace_path(department_id, lemming_id, relative_path)
     end
   end
 
@@ -195,6 +172,43 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
     end
   end
 
+  defp resolve_valid_workspace_path(department_id, lemming_id, relative_path) do
+    workspace_root = workspace_root() |> Path.expand()
+    work_area_root = Path.join([workspace_root, department_id, lemming_id])
+    absolute_path = Path.expand(relative_path, work_area_root)
+
+    if path_within_root?(absolute_path, work_area_root) do
+      build_workspace_path_info(work_area_root, absolute_path, department_id, lemming_id)
+    else
+      path_outside_workspace_error(relative_path)
+    end
+  end
+
+  defp build_workspace_path_info(work_area_root, absolute_path, department_id, lemming_id) do
+    root_path = Path.join(["/workspace", department_id, lemming_id])
+    normalized_relative_path = Path.relative_to(absolute_path, work_area_root)
+    workspace_path = Path.join([root_path, normalized_relative_path])
+
+    with :ok <- validate_no_symlink_components(work_area_root, normalized_relative_path) do
+      {:ok,
+       %{
+         absolute_path: absolute_path,
+         relative_path: normalized_relative_path,
+         root_path: root_path,
+         workspace_path: workspace_path
+       }}
+    end
+  end
+
+  defp path_outside_workspace_error(relative_path) do
+    {:error,
+     %{
+       code: "tool.fs.path_outside_workspace",
+       message: "Path escapes workspace boundary",
+       details: %{path: relative_path}
+     }}
+  end
+
   defp path_within_root?(absolute_path, root_path)
        when is_binary(absolute_path) and is_binary(root_path) do
     normalized_absolute = Path.expand(absolute_path)
@@ -202,6 +216,38 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
 
     normalized_absolute == normalized_root or
       String.starts_with?(normalized_absolute, normalized_root <> "/")
+  end
+
+  defp validate_no_symlink_components(root_path, relative_path)
+       when is_binary(root_path) and is_binary(relative_path) do
+    root_path
+    |> Path.expand()
+    |> validate_no_symlink_components(Path.split(relative_path), relative_path)
+  end
+
+  defp validate_no_symlink_components(_current_path, [], _relative_path), do: :ok
+
+  defp validate_no_symlink_components(current_path, [segment | rest], relative_path) do
+    next_path = Path.join(current_path, segment)
+
+    case File.lstat(next_path) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        {:error,
+         %{
+           code: "tool.fs.path_outside_workspace",
+           message: "Path escapes workspace boundary",
+           details: %{path: relative_path}
+         }}
+
+      {:ok, _stat} ->
+        validate_no_symlink_components(next_path, rest, relative_path)
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
   end
 
   defp read_utf8_file(path) when is_binary(path) do

--- a/lib/lemmings_os/tools/adapters/filesystem.ex
+++ b/lib/lemmings_os/tools/adapters/filesystem.ex
@@ -1,0 +1,251 @@
+defmodule LemmingsOs.Tools.Adapters.Filesystem do
+  @moduledoc """
+  Filesystem adapters for Tool Runtime MVP.
+  """
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+
+  @type success_result :: %{
+          summary: String.t(),
+          preview: String.t() | nil,
+          result: map()
+        }
+
+  @type error_result :: %{
+          code: String.t(),
+          message: String.t(),
+          details: map()
+        }
+
+  @doc """
+  Executes the `fs.read_text_file` adapter.
+
+  ## Examples
+
+      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{
+      ...>   department_id: "department-1",
+      ...>   lemming_id: "lemming-1"
+      ...> }
+      iex> LemmingsOs.Tools.Adapters.Filesystem.read_text_file(instance, %{"path" => "notes.txt"})
+      {:error, %{code: "tool.fs.not_found", details: %{path: "notes.txt"}, message: "File not found"}}
+  """
+  @spec read_text_file(LemmingInstance.t(), map()) ::
+          {:ok, success_result()} | {:error, error_result()}
+  def read_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
+    with {:ok, relative_path} <- validate_read_args(args),
+         {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}} <-
+           resolve_workspace_path(instance, relative_path),
+         {:ok, content} <- read_utf8_file(absolute_path) do
+      {:ok,
+       %{
+         summary: "Read file #{workspace_path}",
+         preview: String.slice(content, 0, 280),
+         result: %{
+           path: workspace_path,
+           content: content,
+           bytes: byte_size(content)
+         }
+       }}
+    end
+  end
+
+  @doc """
+  Executes the `fs.write_text_file` adapter.
+
+  ## Examples
+
+      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{
+      ...>   department_id: "department-1",
+      ...>   lemming_id: "lemming-1"
+      ...> }
+      iex> LemmingsOs.Tools.Adapters.Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
+      {:ok,
+      %{result: %{bytes: 5,
+  path: "/workspace/department-1/lemming-1/notes.txt"},
+  summary: "Wrote file /workspace/department-1/lemming-1/notes.txt", preview: "hello"}}
+  """
+  @spec write_text_file(LemmingInstance.t(), map()) ::
+          {:ok, success_result()} | {:error, error_result()}
+  def write_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
+    with {:ok, {relative_path, content}} <- validate_write_args(args),
+         {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}} <-
+           resolve_workspace_path(instance, relative_path),
+         :ok <- ensure_parent_directory(absolute_path),
+         :ok <- write_utf8_file(absolute_path, content) do
+      {:ok,
+       %{
+         summary: "Wrote file #{workspace_path}",
+         preview: String.slice(content, 0, 280),
+         result: %{
+           path: workspace_path,
+           bytes: byte_size(content)
+         }
+       }}
+    end
+  end
+
+  defp validate_read_args(%{"path" => path}) when is_binary(path), do: {:ok, path}
+  defp validate_read_args(%{path: path}) when is_binary(path), do: {:ok, path}
+
+  defp validate_read_args(_args) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_args",
+       message: "Invalid tool arguments",
+       details: %{required: ["path"]}
+     }}
+  end
+
+  defp validate_write_args(%{"path" => path, "content" => content})
+       when is_binary(path) and is_binary(content),
+       do: {:ok, {path, content}}
+
+  defp validate_write_args(%{path: path, content: content})
+       when is_binary(path) and is_binary(content),
+       do: {:ok, {path, content}}
+
+  defp validate_write_args(_args) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_args",
+       message: "Invalid tool arguments",
+       details: %{required: ["path", "content"]}
+     }}
+  end
+
+  defp resolve_workspace_path(
+         %LemmingInstance{department_id: department_id, lemming_id: lemming_id},
+         relative_path
+       )
+       when is_binary(department_id) and is_binary(lemming_id) and is_binary(relative_path) do
+    with :ok <- validate_relative_path(relative_path) do
+      workspace_root = workspace_root()
+      work_area_root = Path.join([workspace_root, department_id, lemming_id])
+      absolute_path = Path.expand(relative_path, work_area_root)
+
+      if path_within_root?(absolute_path, work_area_root) do
+        workspace_path =
+          Path.join([
+            "/workspace",
+            department_id,
+            lemming_id,
+            Path.relative_to(absolute_path, work_area_root)
+          ])
+
+        {:ok, %{absolute_path: absolute_path, workspace_path: workspace_path}}
+      else
+        {:error,
+         %{
+           code: "tool.fs.path_outside_workspace",
+           message: "Path escapes workspace boundary",
+           details: %{path: relative_path}
+         }}
+      end
+    end
+  end
+
+  defp resolve_workspace_path(_instance, _relative_path) do
+    {:error,
+     %{
+       code: "tool.fs.invalid_instance_scope",
+       message: "Instance scope is incomplete",
+       details: %{}
+     }}
+  end
+
+  defp validate_relative_path(path) when is_binary(path) do
+    cond do
+      path == "" ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{field: "path"}
+         }}
+
+      Path.type(path) == :absolute ->
+        {:error,
+         %{
+           code: "tool.fs.path_must_be_relative",
+           message: "Path must be workspace-relative",
+           details: %{path: path}
+         }}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp path_within_root?(absolute_path, root_path)
+       when is_binary(absolute_path) and is_binary(root_path) do
+    normalized_absolute = Path.expand(absolute_path)
+    normalized_root = Path.expand(root_path)
+
+    normalized_absolute == normalized_root or
+      String.starts_with?(normalized_absolute, normalized_root <> "/")
+  end
+
+  defp read_utf8_file(path) when is_binary(path) do
+    case File.read(path) do
+      {:ok, content} when is_binary(content) ->
+        {:ok, content}
+
+      {:error, :enoent} ->
+        {:error,
+         %{
+           code: "tool.fs.not_found",
+           message: "File not found",
+           details: %{path: Path.basename(path)}
+         }}
+
+      {:error, reason} ->
+        {:error,
+         %{
+           code: "tool.fs.read_failed",
+           message: "Could not read file",
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp ensure_parent_directory(path) when is_binary(path) do
+    path
+    |> Path.dirname()
+    |> File.mkdir_p()
+    |> case do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error,
+         %{
+           code: "tool.fs.write_failed",
+           message: "Could not prepare target directory",
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp write_utf8_file(path, content) when is_binary(path) and is_binary(content) do
+    case File.write(path, content) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        {:error,
+         %{
+           code: "tool.fs.write_failed",
+           message: "Could not write file",
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp workspace_root do
+    Application.get_env(
+      :lemmings_os,
+      :runtime_workspace_root,
+      Path.expand("../../../priv/runtime/workspace", __DIR__)
+    )
+  end
+end

--- a/lib/lemmings_os/tools/adapters/web.ex
+++ b/lib/lemmings_os/tools/adapters/web.ex
@@ -93,9 +93,9 @@ defmodule LemmingsOs.Tools.Adapters.Web do
 
   defp validate_http_url(url) when is_binary(url) do
     case URI.parse(url) do
-      %URI{scheme: scheme, host: host} = _uri
+      %URI{scheme: scheme, host: host} = uri
       when scheme in ["http", "https"] and is_binary(host) ->
-        {:ok, url}
+        validate_egress_url(uri, url)
 
       _uri ->
         {:error,
@@ -108,32 +108,38 @@ defmodule LemmingsOs.Tools.Adapters.Web do
   end
 
   defp request_search(query) when is_binary(query) do
-    req_options = [url: search_endpoint(), params: [q: query, format: "json", no_html: 1]]
+    endpoint = search_endpoint()
 
-    case Req.get(req_options) do
-      {:ok, %Req.Response{} = response} when response.status in 200..299 ->
-        {:ok, response.body}
+    with :ok <- validate_endpoint_egress(endpoint) do
+      req_options =
+        [url: endpoint, params: [q: query, format: "json", no_html: 1]]
+        |> Keyword.merge(req_timeout_options())
 
-      {:ok, %Req.Response{} = response} ->
-        {:error,
-         %{
-           code: "tool.web.bad_status",
-           message: "Web search returned a non-success status",
-           details: %{status: response.status}
-         }}
+      case Req.get(req_options) do
+        {:ok, %Req.Response{} = response} when response.status in 200..299 ->
+          {:ok, response.body}
 
-      {:error, reason} ->
-        {:error,
-         %{
-           code: "tool.web.request_failed",
-           message: "Web search request failed",
-           details: %{reason: inspect(reason)}
-         }}
+        {:ok, %Req.Response{} = response} ->
+          {:error,
+           %{
+             code: "tool.web.bad_status",
+             message: "Web search returned a non-success status",
+             details: %{status: response.status}
+           }}
+
+        {:error, reason} ->
+          {:error,
+           %{
+             code: "tool.web.request_failed",
+             message: "Web search request failed",
+             details: %{reason: inspect(reason)}
+           }}
+      end
     end
   end
 
   defp request_fetch(url) when is_binary(url) do
-    case Req.get(url: url) do
+    case Req.get(Keyword.merge([url: url], req_timeout_options())) do
       {:ok, %Req.Response{} = response} when response.status in 200..299 ->
         {:ok, response}
 
@@ -153,6 +159,89 @@ defmodule LemmingsOs.Tools.Adapters.Web do
            details: %{reason: inspect(reason)}
          }}
     end
+  end
+
+  defp validate_endpoint_egress(endpoint) when is_binary(endpoint) do
+    case URI.parse(endpoint) do
+      %URI{scheme: scheme, host: host} = uri
+      when scheme in ["http", "https"] and is_binary(host) ->
+        uri
+        |> validate_egress_url(endpoint)
+        |> case do
+          {:ok, _url} -> :ok
+          {:error, reason} -> {:error, reason}
+        end
+
+      _uri ->
+        {:error,
+         %{
+           code: "tool.web.invalid_url",
+           message: "Invalid URL",
+           details: %{url: endpoint}
+         }}
+    end
+  end
+
+  defp validate_egress_url(%URI{host: host}, url) when is_binary(host) and is_binary(url) do
+    if private_host_allowed?() or public_host?(host) do
+      {:ok, url}
+    else
+      {:error,
+       %{
+         code: "tool.web.egress_blocked",
+         message: "URL host is blocked by web egress policy",
+         details: %{host: host}
+       }}
+    end
+  end
+
+  defp public_host?(host) when is_binary(host) do
+    normalized_host = host |> String.trim("[]") |> String.downcase()
+
+    not localhost_name?(normalized_host) and
+      not private_ip_literal?(normalized_host)
+  end
+
+  defp localhost_name?("localhost"), do: true
+  defp localhost_name?(host), do: String.ends_with?(host, ".localhost")
+
+  defp private_ip_literal?(host) do
+    host
+    |> String.to_charlist()
+    |> :inet.parse_address()
+    |> case do
+      {:ok, address} -> private_ip?(address)
+      {:error, :einval} -> false
+    end
+  end
+
+  defp private_ip?({first, _second, _third, _fourth}) when first in [0, 10, 127], do: true
+  defp private_ip?({169, 254, _third, _fourth}), do: true
+  defp private_ip?({172, second, _third, _fourth}) when second in 16..31, do: true
+  defp private_ip?({192, 168, _third, _fourth}), do: true
+
+  defp private_ip?({first, _second, _third, _fourth})
+       when first >= 224,
+       do: true
+
+  defp private_ip?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp private_ip?({0, 0, 0, 0, 0, 0, 0, 0}), do: true
+  defp private_ip?({first, _b, _c, _d, _e, _f, _g, _h}) when first in 0xFC00..0xFDFF, do: true
+  defp private_ip?({first, _b, _c, _d, _e, _f, _g, _h}) when first in 0xFE80..0xFEBF, do: true
+  defp private_ip?(_address), do: false
+
+  defp private_host_allowed? do
+    Application.get_env(:lemmings_os, :tools_web_allow_private_hosts, false)
+  end
+
+  defp req_timeout_options do
+    timeout = Application.get_env(:lemmings_os, :tools_web_timeout_ms, 5_000)
+
+    [
+      retry: false,
+      receive_timeout: timeout,
+      connect_options: [timeout: timeout]
+    ]
   end
 
   defp extract_search_results(%{} = payload) do

--- a/lib/lemmings_os/tools/adapters/web.ex
+++ b/lib/lemmings_os/tools/adapters/web.ex
@@ -1,0 +1,196 @@
+defmodule LemmingsOs.Tools.Adapters.Web do
+  @moduledoc """
+  Web adapters for Tool Runtime MVP.
+  """
+
+  @type success_result :: %{
+          summary: String.t(),
+          preview: String.t() | nil,
+          result: map()
+        }
+
+  @type error_result :: %{
+          code: String.t(),
+          message: String.t(),
+          details: map()
+        }
+
+  @doc """
+  Executes the `web.search` adapter.
+
+  ## Examples
+
+      iex> LemmingsOs.Tools.Adapters.Web.search(%{"query" => "phoenix framework"})
+      {:error, %{code: "tool.web.request_failed", details: %{reason: _}, message: "Web search request failed"}}
+  """
+  @spec search(map()) :: {:ok, success_result()} | {:error, error_result()}
+  def search(args) when is_map(args) do
+    with {:ok, query} <- validate_search_args(args),
+         {:ok, payload} <- request_search(query),
+         {:ok, results} <- extract_search_results(payload) do
+      {:ok,
+       %{
+         summary: "Search completed with #{length(results)} result(s)",
+         preview: first_result_preview(results),
+         result: %{query: query, results: results}
+       }}
+    end
+  end
+
+  @doc """
+  Executes the `web.fetch` adapter.
+
+  ## Examples
+
+      iex> LemmingsOs.Tools.Adapters.Web.fetch(%{"url" => "invalid"})
+      {:error, %{code: "tool.web.invalid_url", details: %{url: "invalid"}, message: "Invalid URL"}}
+  """
+  @spec fetch(map()) :: {:ok, success_result()} | {:error, error_result()}
+  def fetch(args) when is_map(args) do
+    with {:ok, url} <- validate_fetch_args(args),
+         {:ok, response} <- request_fetch(url) do
+      body = to_string(response.body || "")
+
+      {:ok,
+       %{
+         summary: "Fetched #{url}",
+         preview: String.slice(body, 0, 280),
+         result: %{
+           url: url,
+           status: response.status,
+           body: body
+         }
+       }}
+    end
+  end
+
+  defp validate_search_args(%{"query" => query}) when is_binary(query) and byte_size(query) > 0,
+    do: {:ok, query}
+
+  defp validate_search_args(%{query: query}) when is_binary(query) and byte_size(query) > 0,
+    do: {:ok, query}
+
+  defp validate_search_args(_args) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_args",
+       message: "Invalid tool arguments",
+       details: %{required: ["query"]}
+     }}
+  end
+
+  defp validate_fetch_args(%{"url" => url}) when is_binary(url), do: validate_http_url(url)
+  defp validate_fetch_args(%{url: url}) when is_binary(url), do: validate_http_url(url)
+
+  defp validate_fetch_args(_args) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_args",
+       message: "Invalid tool arguments",
+       details: %{required: ["url"]}
+     }}
+  end
+
+  defp validate_http_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, host: host} = _uri
+      when scheme in ["http", "https"] and is_binary(host) ->
+        {:ok, url}
+
+      _uri ->
+        {:error,
+         %{
+           code: "tool.web.invalid_url",
+           message: "Invalid URL",
+           details: %{url: url}
+         }}
+    end
+  end
+
+  defp request_search(query) when is_binary(query) do
+    req_options = [url: search_endpoint(), params: [q: query, format: "json", no_html: 1]]
+
+    case Req.get(req_options) do
+      {:ok, %Req.Response{} = response} when response.status in 200..299 ->
+        {:ok, response.body}
+
+      {:ok, %Req.Response{} = response} ->
+        {:error,
+         %{
+           code: "tool.web.bad_status",
+           message: "Web search returned a non-success status",
+           details: %{status: response.status}
+         }}
+
+      {:error, reason} ->
+        {:error,
+         %{
+           code: "tool.web.request_failed",
+           message: "Web search request failed",
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp request_fetch(url) when is_binary(url) do
+    case Req.get(url: url) do
+      {:ok, %Req.Response{} = response} when response.status in 200..299 ->
+        {:ok, response}
+
+      {:ok, %Req.Response{} = response} ->
+        {:error,
+         %{
+           code: "tool.web.bad_status",
+           message: "Web fetch returned a non-success status",
+           details: %{status: response.status}
+         }}
+
+      {:error, reason} ->
+        {:error,
+         %{
+           code: "tool.web.request_failed",
+           message: "Web fetch request failed",
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp extract_search_results(%{} = payload) do
+    results =
+      payload
+      |> Map.get("RelatedTopics", [])
+      |> Enum.flat_map(&normalize_topic/1)
+      |> Enum.take(5)
+
+    {:ok, results}
+  end
+
+  defp extract_search_results(_payload) do
+    {:error,
+     %{
+       code: "tool.web.invalid_response",
+       message: "Web search response has invalid format",
+       details: %{}
+     }}
+  end
+
+  defp normalize_topic(%{"Text" => text, "FirstURL" => url})
+       when is_binary(text) and is_binary(url) do
+    [%{title: text, url: url, snippet: text}]
+  end
+
+  defp normalize_topic(%{"Topics" => topics}) when is_list(topics) do
+    Enum.flat_map(topics, &normalize_topic/1)
+  end
+
+  defp normalize_topic(_topic), do: []
+
+  defp first_result_preview([%{snippet: snippet} | _rest]) when is_binary(snippet),
+    do: String.slice(snippet, 0, 280)
+
+  defp first_result_preview(_results), do: nil
+
+  defp search_endpoint do
+    Application.get_env(:lemmings_os, :tools_web_search_endpoint, "https://api.duckduckgo.com/")
+  end
+end

--- a/lib/lemmings_os/tools/catalog.ex
+++ b/lib/lemmings_os/tools/catalog.ex
@@ -1,0 +1,82 @@
+defmodule LemmingsOs.Tools.Catalog do
+  @moduledoc """
+  Fixed Tool Runtime catalog for the MVP.
+
+  This catalog is intentionally limited to the four approved tools.
+  """
+
+  @tools [
+    %{
+      id: "fs.read_text_file",
+      name: "Read Text File",
+      description: "Read UTF-8 text files from the instance work area.",
+      icon: "hero-document-text",
+      category: "filesystem",
+      risk: "medium"
+    },
+    %{
+      id: "fs.write_text_file",
+      name: "Write Text File",
+      description: "Write UTF-8 text files inside the instance work area.",
+      icon: "hero-pencil-square",
+      category: "filesystem",
+      risk: "high"
+    },
+    %{
+      id: "web.search",
+      name: "Web Search",
+      description: "Search the web for short result snippets.",
+      icon: "hero-magnifying-glass",
+      category: "web",
+      risk: "medium"
+    },
+    %{
+      id: "web.fetch",
+      name: "Web Fetch",
+      description: "Fetch HTTP(S) content from a single URL.",
+      icon: "hero-globe-alt",
+      category: "web",
+      risk: "medium"
+    }
+  ]
+
+  @tool_ids MapSet.new(Enum.map(@tools, & &1.id))
+
+  @type tool :: %{
+          id: String.t(),
+          name: String.t(),
+          description: String.t(),
+          icon: String.t(),
+          category: String.t(),
+          risk: String.t()
+        }
+
+  @doc """
+  Returns the fixed catalog in a runtime-ready shape.
+
+  ## Examples
+
+      iex> tools = LemmingsOs.Tools.Catalog.list_tools()
+      iex> Enum.map(tools, & &1.id)
+      ["fs.read_text_file", "fs.write_text_file", "web.search", "web.fetch"]
+  """
+  @spec list_tools() :: [tool()]
+  def list_tools, do: @tools
+
+  @doc """
+  Returns true when `tool_name` belongs to the fixed catalog.
+
+  ## Examples
+
+      iex> LemmingsOs.Tools.Catalog.supported_tool?("web.fetch")
+      true
+      iex> LemmingsOs.Tools.Catalog.supported_tool?("exec.run")
+      false
+  """
+  @spec supported_tool?(String.t()) :: boolean()
+  def supported_tool?(tool_name) when is_binary(tool_name) do
+    MapSet.member?(@tool_ids, tool_name)
+  end
+
+  def supported_tool?(_tool_name), do: false
+end

--- a/lib/lemmings_os/tools/default_runtime_fetcher.ex
+++ b/lib/lemmings_os/tools/default_runtime_fetcher.ex
@@ -1,11 +1,12 @@
 defmodule LemmingsOs.Tools.DefaultRuntimeFetcher do
   @moduledoc """
-  Default runtime fetcher. Returns `{:error, :not_implemented}` until the
-  real runtime capability registry is implemented.
+  Default runtime fetcher backed by the fixed Tool Runtime MVP catalog.
   """
 
   @behaviour LemmingsOs.Tools.RuntimeFetcherBehaviour
 
+  alias LemmingsOs.Tools.Catalog
+
   @impl true
-  def fetch, do: {:error, :not_implemented}
+  def fetch, do: {:ok, Catalog.list_tools()}
 end

--- a/lib/lemmings_os/tools/runtime.ex
+++ b/lib/lemmings_os/tools/runtime.ex
@@ -1,0 +1,128 @@
+defmodule LemmingsOs.Tools.Runtime do
+  @moduledoc """
+  Tool Runtime execution boundary for the MVP catalog.
+  """
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Tools.Adapters.Filesystem
+  alias LemmingsOs.Tools.Adapters.Web
+  alias LemmingsOs.Tools.Catalog
+  alias LemmingsOs.Worlds.World
+
+  @type success :: %{
+          tool_name: String.t(),
+          args: map(),
+          summary: String.t(),
+          preview: String.t() | nil,
+          result: map()
+        }
+
+  @type error :: %{
+          tool_name: String.t() | nil,
+          code: String.t(),
+          message: String.t(),
+          details: map()
+        }
+
+  @doc """
+  Executes one tool call for a World-scoped runtime instance.
+
+  ## Examples
+
+      iex> world = %LemmingsOs.Worlds.World{id: "world-1"}
+      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{
+      ...>   world_id: "world-1",
+      ...>   department_id: "department-1",
+      ...>   lemming_id: "lemming-1"
+      ...> }
+      iex> LemmingsOs.Tools.Runtime.execute(world, instance, "exec.run", %{})
+      {:error, %{tool_name: "exec.run", code: "tool.unsupported",
+  details: %{tool_name: "exec.run"}, message: "Tool is not supported"}}
+  """
+  @spec execute(World.t(), LemmingInstance.t(), String.t(), map()) ::
+          {:ok, success()} | {:error, error()}
+  def execute(world, instance, tool_name, args)
+
+  def execute(
+        %World{id: world_id},
+        %LemmingInstance{world_id: world_id} = instance,
+        tool_name,
+        args
+      )
+      when is_binary(tool_name) and is_map(args) do
+    if Catalog.supported_tool?(tool_name) do
+      dispatch_tool_call(instance, tool_name, args)
+    else
+      {:error,
+       %{
+         tool_name: tool_name,
+         code: "tool.unsupported",
+         message: "Tool is not supported",
+         details: %{tool_name: tool_name}
+       }}
+    end
+  end
+
+  def execute(%World{}, %LemmingInstance{}, tool_name, _args) when is_binary(tool_name) do
+    {:error,
+     %{
+       tool_name: tool_name,
+       code: "tool.invalid_scope",
+       message: "World scope does not match instance scope",
+       details: %{}
+     }}
+  end
+
+  def execute(%World{}, %LemmingInstance{}, tool_name, _args) do
+    {:error,
+     %{
+       tool_name: nil,
+       code: "tool.validation.invalid_call",
+       message: "Invalid tool runtime call",
+       details: %{tool_name: tool_name}
+     }}
+  end
+
+  defp dispatch_tool_call(instance, "fs.read_text_file", args) do
+    normalize_tool_result("fs.read_text_file", args, Filesystem.read_text_file(instance, args))
+  end
+
+  defp dispatch_tool_call(instance, "fs.write_text_file", args) do
+    normalize_tool_result("fs.write_text_file", args, Filesystem.write_text_file(instance, args))
+  end
+
+  defp dispatch_tool_call(_instance, "web.search", args) do
+    normalize_tool_result("web.search", args, Web.search(args))
+  end
+
+  defp dispatch_tool_call(_instance, "web.fetch", args) do
+    normalize_tool_result("web.fetch", args, Web.fetch(args))
+  end
+
+  defp normalize_tool_result(
+         tool_name,
+         args,
+         {:ok, %{summary: summary, preview: preview, result: result}}
+       )
+       when is_map(args) and is_binary(summary) and is_map(result) do
+    {:ok,
+     %{
+       tool_name: tool_name,
+       args: args,
+       summary: summary,
+       preview: preview,
+       result: result
+     }}
+  end
+
+  defp normalize_tool_result(tool_name, _args, {:error, %{code: code, message: message} = error})
+       when is_binary(code) and is_binary(message) do
+    {:error,
+     %{
+       tool_name: tool_name,
+       code: code,
+       message: message,
+       details: Map.get(error, :details, %{})
+     }}
+  end
+end

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -196,9 +196,152 @@ defmodule LemmingsOsWeb.InstanceComponents do
     """
   end
 
+  attr :id, :string, required: true
+  attr :tool_execution, :map, required: true
+  attr :world_id, :string, default: nil
+  attr :display_now, :any, default: nil
+  attr :class, :string, default: nil
+
+  def tool_execution_card(assigns) do
+    status = normalize_tool_status(assigns.tool_execution.status)
+
+    assigns =
+      assigns
+      |> assign(:tool_status, status)
+      |> assign(:tool_details_id, "tool-execution-details-#{assigns.tool_execution.id}")
+      |> assign(:args_payload, tool_payload_json(assigns.tool_execution.args))
+      |> assign(:result_payload, tool_payload_json(assigns.tool_execution.result))
+      |> assign(:error_payload, tool_payload_json(assigns.tool_execution.error))
+      |> assign(:artifact_link, tool_artifact_link(assigns.tool_execution, assigns.world_id))
+
+    ~H"""
+    <article
+      id={@id}
+      class={["flex w-full justify-start", @class]}
+      data-role="tool"
+      data-status={@tool_status}
+    >
+      <div class="grid w-full max-w-[80%] min-w-[18rem] justify-items-start gap-2">
+        <div class="flex items-center gap-2 px-1 text-xs uppercase tracking-widest text-zinc-500">
+          <span class={[
+            "inline-flex size-8 items-center justify-center rounded-full border text-xs font-semibold",
+            tool_avatar_tone(@tool_status)
+          ]}>
+            {dgettext("lemmings", "Tool")}
+          </span>
+          <span>{dgettext("lemmings", "Tool run")}</span>
+          <.badge tone={tool_status_badge_tone(@tool_status)}>
+            {tool_status_label(@tool_status)}
+          </.badge>
+        </div>
+
+        <div class={[
+          "w-full rounded-2xl border px-4 py-3",
+          tool_card_tone(@tool_status)
+        ]}>
+          <div class="flex flex-wrap items-start justify-between gap-3">
+            <div class="min-w-0 space-y-1">
+              <p class="font-mono text-sm font-semibold text-zinc-100">
+                {@tool_execution.tool_name}
+              </p>
+              <p
+                id={"tool-execution-summary-#{@tool_execution.id}"}
+                class="text-sm leading-6 text-zinc-200"
+              >
+                <%= if @artifact_link do %>
+                  {tool_summary_prefix(@tool_execution)}
+                  <.link
+                    href={@artifact_link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="font-mono text-sky-300 underline decoration-sky-400/40 underline-offset-4 hover:text-sky-200"
+                  >
+                    {@artifact_link.label}
+                  </.link>
+                <% else %>
+                  {tool_summary(@tool_execution)}
+                <% end %>
+              </p>
+            </div>
+
+            <div class="flex shrink-0 flex-wrap justify-end gap-2">
+              <.badge tone="muted">
+                {tool_argument_count_label(@tool_execution.args)}
+              </.badge>
+              <.badge :if={tool_duration_label(@tool_execution)} tone="muted">
+                {tool_duration_label(@tool_execution)}
+              </.badge>
+            </div>
+          </div>
+
+          <p
+            :if={tool_preview(@tool_execution)}
+            id={"tool-execution-preview-#{@tool_execution.id}"}
+            class="mt-3 border-t border-zinc-800 pt-3 text-sm leading-6 text-zinc-400"
+          >
+            {tool_preview(@tool_execution)}
+          </p>
+
+          <details id={@tool_details_id} class="mt-3 border-t border-zinc-800 pt-3">
+            <summary class="cursor-pointer text-xs uppercase tracking-widest text-zinc-500">
+              {dgettext("lemmings", "Inspect persisted details")}
+            </summary>
+
+            <div class="mt-3 grid gap-3">
+              <div>
+                <p class="text-xs uppercase tracking-widest text-zinc-500">
+                  {dgettext("lemmings", "Arguments")}
+                </p>
+                <pre
+                  id={"tool-execution-args-#{@tool_execution.id}"}
+                  class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
+                  phx-no-curly-interpolation
+                ><%= @args_payload %></pre>
+              </div>
+
+              <div :if={@tool_execution.result}>
+                <p class="text-xs uppercase tracking-widest text-zinc-500">
+                  {dgettext("lemmings", "Result")}
+                </p>
+                <pre
+                  id={"tool-execution-result-#{@tool_execution.id}"}
+                  class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
+                  phx-no-curly-interpolation
+                ><%= @result_payload %></pre>
+              </div>
+
+              <div :if={@tool_execution.error}>
+                <p class="text-xs uppercase tracking-widest text-zinc-500">
+                  {dgettext("lemmings", "Error")}
+                </p>
+                <pre
+                  id={"tool-execution-error-#{@tool_execution.id}"}
+                  class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
+                  phx-no-curly-interpolation
+                ><%= @error_payload %></pre>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <div class="flex items-center gap-2 px-1 text-xs uppercase tracking-widest text-zinc-500">
+          <span class="text-zinc-400">{message_clock_label(@tool_execution.inserted_at)}</span>
+          <span class="text-zinc-600">
+            {message_age_label(@tool_execution.inserted_at, @display_now)}
+          </span>
+        </div>
+      </div>
+    </article>
+    """
+  end
+
   defp normalize_status(status) when is_binary(status), do: status
   defp normalize_status(status) when is_atom(status), do: Atom.to_string(status)
   defp normalize_status(_status), do: "created"
+
+  defp normalize_tool_status(status) when is_binary(status), do: status
+  defp normalize_tool_status(status) when is_atom(status), do: Atom.to_string(status)
+  defp normalize_tool_status(_status), do: "running"
 
   defp normalize_role(role) when is_binary(role), do: role
   defp normalize_role(role) when is_atom(role), do: Atom.to_string(role)
@@ -371,6 +514,151 @@ defmodule LemmingsOsWeb.InstanceComponents do
 
   defp message_avatar_label(role) when role in ["assistant", :assistant], do: "AI"
   defp message_avatar_label(_role), do: "You"
+
+  defp tool_card_tone("running"),
+    do: "border-amber-400/20 bg-gradient-to-b from-amber-950/30 to-zinc-950/95"
+
+  defp tool_card_tone("ok"),
+    do: "border-emerald-400/20 bg-gradient-to-b from-emerald-950/30 to-zinc-950/95"
+
+  defp tool_card_tone("error"),
+    do: "border-red-400/20 bg-gradient-to-b from-red-950/25 to-zinc-950/95"
+
+  defp tool_card_tone(_status), do: "border-zinc-800 bg-zinc-950/95"
+
+  defp tool_avatar_tone("running"), do: "border-amber-400/30 bg-amber-400/10 text-amber-200"
+  defp tool_avatar_tone("ok"), do: "border-emerald-400/30 bg-emerald-400/10 text-emerald-300"
+  defp tool_avatar_tone("error"), do: "border-red-400/30 bg-red-400/10 text-red-300"
+  defp tool_avatar_tone(_status), do: "border-zinc-700 bg-zinc-900/80 text-zinc-300"
+
+  defp tool_status_badge_tone("running"), do: "warning"
+  defp tool_status_badge_tone("ok"), do: "success"
+  defp tool_status_badge_tone("error"), do: "danger"
+  defp tool_status_badge_tone(_status), do: "muted"
+
+  defp tool_status_label("running"), do: dgettext("lemmings", "Running")
+  defp tool_status_label("ok"), do: dgettext("lemmings", "Completed")
+  defp tool_status_label("error"), do: dgettext("lemmings", "Failed")
+  defp tool_status_label(status), do: status
+
+  defp tool_summary(%{summary: summary}) when is_binary(summary) and summary != "", do: summary
+
+  defp tool_summary(%{status: "running"}),
+    do: dgettext("lemmings", "Tool execution is still running.")
+
+  defp tool_summary(%{status: "ok"}),
+    do: dgettext("lemmings", "Tool execution completed successfully.")
+
+  defp tool_summary(%{status: "error"} = tool_execution) do
+    tool_error_code = tool_execution |> Map.get(:error, %{}) |> Map.get("code")
+
+    if is_binary(tool_error_code) and tool_error_code != "" do
+      dgettext("lemmings", "Tool execution failed with code %{code}.", code: tool_error_code)
+    else
+      dgettext("lemmings", "Tool execution failed.")
+    end
+  end
+
+  defp tool_summary(_tool_execution), do: dgettext("lemmings", "Tool execution recorded.")
+
+  defp tool_summary_prefix(%{summary: summary} = tool_execution)
+       when is_binary(summary) and summary != "" do
+    case tool_execution.tool_name do
+      "fs.write_text_file" ->
+        "Wrote file "
+
+      "fs.read_text_file" ->
+        "Read file "
+
+      _tool_name ->
+        case tool_artifact_label(tool_execution) do
+          label when is_binary(label) ->
+            String.replace(summary, label, "")
+            |> String.trim()
+            |> ensure_trailing_space()
+
+          _label ->
+            ensure_trailing_space(summary)
+        end
+    end
+  end
+
+  defp tool_summary_prefix(tool_execution),
+    do: ensure_trailing_space(tool_summary(tool_execution))
+
+  defp tool_preview(%{preview: preview}) when is_binary(preview) and preview != "", do: preview
+
+  defp tool_preview(%{status: "error", error: error}) when is_map(error) do
+    error
+    |> Map.get("message")
+    |> normalize_preview_copy()
+  end
+
+  defp tool_preview(%{result: result}) when is_map(result) do
+    result
+    |> Map.get("path")
+    |> normalize_preview_copy()
+  end
+
+  defp tool_preview(_tool_execution), do: nil
+
+  defp tool_artifact_link(tool_execution, world_id) do
+    with true <- tool_execution.tool_name == "fs.write_text_file",
+         true <- is_binary(world_id) and world_id != "",
+         label when is_binary(label) <- tool_artifact_label(tool_execution),
+         true <- Path.type(label) == :relative,
+         path_segments when is_list(path_segments) <- String.split(label, "/", trim: true),
+         true <- path_segments != [] do
+      %{
+        label: label,
+        href:
+          ~p"/lemmings/instances/#{tool_execution.lemming_instance_id}/artifacts/#{path_segments}?#{%{world: world_id}}"
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp tool_artifact_label(%{args: %{"path" => path}}) when is_binary(path) and path != "",
+    do: path
+
+  defp tool_artifact_label(%{args: %{path: path}}) when is_binary(path) and path != "", do: path
+
+  defp tool_artifact_label(%{result: %{"path" => path}}) when is_binary(path) and path != "",
+    do: path
+
+  defp tool_artifact_label(%{result: %{path: path}}) when is_binary(path) and path != "", do: path
+  defp tool_artifact_label(_tool_execution), do: nil
+
+  defp ensure_trailing_space(value) when is_binary(value) and value != "" do
+    if String.ends_with?(value, " "), do: value, else: value <> " "
+  end
+
+  defp ensure_trailing_space(_value), do: ""
+
+  defp normalize_preview_copy(value) when is_binary(value) and value != "", do: value
+  defp normalize_preview_copy(_value), do: nil
+
+  defp tool_duration_label(%{duration_ms: duration_ms})
+       when is_integer(duration_ms) and duration_ms >= 0 do
+    dgettext("lemmings", "%{count} ms", count: duration_ms)
+  end
+
+  defp tool_duration_label(_tool_execution), do: nil
+
+  defp tool_argument_count_label(args) when is_map(args) do
+    dgettext("lemmings", "%{count} args", count: map_size(args))
+  end
+
+  defp tool_argument_count_label(_args), do: dgettext("lemmings", "0 args")
+
+  defp tool_payload_json(nil), do: "{}"
+
+  defp tool_payload_json(payload) when is_map(payload) do
+    Jason.encode!(payload, pretty: true)
+  end
+
+  defp tool_payload_json(payload), do: inspect(payload, pretty: true)
 
   defp assistant_metadata?(role) when role in ["assistant", :assistant], do: true
   defp assistant_metadata?(_role), do: false

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -1,0 +1,43 @@
+defmodule LemmingsOsWeb.InstanceArtifactController do
+  use LemmingsOsWeb, :controller
+
+  alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.Worlds
+
+  def show(conn, %{"id" => id, "path" => path_segments} = params) when is_list(path_segments) do
+    with %{} = world <- resolve_world(params),
+         {:ok, instance} <-
+           LemmingsOs.LemmingInstances.get_instance(id, world: world, preload: [:lemming]),
+         relative_path <- Path.join(path_segments),
+         {:ok, %{absolute_path: absolute_path, relative_path: normalized_path}} <-
+           LemmingInstances.artifact_absolute_path(instance, relative_path),
+         {:ok, content} <- File.read(absolute_path) do
+      conn
+      |> put_resp_content_type(content_type_for(normalized_path))
+      |> put_resp_header(
+        "content-disposition",
+        ~s(inline; filename="#{Path.basename(normalized_path)}")
+      )
+      |> send_resp(200, content)
+    else
+      nil -> send_resp(conn, 404, "World not found")
+      {:error, :not_found} -> send_resp(conn, 404, "Instance not found")
+      {:error, :invalid_path} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :path_outside_workspace} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :enoent} -> send_resp(conn, 404, "Artifact not found")
+      {:error, _reason} -> send_resp(conn, 404, "Artifact not found")
+    end
+  end
+
+  def show(conn, _params), do: send_resp(conn, 404, "Artifact not found")
+
+  defp resolve_world(%{"world" => world_id}) when is_binary(world_id) and world_id != "" do
+    Worlds.get_world(world_id)
+  end
+
+  defp resolve_world(_params), do: Worlds.get_default_world()
+
+  defp content_type_for(path) do
+    MIME.from_path(path)
+  end
+end

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -13,10 +13,11 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
            LemmingInstances.artifact_absolute_path(instance, relative_path),
          {:ok, content} <- File.read(absolute_path) do
       conn
-      |> put_resp_content_type(content_type_for(normalized_path))
+      |> put_resp_header("content-type", "application/octet-stream")
+      |> put_resp_header("x-content-type-options", "nosniff")
       |> put_resp_header(
         "content-disposition",
-        ~s(inline; filename="#{Path.basename(normalized_path)}")
+        ~s(attachment; filename="#{Path.basename(normalized_path)}")
       )
       |> send_resp(200, content)
     else
@@ -36,8 +37,4 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
   end
 
   defp resolve_world(_params), do: Worlds.get_default_world()
-
-  defp content_type_for(path) do
-    MIME.from_path(path)
-  end
 end

--- a/lib/lemmings_os_web/live/home_live.html.heex
+++ b/lib/lemmings_os_web/live/home_live.html.heex
@@ -14,7 +14,7 @@
         <:title>{dgettext("layout", ".home_title_operations_overview")}</:title>
         <:subtitle>{dgettext("layout", ".home_subtitle_operations_overview")}</:subtitle>
 
-        <div class="grid gap-4 lg:grid-cols-2">
+        <div class="grid gap-4 lg:grid-cols-1">
           <div class="flex flex-col gap-4">
             <div id="home-world-summary-card" class={mini_card_class()}>
               <div class="flex items-start justify-between gap-3">

--- a/lib/lemmings_os_web/live/instance_live.ex
+++ b/lib/lemmings_os_web/live/instance_live.ex
@@ -5,6 +5,7 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.PubSub
+  alias LemmingsOs.LemmingTools
   alias LemmingsOs.Helpers
   alias LemmingsOs.Runtime
   alias LemmingsOs.Worlds
@@ -78,6 +79,13 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   def handle_info(
         {:message_appended, %{instance_id: instance_id}},
+        %{assigns: %{instance: %{id: instance_id}}} = socket
+      ) do
+    {:noreply, load_instance(socket, instance_id, %{"world" => current_world_id(socket)})}
+  end
+
+  def handle_info(
+        {:tool_execution_upserted, %{instance_id: instance_id}},
         %{assigns: %{instance: %{id: instance_id}}} = socket
       ) do
     {:noreply, load_instance(socket, instance_id, %{"world" => current_world_id(socket)})}
@@ -187,6 +195,7 @@ defmodule LemmingsOsWeb.InstanceLive do
         case LemmingInstances.get_instance(id, world: world, preload: [:lemming]) do
           {:ok, instance} ->
             messages = LemmingInstances.list_messages(instance)
+            tool_executions = LemmingTools.list_tool_executions(world, instance)
             runtime_state = runtime_state(instance)
             status_now = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -205,7 +214,7 @@ defmodule LemmingsOsWeb.InstanceLive do
               instance_not_found?: false,
               status_tick_ref: nil
             )
-            |> stream(:messages, transcript_entries(messages), reset: true)
+            |> stream(:messages, transcript_entries(messages, tool_executions), reset: true)
             |> schedule_status_tick()
             |> put_shell_breadcrumb(build_shell_breadcrumb(instance))
 
@@ -268,6 +277,18 @@ defmodule LemmingsOsWeb.InstanceLive do
     do: ~p"/lemmings/#{lemming_id}"
 
   defp parent_lemming_path(_instance), do: ~p"/lemmings"
+
+  defp instance_raw_path(%{id: id}, %{id: world_id})
+       when is_binary(id) and is_binary(world_id) do
+    ~p"/lemmings/instances/#{id}/raw?#{%{world: world_id}}"
+  end
+
+  defp instance_raw_path(%{id: id, world_id: world_id}, _world)
+       when is_binary(id) and is_binary(world_id) do
+    ~p"/lemmings/instances/#{id}/raw?#{%{world: world_id}}"
+  end
+
+  defp instance_raw_path(_instance, _world), do: nil
 
   defp parent_lemming_name(%{lemming: %{name: name}}) when is_binary(name) and name != "",
     do: name
@@ -596,26 +617,13 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   defp follow_up_helper_copy(status), do: follow_up_status_copy(status)
 
-  defp transcript_entries(messages) when is_list(messages) do
+  defp transcript_entries(messages, tool_executions)
+       when is_list(messages) and is_list(tool_executions) do
     messages
-    |> Enum.reduce({[], nil}, fn message, {entries, previous_date} ->
-      current_date = message_date(message)
-
-      entries =
-        case current_date do
-          %Date{} = date when date != previous_date ->
-            separator = %{id: "day-#{Date.to_iso8601(date)}", type: :day_divider, date: date}
-
-            entries ++
-              [separator, %{id: "message-#{message.id}", type: :message, message: message}]
-
-          _ ->
-            entries ++ [%{id: "message-#{message.id}", type: :message, message: message}]
-        end
-
-      {entries, current_date || previous_date}
-    end)
-    |> elem(0)
+    |> transcript_message_entries()
+    |> Kernel.++(transcript_tool_execution_entries(tool_executions))
+    |> Enum.sort_by(&transcript_sort_key/1)
+    |> inject_transcript_day_dividers()
   end
 
   defp transcript_total_tokens(messages) when is_list(messages) do
@@ -651,6 +659,75 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   defp message_date(%{inserted_at: %DateTime{} = inserted_at}), do: DateTime.to_date(inserted_at)
   defp message_date(_message), do: nil
+
+  defp tool_execution_date(%{inserted_at: %DateTime{} = inserted_at}),
+    do: DateTime.to_date(inserted_at)
+
+  defp tool_execution_date(_tool_execution), do: nil
+
+  defp transcript_message_entries(messages) do
+    Enum.map(messages, fn message ->
+      %{
+        id: "message-#{message.id}",
+        type: :message,
+        inserted_at: Map.get(message, :inserted_at),
+        message: message
+      }
+    end)
+  end
+
+  defp transcript_tool_execution_entries(tool_executions) do
+    Enum.map(tool_executions, fn tool_execution ->
+      %{
+        id: "tool-execution-#{tool_execution.id}",
+        type: :tool_execution,
+        inserted_at: Map.get(tool_execution, :inserted_at),
+        tool_execution: tool_execution
+      }
+    end)
+  end
+
+  defp transcript_sort_key(%{type: type, inserted_at: inserted_at, id: id}) do
+    {transcript_timestamp_sort_value(inserted_at), transcript_type_rank(type), id}
+  end
+
+  defp transcript_timestamp_sort_value(%DateTime{} = inserted_at),
+    do: DateTime.to_unix(inserted_at, :microsecond)
+
+  defp transcript_timestamp_sort_value(_inserted_at), do: 0
+
+  defp transcript_type_rank(:day_divider), do: 0
+  defp transcript_type_rank(:message), do: 1
+  defp transcript_type_rank(:tool_execution), do: 2
+  defp transcript_type_rank(_type), do: 3
+
+  defp inject_transcript_day_dividers(entries) do
+    entries
+    |> Enum.reduce({[], nil}, fn entry, {acc, previous_date} ->
+      current_date = transcript_entry_date(entry)
+
+      next_entries =
+        case current_date do
+          %Date{} = date when date != previous_date ->
+            separator = %{id: "day-#{Date.to_iso8601(date)}", type: :day_divider, date: date}
+            acc ++ [separator, entry]
+
+          _date ->
+            acc ++ [entry]
+        end
+
+      {next_entries, current_date || previous_date}
+    end)
+    |> elem(0)
+  end
+
+  defp transcript_entry_date(%{type: :message, message: message}), do: message_date(message)
+
+  defp transcript_entry_date(%{type: :tool_execution, tool_execution: tool_execution}),
+    do: tool_execution_date(tool_execution)
+
+  defp transcript_entry_date(%{date: %Date{} = date}), do: date
+  defp transcript_entry_date(_entry), do: nil
 
   defp transcript_day_label(%Date{} = date) do
     Calendar.strftime(date, "%A · %b %-d")

--- a/lib/lemmings_os_web/live/instance_live.html.heex
+++ b/lib/lemmings_os_web/live/instance_live.html.heex
@@ -85,6 +85,16 @@
                 <.icon name="hero-arrow-left" class="size-4" />
                 {dgettext("lemmings", "Back to parent lemming")}
               </.link>
+
+              <.link
+                :if={instance_raw_path(@instance, @world)}
+                id="instance-raw-context-link"
+                navigate={instance_raw_path(@instance, @world)}
+                class="inline-flex min-h-11 items-center gap-2 border border-zinc-700 bg-zinc-950/70 px-4 py-2 text-xs font-medium uppercase tracking-widest text-zinc-300 transition duration-150 ease-out hover:-translate-y-px hover:border-zinc-500 hover:text-zinc-100"
+              >
+                <.icon name="hero-code-bracket-square" class="size-4" />
+                {dgettext("lemmings", "Raw context")}
+              </.link>
             </div>
           </div>
 
@@ -212,7 +222,7 @@
               {dgettext("lemmings", "Conversation Transcript")}
             </p>
             <p class="text-xs uppercase tracking-widest text-zinc-500">
-              {dgettext("lemmings", "Chronological messages")}
+              {dgettext("lemmings", "Chronological session activity")}
             </p>
           </div>
 
@@ -243,6 +253,14 @@
               :if={entry.type == :message}
               id={"bubble-#{dom_id}"}
               message={entry.message}
+              display_now={@status_now}
+            />
+
+            <InstanceComponents.tool_execution_card
+              :if={entry.type == :tool_execution}
+              id={"card-tool-execution-#{entry.tool_execution.id}"}
+              tool_execution={entry.tool_execution}
+              world_id={@world && @world.id}
               display_now={@status_now}
             />
           </div>

--- a/lib/lemmings_os_web/live/instance_raw_live.ex
+++ b/lib/lemmings_os_web/live/instance_raw_live.ex
@@ -1,0 +1,846 @@
+defmodule LemmingsOsWeb.InstanceRawLive do
+  use LemmingsOsWeb, :live_view
+
+  import LemmingsOsWeb.MockShell
+
+  alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.LemmingInstances.Executor
+  alias LemmingsOs.LemmingInstances.Message
+  alias LemmingsOs.LemmingInstances.PubSub
+  alias LemmingsOs.LemmingInstances.ToolExecution
+  alias LemmingsOs.LemmingTools
+  alias LemmingsOs.ModelRuntime
+  alias LemmingsOs.Worlds
+  alias LemmingsOs.Worlds.World
+
+  @max_live_steps 40
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {:ok,
+     socket
+     |> assign_shell(:lemmings, dgettext("lemmings", "Instance Raw Context"))
+     |> assign(
+       world: nil,
+       instance: nil,
+       runtime_state: nil,
+       model_steps: [],
+       interaction_timeline: [],
+       interaction_timeline_source: nil,
+       model_request: nil,
+       model_request_source: nil,
+       subscribed_instance_id: nil,
+       instance_not_found?: false,
+       parent_lemming_path: nil,
+       session_path: nil,
+       shell_breadcrumb: default_shell_breadcrumb(:lemmings)
+     )}
+  end
+
+  @impl true
+  def handle_params(%{"id" => id} = params, _uri, socket) do
+    {:noreply, load_instance(socket, id, params)}
+  end
+
+  @impl true
+  def handle_info({:message_appended, %{instance_id: instance_id}}, socket) do
+    {:noreply, maybe_reload_instance(socket, instance_id)}
+  end
+
+  @impl true
+  def handle_info({:tool_execution_upserted, %{instance_id: instance_id}}, socket) do
+    {:noreply, maybe_reload_instance(socket, instance_id)}
+  end
+
+  @impl true
+  def handle_info({:model_step_upserted, %{instance_id: instance_id}}, socket) do
+    {:noreply, maybe_reload_instance(socket, instance_id)}
+  end
+
+  @impl true
+  def handle_info({:status_changed, %{instance_id: instance_id}}, socket) do
+    {:noreply, maybe_reload_instance(socket, instance_id)}
+  end
+
+  defp load_instance(socket, id, params) do
+    case resolve_world(params) do
+      %World{} = world -> load_world_instance(socket, id, world)
+      nil -> assign_not_found(socket)
+    end
+  end
+
+  defp load_world_instance(socket, id, world) do
+    case LemmingInstances.get_instance(id, world: world, preload: [:lemming]) do
+      {:ok, instance} ->
+        runtime_state = load_runtime_state(instance, world)
+        messages = load_messages(instance, world)
+        tool_executions = load_tool_executions(instance, world)
+        model_steps = load_model_steps(instance)
+
+        {interaction_timeline, interaction_timeline_source} =
+          build_interaction_timeline(model_steps, messages, tool_executions)
+
+        {model_request, model_request_source} =
+          load_model_request(instance, runtime_state, model_steps, messages)
+
+        session_path = ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}"
+        raw_path = ~p"/lemmings/instances/#{instance.id}/raw?#{%{world: world.id}}"
+
+        socket
+        |> maybe_subscribe_instance(instance)
+        |> assign(
+          world: world,
+          instance: instance,
+          runtime_state: runtime_state,
+          model_steps: model_steps,
+          interaction_timeline: interaction_timeline,
+          interaction_timeline_source: interaction_timeline_source,
+          model_request: model_request,
+          model_request_source: model_request_source,
+          instance_not_found?: false,
+          parent_lemming_path: parent_lemming_path(instance),
+          session_path: session_path,
+          shell_breadcrumb: build_shell_breadcrumb(instance, session_path, raw_path)
+        )
+
+      {:error, :not_found} ->
+        assign_not_found(socket)
+    end
+  end
+
+  defp load_runtime_state(instance, world) do
+    case LemmingInstances.get_runtime_state(instance.id, world: world) do
+      {:ok, state} -> state
+      {:error, :not_found} -> %{}
+    end
+  end
+
+  defp load_messages(instance, world) do
+    LemmingInstances.list_messages(instance, world: world)
+  end
+
+  defp load_tool_executions(instance, world) do
+    LemmingTools.list_tool_executions(world, instance)
+  end
+
+  defp load_model_steps(instance) do
+    case Registry.lookup(LemmingsOs.LemmingInstances.ExecutorRegistry, instance.id) do
+      [{_pid, _value}] ->
+        instance.id
+        |> Executor.snapshot()
+        |> Map.get(:model_steps, [])
+        |> Enum.take(-@max_live_steps)
+
+      [] ->
+        []
+    end
+  catch
+    :exit, _reason -> []
+  end
+
+  defp load_model_request(instance, runtime_state, model_steps, messages)
+       when is_list(model_steps) do
+    case List.last(model_steps) do
+      %{request_payload: payload} when is_map(payload) ->
+        {payload, :live_executor_trace}
+
+      _other ->
+        fallback_model_request(instance, runtime_state, messages)
+    end
+  end
+
+  defp fallback_model_request(instance, runtime_state, messages) do
+    case build_model_request(instance, runtime_state) do
+      {:ok, request} ->
+        {request, :runtime_state}
+
+      {:error, _reason} ->
+        case build_model_request_from_transcript(instance, messages) do
+          {:ok, request} -> {request, :transcript_reconstruction}
+          {:error, reason} -> {%{error: inspect(reason)}, :unavailable}
+        end
+    end
+  end
+
+  defp build_model_request(instance, runtime_state) do
+    history = Map.get(runtime_state, :context_messages, [])
+    current_item = Map.get(runtime_state, :current_item)
+
+    ModelRuntime.debug_request(instance.config_snapshot || %{}, history, current_item)
+  end
+
+  defp build_model_request_from_transcript(instance, messages) do
+    case split_transcript_for_request(messages) do
+      {:ok, history, current_request} ->
+        ModelRuntime.debug_request(instance.config_snapshot || %{}, history, current_request)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp split_transcript_for_request(messages) do
+    user_messages =
+      Enum.filter(messages, fn
+        %Message{role: "user"} -> true
+        _message -> false
+      end)
+
+    case List.last(user_messages) do
+      %Message{} = current_request ->
+        history =
+          messages
+          |> Enum.take_while(&(&1.id != current_request.id))
+          |> Enum.map(&message_to_context_message/1)
+
+        {:ok, history, %{content: current_request.content}}
+
+      nil ->
+        {:error, :invalid_request}
+    end
+  end
+
+  defp message_to_context_message(%Message{role: role, content: content}) do
+    %{role: role, content: content}
+  end
+
+  defp build_interaction_timeline(model_steps, messages, tool_executions)
+       when is_list(model_steps) and model_steps != [] do
+    executions_by_id = Map.new(tool_executions, &{&1.id, &1})
+
+    timeline =
+      [
+        build_user_request_entry(model_steps, messages)
+        | build_live_timeline_entries(model_steps, executions_by_id)
+      ]
+      |> List.flatten()
+      |> Enum.reject(&is_nil/1)
+      |> renumber_timeline()
+
+    {timeline, :live_executor_trace}
+  end
+
+  defp build_interaction_timeline(_model_steps, messages, tool_executions) do
+    timeline =
+      messages
+      |> build_persisted_timeline(tool_executions)
+      |> Enum.reject(&is_nil/1)
+      |> renumber_timeline()
+
+    {timeline, :persisted_history_only}
+  end
+
+  defp build_user_request_entry(model_steps, messages) do
+    content =
+      model_steps
+      |> List.first()
+      |> extract_current_request_content()
+      |> case do
+        nil -> latest_user_message_content(messages)
+        value -> value
+      end
+
+    if present?(content) do
+      %{
+        id: "user-request",
+        kind: :user_request,
+        title: "1. User -> App",
+        summary: "Operator request received",
+        body: content,
+        timestamp: latest_user_message_at(messages),
+        meta: [],
+        status: nil,
+        raw_sections: []
+      }
+    end
+  end
+
+  defp build_live_timeline_entries(model_steps, executions_by_id) do
+    model_steps
+    |> Enum.chunk_by(&Map.get(&1, :request_payload))
+    |> Enum.flat_map(fn request_group ->
+      build_live_request_group_entries(request_group, executions_by_id)
+    end)
+  end
+
+  defp build_live_request_group_entries([first_step | _rest] = request_group, executions_by_id) do
+    [
+      build_llm_request_entry(first_step)
+      | Enum.with_index(request_group, 1)
+        |> Enum.flat_map(fn {model_step, retry_attempt} ->
+          build_live_step_entries(model_step, executions_by_id, retry_attempt)
+        end)
+    ]
+  end
+
+  defp build_live_step_entries(model_step, executions_by_id, retry_attempt) do
+    tool_execution =
+      model_step
+      |> Map.get(:tool_execution_id)
+      |> then(&Map.get(executions_by_id, &1))
+
+    [
+      build_llm_response_entry(model_step, retry_attempt)
+      | build_tool_entries(model_step, tool_execution)
+    ]
+  end
+
+  defp build_llm_request_entry(model_step) do
+    request_payload = Map.get(model_step, :request_payload, %{})
+    request = request_payload["request"] || %{}
+    messages = request["messages"] || []
+    non_system_count = Enum.count(messages, &(&1["role"] != "system"))
+
+    %{
+      id: "step-#{model_step.step_index}-llm-request",
+      kind: :llm_request,
+      title: "App -> LLM",
+      summary:
+        "Send provider request with system prompt, tools catalog, and #{non_system_count} context message(s)",
+      body: request_messages_body(messages),
+      timestamp: Map.get(model_step, :started_at),
+      meta: request_meta(request_payload, messages),
+      status: Map.get(model_step, :status),
+      raw_sections: [
+        %{label: "Provider request", payload: request_payload},
+        %{label: "System prompt", payload: extract_system_prompt(messages)}
+      ]
+    }
+  end
+
+  defp build_llm_response_entry(model_step, retry_attempt) do
+    parsed_output = Map.get(model_step, :parsed_output) || %{}
+    {summary, body} = llm_response_summary_and_body(model_step, parsed_output)
+
+    %{
+      id: "step-#{model_step.step_index}-llm-response",
+      kind: :llm_response,
+      title: llm_response_title(retry_attempt),
+      summary: summary,
+      body: body,
+      timestamp: Map.get(model_step, :completed_at) || Map.get(model_step, :started_at),
+      meta: response_meta(model_step),
+      status: Map.get(model_step, :status),
+      raw_sections: [
+        %{label: "Parsed response", payload: parsed_output},
+        %{label: "Provider raw response", payload: model_step.response_payload},
+        %{label: "Error", payload: model_step.error}
+      ]
+    }
+  end
+
+  defp llm_response_summary_and_body(_model_step, %{"action" => "tool_call"} = parsed_output) do
+    tool_name = parsed_output["tool_name"] || "unknown tool"
+    {"LLM requested tool #{tool_name}", format_tool_args_body(parsed_output["args"] || %{})}
+  end
+
+  defp llm_response_summary_and_body(_model_step, %{"action" => "reply"} = parsed_output) do
+    {"LLM returned final reply", parsed_output["reply"]}
+  end
+
+  defp llm_response_summary_and_body(model_step, parsed_output) do
+    {"LLM returned an unexpected payload", llm_error_body(model_step, parsed_output)}
+  end
+
+  defp llm_error_body(_model_step, parsed_output) when map_size(parsed_output) > 0 do
+    Jason.encode!(parsed_output, pretty: true)
+  end
+
+  defp llm_error_body(model_step, _parsed_output) do
+    error = Map.get(model_step, :error) || %{}
+    response_payload = Map.get(model_step, :response_payload) || %{}
+
+    cond do
+      is_binary(error["content"]) and error["content"] != "" ->
+        error["content"]
+
+      is_binary(response_payload["content"]) ->
+        response_payload["content"]
+
+      map_size(error) > 0 ->
+        Jason.encode!(error, pretty: true)
+
+      true ->
+        "%{}"
+    end
+  end
+
+  defp build_tool_entries(
+         %{parsed_output: %{"action" => "tool_call"} = parsed_output} = model_step,
+         tool_execution
+       ) do
+    tool_name = parsed_output["tool_name"] || "unknown tool"
+    tool_args = parsed_output["args"] || %{}
+
+    [
+      %{
+        id: "step-#{model_step.step_index}-tool-call",
+        kind: :tool_call,
+        title: "App -> Tool",
+        summary: "Execute #{tool_name}",
+        body: format_tool_args_body(tool_args),
+        timestamp: tool_entry_timestamp(tool_execution),
+        meta: tool_call_meta(tool_execution),
+        status: tool_execution_status(tool_execution),
+        raw_sections: [
+          %{label: "Tool arguments", payload: tool_args}
+        ]
+      },
+      build_tool_result_entry(model_step, tool_execution)
+    ]
+  end
+
+  defp build_tool_entries(_model_step, _tool_execution), do: []
+
+  defp build_tool_result_entry(model_step, nil) do
+    %{
+      id: "step-#{model_step.step_index}-tool-result-missing",
+      kind: :tool_result,
+      title: "Tool -> App",
+      summary: "Tool result not available in persistence",
+      body: "Live model step exists, but no durable tool row was found.",
+      timestamp: Map.get(model_step, :completed_at) || Map.get(model_step, :started_at),
+      meta: [],
+      status: "error",
+      raw_sections: []
+    }
+  end
+
+  defp build_tool_result_entry(model_step, %ToolExecution{} = tool_execution) do
+    %{
+      id: "step-#{model_step.step_index}-tool-result",
+      kind: :tool_result,
+      title: "Tool -> App",
+      summary: tool_result_summary(tool_execution),
+      body: tool_result_body(tool_execution),
+      timestamp: tool_result_timestamp(tool_execution),
+      meta: tool_result_meta(tool_execution),
+      status: tool_execution.status,
+      raw_sections: [
+        %{label: "Persisted tool arguments", payload: tool_execution.args},
+        %{label: "Persisted tool result", payload: tool_execution.result},
+        %{label: "Persisted tool error", payload: tool_execution.error}
+      ]
+    }
+  end
+
+  defp build_persisted_timeline(messages, tool_executions) do
+    [
+      build_persisted_user_entry(messages),
+      Enum.map(tool_executions, &build_persisted_tool_entry/1),
+      build_persisted_reply_entry(messages)
+    ]
+    |> List.flatten()
+  end
+
+  defp build_persisted_user_entry(messages) do
+    case latest_user_message_content(messages) do
+      nil ->
+        nil
+
+      content ->
+        %{
+          id: "persisted-user-request",
+          kind: :user_request,
+          title: "User -> App",
+          summary: "Persisted user request",
+          body: content,
+          timestamp: latest_user_message_at(messages),
+          meta: [],
+          status: nil,
+          raw_sections: []
+        }
+    end
+  end
+
+  defp build_persisted_tool_entry(tool_execution) do
+    %{
+      id: "persisted-tool-#{tool_execution.id}",
+      kind: :tool_result,
+      title: "Persisted tool execution",
+      summary: tool_result_summary(tool_execution),
+      body: tool_result_body(tool_execution),
+      timestamp: tool_result_timestamp(tool_execution),
+      meta: tool_result_meta(tool_execution),
+      status: tool_execution.status,
+      raw_sections: [
+        %{label: "Persisted tool arguments", payload: tool_execution.args},
+        %{label: "Persisted tool result", payload: tool_execution.result},
+        %{label: "Persisted tool error", payload: tool_execution.error}
+      ]
+    }
+  end
+
+  defp build_persisted_reply_entry(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find(fn
+      %Message{role: "assistant"} -> true
+      _message -> false
+    end)
+    |> case do
+      %Message{} = message ->
+        %{
+          id: "persisted-final-reply",
+          kind: :final_reply,
+          title: "LLM -> App",
+          summary: "Final assistant reply stored in transcript",
+          body: message.content,
+          timestamp: message.inserted_at,
+          meta: persisted_message_meta(message),
+          status: nil,
+          raw_sections: []
+        }
+
+      nil ->
+        nil
+    end
+  end
+
+  defp latest_user_message_content(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %Message{role: "user", content: content} -> content
+      _message -> nil
+    end)
+  end
+
+  defp latest_user_message_at(messages) do
+    messages
+    |> Enum.reverse()
+    |> Enum.find_value(fn
+      %Message{role: "user", inserted_at: inserted_at} -> inserted_at
+      _message -> nil
+    end)
+  end
+
+  defp extract_current_request_content(nil), do: nil
+
+  defp extract_current_request_content(%{request_payload: request_payload}) do
+    request_payload
+    |> Map.get("request", %{})
+    |> Map.get("messages", [])
+    |> List.last()
+    |> case do
+      %{"content" => content} when is_binary(content) -> content
+      _other -> nil
+    end
+  end
+
+  defp request_messages_body(messages) when is_list(messages) and messages != [] do
+    Enum.map_join(messages, "\n\n", fn message ->
+      role =
+        message
+        |> Map.get("role", "unknown")
+        |> to_string()
+        |> String.upcase()
+
+      content =
+        case Map.get(message, "content") do
+          value when is_binary(value) and value != "" -> value
+          _other -> "(empty)"
+        end
+
+      "#{role}\n#{content}"
+    end)
+  end
+
+  defp request_messages_body(_messages), do: "Request messages unavailable."
+
+  defp request_meta(request_payload, messages) do
+    [
+      provider_value(request_payload),
+      model_value(request_payload),
+      "#{length(messages)} total message(s)"
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp response_meta(model_step) do
+    [
+      Map.get(model_step, :provider),
+      Map.get(model_step, :model),
+      tokens_meta(model_step),
+      duration_meta(Map.get(model_step, :duration_ms))
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp tool_call_meta(nil), do: []
+
+  defp tool_call_meta(tool_execution) do
+    [
+      tool_execution.id,
+      duration_meta(tool_execution.duration_ms)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp tool_result_meta(tool_execution) do
+    [
+      tool_execution.tool_name,
+      duration_meta(tool_execution.duration_ms)
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp persisted_message_meta(%Message{} = message) do
+    [message.provider, message.model, tokens_meta(message)]
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp tokens_meta(%{input_tokens: input_tokens, output_tokens: output_tokens})
+       when is_integer(input_tokens) and is_integer(output_tokens) do
+    "#{input_tokens} in / #{output_tokens} out"
+  end
+
+  defp tokens_meta(%{total_tokens: total_tokens}) when is_integer(total_tokens) do
+    "#{total_tokens} total tokens"
+  end
+
+  defp tokens_meta(_payload), do: nil
+
+  defp duration_meta(duration_ms) when is_integer(duration_ms), do: "#{duration_ms} ms"
+  defp duration_meta(_duration_ms), do: nil
+
+  defp provider_value(%{"provider" => provider}) when is_binary(provider), do: provider
+  defp provider_value(_payload), do: nil
+
+  defp model_value(%{"model" => model}) when is_binary(model), do: model
+  defp model_value(_payload), do: nil
+
+  defp format_tool_args_body(args) when is_map(args) and map_size(args) == 0 do
+    "Tool called without arguments."
+  end
+
+  defp format_tool_args_body(args) when is_map(args) do
+    Enum.map_join(args, "\n\n", fn {key, value} ->
+      case render_tool_arg_value(value) do
+        {:inline, rendered} ->
+          "- `#{key}`: #{rendered}"
+
+        {:block, rendered} ->
+          "- `#{key}`:\n#{indent_block(rendered, 2)}"
+      end
+    end)
+  end
+
+  defp format_tool_args_body(_args), do: "Tool arguments unavailable."
+
+  defp render_tool_arg_value(value) when is_binary(value) do
+    if String.contains?(value, "\n") do
+      {:block, value}
+    else
+      {:inline, value}
+    end
+  end
+
+  defp render_tool_arg_value(value) when is_map(value) or is_list(value) do
+    {:block, Jason.encode!(value, pretty: true)}
+  end
+
+  defp render_tool_arg_value(value), do: {:inline, inspect(value)}
+
+  defp indent_block(content, spaces)
+       when is_binary(content) and is_integer(spaces) and spaces > 0 do
+    prefix = String.duplicate(" ", spaces)
+
+    content
+    |> String.split("\n")
+    |> Enum.map_join("\n", &(prefix <> &1))
+  end
+
+  defp tool_result_summary(%ToolExecution{status: "ok", tool_name: tool_name}) do
+    "#{tool_name} completed"
+  end
+
+  defp tool_result_summary(%ToolExecution{status: "error", tool_name: tool_name}) do
+    "#{tool_name} failed"
+  end
+
+  defp tool_result_summary(%ToolExecution{tool_name: tool_name}), do: tool_name
+
+  defp tool_result_body(%ToolExecution{} = tool_execution) do
+    cond do
+      present?(tool_execution.preview) and present?(tool_execution.summary) ->
+        "#{tool_execution.summary}\n\n#{tool_execution.preview}"
+
+      present?(tool_execution.summary) ->
+        tool_execution.summary
+
+      present?(tool_execution.preview) ->
+        tool_execution.preview
+
+      is_map(tool_execution.error) ->
+        map_message(tool_execution.error) || inspect(tool_execution.error)
+
+      true ->
+        "Tool execution finished without a summary."
+    end
+  end
+
+  defp map_message(%{"message" => message}) when is_binary(message), do: message
+  defp map_message(%{message: message}) when is_binary(message), do: message
+  defp map_message(_value), do: nil
+
+  defp tool_execution_status(nil), do: "running"
+  defp tool_execution_status(%ToolExecution{status: status}), do: status
+
+  defp tool_entry_timestamp(nil), do: nil
+  defp tool_entry_timestamp(%ToolExecution{started_at: %DateTime{} = started_at}), do: started_at
+
+  defp tool_entry_timestamp(%ToolExecution{inserted_at: %DateTime{} = inserted_at}),
+    do: inserted_at
+
+  defp tool_entry_timestamp(_tool_execution), do: nil
+
+  defp tool_result_timestamp(%ToolExecution{completed_at: %DateTime{} = completed_at}),
+    do: completed_at
+
+  defp tool_result_timestamp(%ToolExecution{updated_at: %DateTime{} = updated_at}), do: updated_at
+
+  defp tool_result_timestamp(%ToolExecution{inserted_at: %DateTime{} = inserted_at}),
+    do: inserted_at
+
+  defp tool_result_timestamp(_tool_execution), do: nil
+
+  defp extract_system_prompt(messages) do
+    messages
+    |> Enum.find(fn message -> message["role"] == "system" end)
+    |> case do
+      %{"content" => content} -> content
+      _other -> nil
+    end
+  end
+
+  defp llm_response_title(1), do: "LLM -> App"
+  defp llm_response_title(retry_attempt), do: "LLM -> App (retry #{retry_attempt})"
+
+  defp renumber_timeline(entries) do
+    entries
+    |> Enum.with_index(1)
+    |> Enum.map(fn {entry, index} ->
+      Map.put(entry, :title, "#{index}. #{strip_timeline_prefix(entry.title)}")
+    end)
+  end
+
+  defp strip_timeline_prefix(title) when is_binary(title) do
+    Regex.replace(~r/^\d+\.\s+/, title, "")
+  end
+
+  defp present?(value) when is_binary(value), do: value != ""
+  defp present?(_value), do: false
+
+  defp interaction_timeline_source_copy(:live_executor_trace) do
+    "Source: live executor trace"
+  end
+
+  defp interaction_timeline_source_copy(:persisted_history_only) do
+    "Source: persisted transcript/tool history only"
+  end
+
+  defp interaction_timeline_source_copy(_source) do
+    "Source: unavailable"
+  end
+
+  defp model_request_source_copy(:live_executor_trace) do
+    "Source: exact latest live request"
+  end
+
+  defp model_request_source_copy(:runtime_state) do
+    "Source: live executor snapshot"
+  end
+
+  defp model_request_source_copy(:transcript_reconstruction) do
+    "Source: reconstructed from persisted transcript"
+  end
+
+  defp model_request_source_copy(_source) do
+    "Source: unavailable"
+  end
+
+  defp timeline_timestamp(nil), do: nil
+  defp timeline_timestamp(%DateTime{} = timestamp), do: Calendar.strftime(timestamp, "%H:%M:%S")
+
+  defp timeline_entry_status_class("ok"),
+    do: "border-emerald-400/40 bg-emerald-400/10 text-emerald-200"
+
+  defp timeline_entry_status_class("error"), do: "border-rose-400/40 bg-rose-400/10 text-rose-200"
+
+  defp timeline_entry_status_class("running"),
+    do: "border-amber-300/40 bg-amber-300/10 text-amber-100"
+
+  defp timeline_entry_status_class(_status), do: "border-zinc-700 bg-zinc-900 text-zinc-300"
+
+  defp resolve_world(%{"world" => world_id}) when is_binary(world_id) and world_id != "" do
+    Worlds.get_world(world_id)
+  end
+
+  defp resolve_world(_params), do: Worlds.get_default_world()
+
+  defp maybe_subscribe_instance(socket, instance) do
+    connected? = connected?(socket)
+    subscribed_instance_id = socket.assigns.subscribed_instance_id
+
+    if connected? and subscribed_instance_id != instance.id do
+      :ok = PubSub.subscribe_instance(instance.id)
+      :ok = PubSub.subscribe_instance_messages(instance.id)
+      assign(socket, subscribed_instance_id: instance.id)
+    else
+      socket
+    end
+  end
+
+  defp maybe_reload_instance(
+         %{assigns: %{instance: %{id: instance_id}, world: world}} = socket,
+         instance_id
+       )
+       when is_struct(world, World) do
+    load_world_instance(socket, instance_id, world)
+  end
+
+  defp maybe_reload_instance(socket, _instance_id), do: socket
+
+  defp assign_not_found(socket) do
+    assign(socket,
+      world: nil,
+      instance: nil,
+      runtime_state: nil,
+      model_steps: [],
+      interaction_timeline: [],
+      interaction_timeline_source: nil,
+      model_request: nil,
+      model_request_source: nil,
+      subscribed_instance_id: nil,
+      instance_not_found?: true,
+      parent_lemming_path: nil,
+      session_path: nil,
+      shell_breadcrumb: default_shell_breadcrumb(:lemmings)
+    )
+  end
+
+  defp build_shell_breadcrumb(instance, session_path, raw_path) do
+    [
+      shell_item(:lemmings, "/lemmings"),
+      shell_item(parent_lemming_name(instance), parent_lemming_path(instance)),
+      shell_item(instance.id, session_path),
+      shell_item(dgettext("lemmings", "Raw Context"), raw_path)
+    ]
+  end
+
+  defp parent_lemming_path(%{lemming_id: lemming_id}) when is_binary(lemming_id),
+    do: ~p"/lemmings/#{lemming_id}"
+
+  defp parent_lemming_path(_instance), do: ~p"/lemmings"
+
+  defp parent_lemming_name(%{lemming: %{name: name}}) when is_binary(name) and name != "",
+    do: name
+
+  defp parent_lemming_name(%{lemming: %{id: id}}) when is_binary(id), do: id
+  defp parent_lemming_name(%{lemming_id: lemming_id}) when is_binary(lemming_id), do: lemming_id
+  defp parent_lemming_name(_instance), do: dgettext("world", ".label_not_available")
+
+  defp json_payload(nil), do: "{}"
+  defp json_payload(payload), do: Jason.encode!(payload, pretty: true)
+end

--- a/lib/lemmings_os_web/live/instance_raw_live.html.heex
+++ b/lib/lemmings_os_web/live/instance_raw_live.html.heex
@@ -1,0 +1,237 @@
+<Layouts.app
+  flash={@flash}
+  current_scope={@current_scope}
+  page_key={@page_key}
+  page_title={@page_title}
+  shell_user={@shell_user}
+  shell_host={@shell_host}
+  shell_breadcrumb={@shell_breadcrumb}
+  summary={@summary}
+>
+  <div id="instance-raw-page" class="flex min-h-0 w-full flex-col gap-6">
+    <section
+      :if={@instance_not_found?}
+      id="instance-raw-not-found"
+      class="border-2 border-amber-400/40 bg-zinc-950/85 p-6 shadow-xl"
+      role="alert"
+    >
+      <p class="text-lg font-semibold text-zinc-50">
+        {dgettext("lemmings", "Instance not found")}
+      </p>
+      <p class="mt-2 text-sm leading-6 text-zinc-400">
+        {dgettext(
+          "lemmings",
+          "The requested runtime session could not be loaded for this world scope."
+        )}
+      </p>
+    </section>
+
+    <section
+      :if={!@instance_not_found?}
+      class="flex min-h-0 flex-col gap-6 border border-emerald-400/20 bg-zinc-950/95 p-5"
+    >
+      <div class="flex flex-wrap items-start justify-between gap-4 border-b border-emerald-400/10 pb-4">
+        <div class="space-y-2">
+          <p class="text-xs uppercase tracking-widest text-zinc-500">
+            {dgettext("lemmings", "Runtime debug surface")}
+          </p>
+          <h1 class="text-2xl font-semibold tracking-tight text-zinc-50">
+            {dgettext("lemmings", "Raw Context")}
+          </h1>
+          <p class="max-w-3xl text-sm leading-7 text-zinc-400">
+            {dgettext(
+              "lemmings",
+              "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
+            )}
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-3">
+          <.link
+            :if={@session_path}
+            id="instance-raw-session-link"
+            navigate={@session_path}
+            class="inline-flex min-h-11 items-center gap-2 border border-sky-400/40 bg-sky-400/10 px-4 py-2 text-xs font-medium uppercase tracking-widest text-sky-300 transition duration-150 ease-out hover:-translate-y-px hover:border-sky-300 hover:text-sky-200"
+          >
+            <.icon name="hero-arrow-left" class="size-4" />
+            {dgettext("lemmings", "Back to session")}
+          </.link>
+        </div>
+      </div>
+
+      <section id="instance-raw-interaction-timeline" class="space-y-4">
+        <div class="space-y-2">
+          <p class="text-xs uppercase tracking-widest text-zinc-500">
+            {dgettext("lemmings", "Interaction timeline")}
+          </p>
+          <p
+            id="instance-raw-interaction-timeline-source"
+            class="text-xs leading-6 text-zinc-500"
+          >
+            {interaction_timeline_source_copy(@interaction_timeline_source)}
+          </p>
+          <p
+            :if={@interaction_timeline_source == :persisted_history_only}
+            id="instance-raw-interaction-timeline-warning"
+            class="text-xs leading-6 text-amber-200"
+          >
+            {dgettext(
+              "lemmings",
+              "Live executor trace is unavailable. This fallback only shows persisted transcript and tool rows, not every intermediate LLM turn."
+            )}
+          </p>
+        </div>
+
+        <div
+          :if={Enum.empty?(@interaction_timeline)}
+          id="instance-raw-interaction-empty"
+          class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4 text-sm leading-7 text-zinc-500"
+        >
+          {dgettext("lemmings", "No interaction trace is available yet.")}
+        </div>
+
+        <div :if={!Enum.empty?(@interaction_timeline)} class="space-y-4">
+          <article
+            :for={entry <- @interaction_timeline}
+            id={"timeline-entry-#{entry.id}"}
+            class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4"
+          >
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div class="space-y-2">
+                <div class="flex flex-wrap items-center gap-3">
+                  <p class="text-sm font-semibold tracking-wide text-zinc-50">{entry.title}</p>
+                  <p
+                    :if={entry.timestamp}
+                    class="text-[11px] uppercase tracking-[0.25em] text-zinc-500"
+                  >
+                    {timeline_timestamp(entry.timestamp)}
+                  </p>
+                </div>
+                <p class="text-sm text-emerald-200">{entry.summary}</p>
+              </div>
+
+              <span
+                :if={entry.status}
+                class={[
+                  "inline-flex items-center border px-2 py-1 text-[10px] uppercase tracking-[0.3em]",
+                  timeline_entry_status_class(entry.status)
+                ]}
+              >
+                {entry.status}
+              </span>
+            </div>
+
+            <div
+              :if={entry.body}
+              class="mt-3 whitespace-pre-wrap text-sm leading-7 text-zinc-300"
+            >
+              {entry.body}
+            </div>
+
+            <div :if={entry.meta != []} class="mt-4 flex flex-wrap gap-2">
+              <span
+                :for={meta <- entry.meta}
+                class="inline-flex items-center border border-zinc-700 bg-zinc-900 px-2 py-1 text-[10px] uppercase tracking-[0.25em] text-zinc-400"
+              >
+                {meta}
+              </span>
+            </div>
+
+            <details :if={entry.raw_sections != []} class="mt-4 border-t border-zinc-800 pt-4">
+              <summary class="cursor-pointer list-none text-xs uppercase tracking-[0.25em] text-zinc-500">
+                {dgettext("lemmings", "Inspect raw details")}
+              </summary>
+
+              <div class="mt-4 space-y-4">
+                <div
+                  :for={section <- entry.raw_sections}
+                  :if={not is_nil(section.payload)}
+                  class="space-y-2"
+                >
+                  <p class="text-[11px] uppercase tracking-[0.25em] text-zinc-500">
+                    {section.label}
+                  </p>
+                  <pre
+                    class="overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950 p-3 text-xs leading-6 text-zinc-300"
+                    phx-no-curly-interpolation
+                  ><%= json_payload(section.payload) %></pre>
+                </div>
+              </div>
+            </details>
+          </article>
+        </div>
+      </section>
+
+      <div class="grid gap-6 xl:grid-cols-2">
+        <section id="instance-raw-model-request" class="space-y-3 xl:col-span-2">
+          <details class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4">
+            <summary class="cursor-pointer list-none">
+              <p class="text-xs uppercase tracking-widest text-zinc-500">
+                {dgettext("lemmings", "Latest provider request")}
+              </p>
+              <p
+                id="instance-raw-model-request-source"
+                class="mt-2 text-xs leading-6 text-zinc-500"
+              >
+                {model_request_source_copy(@model_request_source)}
+              </p>
+            </summary>
+
+            <pre
+              class="mt-4 overflow-x-auto rounded-2xl border border-zinc-800 bg-zinc-950 p-4 text-xs leading-6 text-zinc-300"
+              phx-no-curly-interpolation
+            ><%= json_payload(@model_request) %></pre>
+          </details>
+        </section>
+
+        <section id="instance-raw-context-messages" class="space-y-3">
+          <details class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4">
+            <summary class="cursor-pointer list-none text-xs uppercase tracking-widest text-zinc-500">
+              {dgettext("lemmings", "Context messages")}
+            </summary>
+            <pre
+              class="mt-4 overflow-x-auto rounded-2xl border border-zinc-800 bg-zinc-950 p-4 text-xs leading-6 text-zinc-300"
+              phx-no-curly-interpolation
+            ><%= json_payload(@runtime_state[:context_messages]) %></pre>
+          </details>
+        </section>
+
+        <section id="instance-raw-current-item" class="space-y-3">
+          <details class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4">
+            <summary class="cursor-pointer list-none text-xs uppercase tracking-widest text-zinc-500">
+              {dgettext("lemmings", "Current item")}
+            </summary>
+            <pre
+              class="mt-4 overflow-x-auto rounded-2xl border border-zinc-800 bg-zinc-950 p-4 text-xs leading-6 text-zinc-300"
+              phx-no-curly-interpolation
+            ><%= json_payload(@runtime_state[:current_item]) %></pre>
+          </details>
+        </section>
+
+        <section id="instance-raw-runtime-state" class="space-y-3">
+          <details class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4">
+            <summary class="cursor-pointer list-none text-xs uppercase tracking-widest text-zinc-500">
+              {dgettext("lemmings", "Runtime state")}
+            </summary>
+            <pre
+              class="mt-4 overflow-x-auto rounded-2xl border border-zinc-800 bg-zinc-950 p-4 text-xs leading-6 text-zinc-300"
+              phx-no-curly-interpolation
+            ><%= json_payload(@runtime_state) %></pre>
+          </details>
+        </section>
+
+        <section id="instance-raw-config-snapshot" class="space-y-3">
+          <details class="rounded-2xl border border-zinc-800 bg-zinc-950/80 p-4">
+            <summary class="cursor-pointer list-none text-xs uppercase tracking-widest text-zinc-500">
+              {dgettext("lemmings", "Config snapshot")}
+            </summary>
+            <pre
+              class="mt-4 overflow-x-auto rounded-2xl border border-zinc-800 bg-zinc-950 p-4 text-xs leading-6 text-zinc-300"
+              phx-no-curly-interpolation
+            ><%= json_payload(@instance.config_snapshot) %></pre>
+          </details>
+        </section>
+      </div>
+    </section>
+  </div>
+</Layouts.app>

--- a/lib/lemmings_os_web/live/tools_live.ex
+++ b/lib/lemmings_os_web/live/tools_live.ex
@@ -3,6 +3,7 @@ defmodule LemmingsOsWeb.ToolsLive do
 
   import LemmingsOsWeb.MockShell
 
+  alias LemmingsOs.Helpers
   alias LemmingsOsWeb.PageData.ToolsPageSnapshot
 
   def mount(_params, _session, socket) do
@@ -19,26 +20,21 @@ defmodule LemmingsOsWeb.ToolsLive do
   end
 
   defp assign_tools_snapshot(socket, snapshot, query) do
+    filtered_tools = filter_tools(snapshot.tools, query)
+
     assign(socket,
       snapshot: snapshot,
       filter: query,
       filter_form: build_filter_form(query),
-      filtered_tools: filter_tools(snapshot.tools, query)
+      filtered_tools: filtered_tools,
+      grouped_tools: group_tools(filtered_tools)
     )
   end
 
   defp build_snapshot do
     ToolsPageSnapshot.build(
-      runtime_fetcher: runtime_fetcher(),
+      runtime_fetcher: LemmingsOs.Tools.DefaultRuntimeFetcher,
       policy_fetcher: policy_fetcher()
-    )
-  end
-
-  defp runtime_fetcher do
-    Application.get_env(
-      :lemmings_os,
-      :tools_runtime_fetcher,
-      LemmingsOs.Tools.DefaultRuntimeFetcher
     )
   end
 
@@ -65,6 +61,15 @@ defmodule LemmingsOsWeb.ToolsLive do
         |> String.downcase()
 
       String.contains?(searchable_text, normalized_query)
+    end)
+  end
+
+  defp group_tools(tools) do
+    tools
+    |> Enum.group_by(&Helpers.display_value(&1.category, unavailable_label: "uncategorized"))
+    |> Enum.sort_by(fn {category, _tools} -> category end)
+    |> Enum.map(fn {category, grouped_tools} ->
+      %{category: String.capitalize(category), tools: Enum.sort_by(grouped_tools, & &1.name)}
     end)
   end
 
@@ -158,4 +163,13 @@ defmodule LemmingsOsWeb.ToolsLive do
   defp mini_card_meta_class do
     "text-xs uppercase tracking-widest text-zinc-400"
   end
+
+  defp tool_list_item_copy(tool_name, risk) do
+    dgettext("layout", ".tools_list_item_copy", name: tool_name, risk: risk_label(risk))
+  end
+
+  defp risk_label("high"), do: dgettext("layout", ".tools_risk_high")
+  defp risk_label("medium"), do: dgettext("layout", ".tools_risk_medium")
+  defp risk_label("low"), do: dgettext("layout", ".tools_risk_low")
+  defp risk_label(_risk), do: dgettext("layout", ".tools_risk_unknown")
 end

--- a/lib/lemmings_os_web/live/tools_live.html.heex
+++ b/lib/lemmings_os_web/live/tools_live.html.heex
@@ -51,72 +51,104 @@
       </div>
     </.panel>
 
-    <.content_grid id="tools-content-grid" columns="sidebar">
-      <.panel id="tools-grid-panel">
-        <:title>{dgettext("layout", ".tools_capability_panel_title")}</:title>
-        <:subtitle>{dgettext("layout", ".tools_capability_panel_subtitle")}</:subtitle>
-        <:actions>
-          <.form
-            for={@filter_form}
-            id="tools-filter-form"
-            class="ml-auto w-full sm:max-w-sm"
-            phx-change="filter_tools"
-          >
-            <.input
-              field={@filter_form[:query]}
-              id="tools-filter-input"
-              type="search"
-              label={dgettext("layout", ".tools_filter_label")}
-              placeholder={dgettext("layout", ".tools_filter_placeholder")}
-              phx-debounce={250}
-            />
-          </.form>
-        </:actions>
-
-        <div :if={@filtered_tools == []} class="flex min-h-72 items-center justify-center">
-          <.empty_state
-            id="tools-empty-state"
-            title={empty_state_title(@filter, @snapshot.runtime.status)}
-            copy={empty_state_copy(@filter, @snapshot.runtime.status)}
+    <.panel id="tools-grid-panel">
+      <:title>{dgettext("layout", ".tools_capability_panel_title")}</:title>
+      <:subtitle>{dgettext("layout", ".tools_capability_panel_subtitle")}</:subtitle>
+      <:actions>
+        <.form
+          for={@filter_form}
+          id="tools-filter-form"
+          class="ml-auto w-full sm:max-w-sm"
+          phx-change="filter_tools"
+        >
+          <.input
+            field={@filter_form[:query]}
+            id="tools-filter-input"
+            type="search"
+            label={dgettext("layout", ".tools_filter_label")}
+            placeholder={dgettext("layout", ".tools_filter_placeholder")}
+            phx-debounce={250}
           />
-        </div>
+        </.form>
+      </:actions>
 
-        <div
-          :if={@filtered_tools != []}
-          class="grid gap-4 md:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2"
+      <div :if={@filtered_tools == []} class="flex min-h-72 items-center justify-center">
+        <.empty_state
+          id="tools-empty-state"
+          title={empty_state_title(@filter, @snapshot.runtime.status)}
+          copy={empty_state_copy(@filter, @snapshot.runtime.status)}
+        />
+      </div>
+
+      <div
+        :if={@filtered_tools != []}
+        id="tools-grouped-list"
+        class="flex flex-col gap-4"
+      >
+        <article
+          :for={group <- @grouped_tools}
+          id={"tool-group-#{String.downcase(group.category)}"}
+          class={mini_card_class()}
         >
-          <SystemComponents.tool_runtime_card :for={tool <- @filtered_tools} tool={tool} />
-        </div>
-      </.panel>
-
-      <.panel id="tools-issues-panel">
-        <:title>{dgettext("layout", ".tools_issues_panel_title")}</:title>
-        <:subtitle>{dgettext("layout", ".tools_issues_panel_subtitle")}</:subtitle>
-
-        <div
-          :if={@snapshot.issues == []}
-          class="flex min-h-72 items-center justify-center px-6 py-8 text-center"
-        >
-          <p class={mini_card_meta_class()}>{dgettext("layout", ".tools_no_issues")}</p>
-        </div>
-
-        <div :if={@snapshot.issues != []} class="flex flex-col gap-4">
-          <article
-            :for={issue <- @snapshot.issues}
-            id={"tools-issue-#{issue.code}"}
-            class={mini_card_class()}
-          >
-            <div class="flex items-start justify-between gap-3">
+          <h3 class={mini_card_title_class()}>{group.category}</h3>
+          <ul class="mt-3 space-y-2">
+            <li
+              :for={tool <- group.tools}
+              id={"tool-list-item-#{tool.id}"}
+              class="flex items-start gap-2 text-sm text-zinc-200"
+            >
+              <.icon
+                :if={not Helpers.blank?(tool.icon)}
+                name={tool.icon}
+                class="size-4 text-zinc-400"
+              />
+              <.icon
+                :if={Helpers.blank?(tool.icon)}
+                name="hero-wrench-screwdriver"
+                class="size-4 text-zinc-400"
+              />
               <div class="min-w-0">
-                <div class={mini_card_title_class()}>{issue_summary(issue)}</div>
-                <p class={mini_card_meta_class()}>{issue_detail(issue, @snapshot)}</p>
+                <p>{tool_list_item_copy(tool.name, tool.risk)}</p>
+                <p
+                  id={"tool-list-description-#{tool.id}"}
+                  class="text-xs text-zinc-400"
+                >
+                  {tool.description || dgettext("layout", ".tools_description_unavailable")}
+                </p>
               </div>
-              <.status kind={:issue} value={issue.severity} />
+            </li>
+          </ul>
+        </article>
+      </div>
+    </.panel>
+
+    <.panel id="tools-issues-panel">
+      <:title>{dgettext("layout", ".tools_issues_panel_title")}</:title>
+      <:subtitle>{dgettext("layout", ".tools_issues_panel_subtitle")}</:subtitle>
+
+      <div
+        :if={@snapshot.issues == []}
+        class="flex min-h-72 items-center justify-center px-6 py-8 text-center"
+      >
+        <p class={mini_card_meta_class()}>{dgettext("layout", ".tools_no_issues")}</p>
+      </div>
+
+      <div :if={@snapshot.issues != []} class="flex flex-col gap-4">
+        <article
+          :for={issue <- @snapshot.issues}
+          id={"tools-issue-#{issue.code}"}
+          class={mini_card_class()}
+        >
+          <div class="flex items-start justify-between gap-3">
+            <div class="min-w-0">
+              <div class={mini_card_title_class()}>{issue_summary(issue)}</div>
+              <p class={mini_card_meta_class()}>{issue_detail(issue, @snapshot)}</p>
             </div>
-            <p class="mt-3 text-sm text-zinc-400">{issue_action(issue)}</p>
-          </article>
-        </div>
-      </.panel>
-    </.content_grid>
+            <.status kind={:issue} value={issue.severity} />
+          </div>
+          <p class="mt-3 text-sm text-zinc-400">{issue_action(issue)}</p>
+        </article>
+      </div>
+    </.panel>
   </.content_container>
 </Layouts.app>

--- a/lib/lemmings_os_web/router.ex
+++ b/lib/lemmings_os_web/router.ex
@@ -30,6 +30,8 @@ defmodule LemmingsOsWeb.Router do
     live "/lemmings/import", ImportLemmingLive, :import
     live "/lemmings", LemmingsLive, :index
     live "/lemmings/:id", LemmingsLive, :show
+    get "/lemmings/instances/:id/artifacts/*path", InstanceArtifactController, :show
+    live "/lemmings/instances/:id/raw", InstanceRawLive, :show
     live "/lemmings/instances/:id", InstanceLive, :show
     live "/tools", ToolsLive, :index
     live "/logs", LogsLive, :index

--- a/lib/lemmings_os_web/telemetry.ex
+++ b/lib/lemmings_os_web/telemetry.ex
@@ -91,6 +91,11 @@ defmodule LemmingsOsWeb.Telemetry do
       last_value("lemmings_os.runtime.instances.expired"),
       sum("lemmings_os.runtime.session.spawn.count"),
       sum("lemmings_os.runtime.session.recovered.count"),
+      sum("lemmings_os.runtime.tool_execution.started.count"),
+      sum("lemmings_os.runtime.tool_execution.completed.count"),
+      sum("lemmings_os.runtime.tool_execution.failed.count"),
+      summary("lemmings_os.runtime.tool_execution.completed.duration_ms"),
+      summary("lemmings_os.runtime.tool_execution.failed.duration_ms"),
 
       # VM Metrics
       summary("vm.memory.total", unit: {:byte, :kilobyte}),

--- a/llms/tasks/0006_implement_tool_runtime_mvp/01_backend_persistence_and_work_area.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/01_backend_persistence_and_work_area.md
@@ -1,8 +1,8 @@
 # Task 01: Backend Persistence And Work Area
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer`
@@ -11,7 +11,7 @@
 Act as `dev-backend-elixir-engineer` following `llms/constitution.md` and implement the persistence changes for Tool Runtime MVP.
 
 ## Objective
-Add the minimal durable backend support for tool execution history and per-instance work area persistence/creation at spawn time.
+Add the minimal durable backend support for tool execution history and per-instance work area creation at spawn time.
 
 ## Inputs Required
 
@@ -22,13 +22,12 @@ Add the minimal durable backend support for tool execution history and per-insta
 
 ## Expected Outputs
 
-- [ ] Migration(s) for runtime session work area persistence and durable tool execution history
+- [ ] Migration(s) for durable tool execution history and any required work area schema cleanup
 - [ ] Schema/context support for the new persistence needs
 - [ ] Spawn-time work area creation wired into the runtime flow
 
 ## Acceptance Criteria
 
-- [ ] Runtime sessions persist their work area location relative to `/workspace`
 - [ ] Work area creation happens at spawn time
 - [ ] Tool execution history is persisted durably and linked to the runtime session and world scope
 - [ ] New public context APIs remain explicitly world-scoped
@@ -48,7 +47,7 @@ Add the minimal durable backend support for tool execution history and per-insta
 
 ### For the Human Reviewer
 1. Verify durable tool execution history exists.
-2. Verify work area persistence is relative to `/workspace`.
+2. Verify work area creation uses the configured runtime workspace root.
 3. Verify scope stays within the MVP slice.
 
 ---

--- a/llms/tasks/0006_implement_tool_runtime_mvp/01_backend_persistence_and_work_area.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/01_backend_persistence_and_work_area.md
@@ -1,0 +1,60 @@
+# Task 01: Backend Persistence And Work Area
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer`
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer` following `llms/constitution.md` and implement the persistence changes for Tool Runtime MVP.
+
+## Objective
+Add the minimal durable backend support for tool execution history and per-instance work area persistence/creation at spawn time.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] `lib/lemmings_os/lemming_instances.ex`
+- [ ] `lib/lemmings_os/lemming_instances/lemming_instance.ex`
+- [ ] Current runtime spawn flow and migrations patterns
+
+## Expected Outputs
+
+- [ ] Migration(s) for runtime session work area persistence and durable tool execution history
+- [ ] Schema/context support for the new persistence needs
+- [ ] Spawn-time work area creation wired into the runtime flow
+
+## Acceptance Criteria
+
+- [ ] Runtime sessions persist their work area location relative to `/workspace`
+- [ ] Work area creation happens at spawn time
+- [ ] Tool execution history is persisted durably and linked to the runtime session and world scope
+- [ ] New public context APIs remain explicitly world-scoped
+
+## Technical Notes
+
+### Constraints
+- Keep the persistence slice limited to this MVP
+- Do not implement approvals, MCP, Docker sandboxing, or broader tool governance
+
+## Execution Instructions
+
+### For the Agent
+1. Add the required persistence changes.
+2. Wire spawn-time work area creation into the runtime/session flow.
+3. Expose the minimum context support needed by later tasks.
+
+### For the Human Reviewer
+1. Verify durable tool execution history exists.
+2. Verify work area persistence is relative to `/workspace`.
+3. Verify scope stays within the MVP slice.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/02_backend_tool_catalog_and_adapters.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/02_backend_tool_catalog_and_adapters.md
@@ -1,8 +1,8 @@
 # Task 02: Backend Tool Catalog And Adapters
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer`

--- a/llms/tasks/0006_implement_tool_runtime_mvp/02_backend_tool_catalog_and_adapters.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/02_backend_tool_catalog_and_adapters.md
@@ -1,0 +1,62 @@
+# Task 02: Backend Tool Catalog And Adapters
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer`
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer` following `llms/constitution.md` and implement the fixed Tool Runtime catalog and MVP tool adapters.
+
+## Objective
+Implement the fixed four-tool catalog and the backend execution support for `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch`.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 01 outputs
+- [ ] Existing `lib/lemmings_os/tools/` registry seam
+- [ ] Existing runtime/config conventions
+
+## Expected Outputs
+
+- [ ] Fixed global tool catalog for this PR
+- [ ] Structured arg validation and normalized success/error handling for the four approved tools
+- [ ] Backend adapters for filesystem and web tools using project conventions
+
+## Acceptance Criteria
+
+- [ ] Only the four approved tools are executable
+- [ ] Filesystem tools enforce workspace-relative paths
+- [ ] Web tools use `Req`
+- [ ] Success and error outcomes are normalized consistently
+- [ ] The runtime-facing catalog can be reused by the tools page later
+
+## Technical Notes
+
+### Constraints
+- No `exec.run`
+- No shell execution path
+- No catalog expansion beyond the approved four tools
+
+## Execution Instructions
+
+### For the Agent
+1. Implement the fixed catalog definition.
+2. Implement adapters and arg validation for the four approved tools.
+3. Keep the result/error contract stable enough for executor/UI use.
+
+### For the Human Reviewer
+1. Verify only four tools are present.
+2. Verify `Req` is used for web behavior.
+3. Verify path handling remains within `/workspace`.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/03_backend_executor_tool_loop.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/03_backend_executor_tool_loop.md
@@ -1,0 +1,61 @@
+# Task 03: Backend Executor Tool Loop
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer`
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer` following `llms/constitution.md` and implement the executor/model integration for the Tool Runtime MVP loop.
+
+## Objective
+Extend the existing executor/model runtime path so the session can handle the minimum `tool_call` loop needed for this PR and continue toward a final assistant reply.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 01 outputs
+- [ ] Task 02 outputs
+- [ ] `lib/lemmings_os/lemming_instances/executor.ex`
+- [ ] `lib/lemmings_os/model_runtime.ex`
+
+## Expected Outputs
+
+- [ ] Minimum model runtime support for `tool_call`
+- [ ] Executor integration with the direct tool runtime boundary
+- [ ] Persisted/broadcast tool lifecycle handling wired into the runtime loop
+
+## Acceptance Criteria
+
+- [ ] Executor uses a direct runtime call path for tool execution
+- [ ] PubSub is not used as the primary execution mechanism
+- [ ] The runtime can process the minimum tool-call loop needed by this MVP
+- [ ] Tool execution outcomes are available to continued reasoning and final reply generation
+
+## Technical Notes
+
+### Constraints
+- Keep the loop limited to the MVP tool slice
+- Do not add general workflow orchestration, approvals, or delegation
+
+## Execution Instructions
+
+### For the Agent
+1. Extend the model/runtime contract just enough for MVP tool calls.
+2. Wire the executor to the backend tool runtime boundary.
+3. Ensure persisted lifecycle state is compatible with later UI tasks.
+
+### For the Human Reviewer
+1. Verify the executor remains the primary runtime owner.
+2. Verify the tool-call loop is minimal and scope-controlled.
+3. Verify no extra orchestration features are introduced.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/03_backend_executor_tool_loop.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/03_backend_executor_tool_loop.md
@@ -1,8 +1,8 @@
 # Task 03: Backend Executor Tool Loop
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer`

--- a/llms/tasks/0006_implement_tool_runtime_mvp/04_backend_observability_and_runtime_visibility.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/04_backend_observability_and_runtime_visibility.md
@@ -1,0 +1,62 @@
+# Task 04: Backend Observability And Runtime Visibility
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-logging-daily-guardian`
+
+## Agent Invocation
+Act as `dev-logging-daily-guardian` following `llms/constitution.md` and implement the observability slice for Tool Runtime MVP.
+
+## Objective
+Add logging, telemetry, metrics, and runtime/operator visibility for tool execution lifecycle transitions.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Tasks 01 through 03 outputs
+- [ ] `lib/lemmings_os/lemming_instances/telemetry.ex`
+- [ ] `lib/lemmings_os/runtime/activity_log.ex`
+- [ ] `lib/lemmings_os_web/telemetry.ex`
+
+## Expected Outputs
+
+- [ ] Structured logs for tool lifecycle transitions
+- [ ] Telemetry events for started/completed/failed tool executions
+- [ ] Metrics for volume, success/error rate, and durations
+- [ ] Runtime-facing operator visibility aligned with existing patterns
+
+## Acceptance Criteria
+
+- [ ] Tool lifecycle transitions are logged
+- [ ] Telemetry includes hierarchy metadata plus tool identity
+- [ ] Metrics cover count, success/error, and duration
+- [ ] Historical runtime visibility is available beyond live PubSub events
+
+## Technical Notes
+
+### Constraints
+- Avoid logging sensitive payloads
+- Reuse existing runtime observability patterns
+
+## Execution Instructions
+
+### For the Agent
+1. Add lifecycle logs and telemetry for tool execution.
+2. Extend runtime metrics/reporting surfaces as needed for this MVP.
+3. Keep the observability contract aligned to current runtime conventions.
+
+### For the Human Reviewer
+1. Verify logs, telemetry, and metrics all exist.
+2. Verify metadata includes runtime hierarchy context.
+3. Verify observability covers failures as well as success cases.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/04_backend_observability_and_runtime_visibility.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/04_backend_observability_and_runtime_visibility.md
@@ -1,8 +1,8 @@
 # Task 04: Backend Observability And Runtime Visibility
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-logging-daily-guardian`

--- a/llms/tasks/0006_implement_tool_runtime_mvp/05_backend_tests_persistence_and_adapters.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/05_backend_tests_persistence_and_adapters.md
@@ -1,7 +1,7 @@
 # Task 05: Backend Tests Persistence And Adapters
 
 ## Status
-- **Status**: ⏳ PENDING
+- **Status**: ✅ COMPLETED
 - **Approved**: [ ] Human sign-off
 
 ## Assigned Agent
@@ -15,25 +15,25 @@ Add deterministic backend tests for the persistence and adapter work from Tasks 
 
 ## Inputs Required
 
-- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
-- [ ] Task 01 outputs
-- [ ] Task 02 outputs
-- [ ] Existing backend/runtime test patterns
-- [ ] `test/support/factory.ex`
+- [x] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [x] Task 01 outputs
+- [x] Task 02 outputs
+- [x] Existing backend/runtime test patterns
+- [x] `test/support/factory.ex`
 
 ## Expected Outputs
 
-- [ ] ExUnit coverage for new persistence behavior
-- [ ] ExUnit coverage for work area behavior
-- [ ] ExUnit coverage for the four MVP tool adapters
+- [x] ExUnit coverage for new persistence behavior
+- [x] ExUnit coverage for work area behavior
+- [x] ExUnit coverage for the four MVP tool adapters
 
 ## Acceptance Criteria
 
-- [ ] Tests cover durable tool execution persistence
-- [ ] Tests cover world-scoped access for new public APIs
-- [ ] Tests cover work area persistence and spawn-time behavior
-- [ ] Tests cover filesystem path boundary handling
-- [ ] Tests cover normalized adapter success/error behavior
+- [x] Tests cover durable tool execution persistence
+- [x] Tests cover world-scoped access for new public APIs
+- [x] Tests cover work area persistence and spawn-time behavior
+- [x] Tests cover filesystem path boundary handling
+- [x] Tests cover normalized adapter success/error behavior
 
 ## Technical Notes
 
@@ -56,7 +56,36 @@ Add deterministic backend tests for the persistence and adapter work from Tasks 
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented deterministic backend test coverage for Task 01/02 persistence + adapters.
+
+### Scenario-to-test mapping
+- Durable tool execution persistence:
+  - `test/lemmings_os/lemming_tools_test.exs`
+  - `S01` verifies durable create/list behavior and chronological ordering.
+  - `S03` verifies persisted completion updates (`status`, `result`, `summary`, `preview`, `completed_at`, `duration_ms`).
+- World-scoped public API enforcement:
+  - `test/lemmings_os/lemming_tools_test.exs`
+  - `S04` verifies world-scope enforcement for `create_tool_execution/3`, `list_tool_executions/3`, `get_tool_execution/4`, and `update_tool_execution/4`.
+- Work area persistence + spawn-time behavior:
+  - Existing coverage retained in `test/lemmings_os/lemming_instances_test.exs` (`S03b`) validating spawn-time work area creation under configured runtime workspace root.
+- Filesystem path boundary handling:
+  - `test/lemmings_os/tools/adapters/filesystem_test.exs`
+  - `S04` absolute path rejection, `S05` upward traversal rejection + no escaped file write, `S06` missing file normalization, `S07` invalid instance scope rejection.
+- Normalized adapter success/error behavior:
+  - `test/lemmings_os/tools/adapters/filesystem_test.exs`
+    - `S01` write success normalization, `S02` read success normalization, `S03` invalid args normalization.
+  - `test/lemmings_os/tools/adapters/web_test.exs`
+    - `S01` search success normalization, `S02` empty result normalization, `S03` invalid args normalization, `S04` search bad-status normalization.
+    - `S05` fetch success normalization, `S06` invalid URL normalization, `S07` fetch bad-status normalization, `S08` transport failure normalization.
+
+### Determinism and external dependency constraints
+- Web adapter tests use `Bypass` only; no real external web calls.
+- Filesystem tests use isolated temp workspace roots with cleanup in `on_exit`.
+
+### Validation run
+- `mix format`
+- `mix test test/lemmings_os/lemming_tools_test.exs test/lemmings_os/tools/adapters/filesystem_test.exs test/lemmings_os/tools/adapters/web_test.exs`
+- `mix precommit`
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/05_backend_tests_persistence_and_adapters.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/05_backend_tests_persistence_and_adapters.md
@@ -1,0 +1,62 @@
+# Task 05: Backend Tests Persistence And Adapters
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author`
+
+## Agent Invocation
+Act as `qa-elixir-test-author` following `llms/constitution.md` and implement backend tests for persistence, work area behavior, and MVP tool adapters.
+
+## Objective
+Add deterministic backend tests for the persistence and adapter work from Tasks 01 and 02.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 01 outputs
+- [ ] Task 02 outputs
+- [ ] Existing backend/runtime test patterns
+- [ ] `test/support/factory.ex`
+
+## Expected Outputs
+
+- [ ] ExUnit coverage for new persistence behavior
+- [ ] ExUnit coverage for work area behavior
+- [ ] ExUnit coverage for the four MVP tool adapters
+
+## Acceptance Criteria
+
+- [ ] Tests cover durable tool execution persistence
+- [ ] Tests cover world-scoped access for new public APIs
+- [ ] Tests cover work area persistence and spawn-time behavior
+- [ ] Tests cover filesystem path boundary handling
+- [ ] Tests cover normalized adapter success/error behavior
+
+## Technical Notes
+
+### Constraints
+- Deterministic tests only
+- No real external web calls
+
+## Execution Instructions
+
+### For the Agent
+1. Add backend tests for persistence and adapters.
+2. Use factories and existing runtime test conventions.
+3. Cover edge/error cases from the plan.
+
+### For the Human Reviewer
+1. Verify persistence and adapter coverage is complete.
+2. Verify workspace path boundaries are tested.
+3. Verify no real external dependency is exercised.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/06_backend_tests_executor_and_observability.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/06_backend_tests_executor_and_observability.md
@@ -1,0 +1,61 @@
+# Task 06: Backend Tests Executor And Observability
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author`
+
+## Agent Invocation
+Act as `qa-elixir-test-author` following `llms/constitution.md` and implement backend tests for the executor tool loop and observability behavior.
+
+## Objective
+Add deterministic backend tests for the runtime tool-call loop and the observability work from Tasks 03 and 04.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 03 outputs
+- [ ] Task 04 outputs
+- [ ] Existing executor/runtime telemetry test patterns
+
+## Expected Outputs
+
+- [ ] ExUnit coverage for the minimum tool-call loop
+- [ ] ExUnit coverage for started/completed/failed lifecycle behavior
+- [ ] ExUnit coverage for telemetry and metrics contracts where appropriate
+
+## Acceptance Criteria
+
+- [ ] Tests cover `tool_call` -> tool result -> continued runtime flow
+- [ ] Tests cover started/completed/failed lifecycle handling
+- [ ] Tests cover telemetry/logging expectations at the backend contract level where appropriate
+- [ ] Tests cover metric emission for count, success/error, and duration where appropriate
+- [ ] Tests remain deterministic and aligned with OTP/runtime testing conventions
+
+## Technical Notes
+
+### Constraints
+- No separate verification task
+- Keep coverage focused on the MVP loop and observability slice
+
+## Execution Instructions
+
+### For the Agent
+1. Add runtime/executor tests for the MVP tool loop.
+2. Add observability contract coverage.
+3. Keep the tests deterministic and consistent with repo runtime tests.
+
+### For the Human Reviewer
+1. Verify the tool-call loop is covered.
+2. Verify lifecycle observability is covered.
+3. Verify tests remain deterministic.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/06_backend_tests_executor_and_observability.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/06_backend_tests_executor_and_observability.md
@@ -1,8 +1,8 @@
 # Task 06: Backend Tests Executor And Observability
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-elixir-test-author`
@@ -15,24 +15,24 @@ Add deterministic backend tests for the runtime tool-call loop and the observabi
 
 ## Inputs Required
 
-- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
-- [ ] Task 03 outputs
-- [ ] Task 04 outputs
-- [ ] Existing executor/runtime telemetry test patterns
+- [x] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [x] Task 03 outputs
+- [x] Task 04 outputs
+- [x] Existing executor/runtime telemetry test patterns
 
 ## Expected Outputs
 
-- [ ] ExUnit coverage for the minimum tool-call loop
-- [ ] ExUnit coverage for started/completed/failed lifecycle behavior
-- [ ] ExUnit coverage for telemetry and metrics contracts where appropriate
+- [x] ExUnit coverage for the minimum tool-call loop
+- [x] ExUnit coverage for started/completed/failed lifecycle behavior
+- [x] ExUnit coverage for telemetry and metrics contracts where appropriate
 
 ## Acceptance Criteria
 
-- [ ] Tests cover `tool_call` -> tool result -> continued runtime flow
-- [ ] Tests cover started/completed/failed lifecycle handling
-- [ ] Tests cover telemetry/logging expectations at the backend contract level where appropriate
-- [ ] Tests cover metric emission for count, success/error, and duration where appropriate
-- [ ] Tests remain deterministic and aligned with OTP/runtime testing conventions
+- [x] Tests cover `tool_call` -> tool result -> continued runtime flow
+- [x] Tests cover started/completed/failed lifecycle handling
+- [x] Tests cover telemetry/logging expectations at the backend contract level where appropriate
+- [x] Tests cover metric emission for count, success/error, and duration where appropriate
+- [x] Tests remain deterministic and aligned with OTP/runtime testing conventions
 
 ## Technical Notes
 
@@ -55,7 +55,37 @@ Add deterministic backend tests for the runtime tool-call loop and the observabi
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented deterministic backend coverage for the executor tool loop and observability slice from Tasks 03 and 04.
+
+### Scenario-to-test mapping
+- Minimum `tool_call` loop:
+  - `test/lemmings_os/lemming_instances/executor_test.exs`
+  - `S08` verifies `tool_call -> runtime execute -> persisted tool result -> continued reasoning -> final assistant reply`.
+  - `S09` verifies `tool_call -> persisted tool error -> continued reasoning -> final assistant reply`.
+  - `S11` adds unsupported-tool coverage (`exec.run`) and verifies the executor persists the normalized `tool.unsupported` failure while still finishing with a final reply.
+- Started/completed/failed lifecycle handling:
+  - `S08` asserts `started` and `completed` telemetry plus persisted `ok` execution state.
+  - `S09` asserts `started` and `failed` telemetry plus persisted `error` execution state.
+  - `S10` asserts structured lifecycle logging for success (`started` and `completed`).
+  - `S11` asserts structured lifecycle logging for unsupported-tool failure (`started` and `failed`).
+- Telemetry/logging expectations:
+  - `test/lemmings_os/lemming_instances/executor_test.exs`
+  - `S08`, `S09`, `S10`, and `S11` assert hierarchy metadata, `tool_name`, status, duration, and stable `reason` tokens where applicable.
+  - `test/lemmings_os/lemming_instances/telemetry_test.exs` retains backend telemetry coverage for runtime-created, executor-started, scheduler, pool, and DETS events.
+- Metric emission/contracts:
+  - `test/lemmings_os_web/telemetry_test.exs`
+  - `metrics/0 includes tool execution lifecycle metrics` verifies count/success-error/duration metric definitions.
+  - `emit_runtime_snapshot/0 emits aggregate runtime instance measurements` verifies the telemetry poller-facing runtime snapshot emits aggregate measurements deterministically.
+
+### Determinism notes
+- Tool-loop tests use injected fake model runtimes and injected tool runtimes only.
+- Observability tests use telemetry attachments, `capture_log/1`, and local DB state only.
+- No real external requests or timing-sensitive sleeps were introduced.
+
+### Validation run
+- `mix format`
+- `mix test test/lemmings_os/lemming_instances/executor_test.exs test/lemmings_os/lemming_instances/telemetry_test.exs test/lemmings_os_web/telemetry_test.exs`
+- `mix precommit`
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/07_frontend_transcript_tool_cards.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/07_frontend_transcript_tool_cards.md
@@ -1,0 +1,62 @@
+# Task 07: Frontend Transcript Tool Cards
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-frontend-ui-engineer`
+
+## Agent Invocation
+Act as `dev-frontend-ui-engineer` following `llms/constitution.md` and implement the transcript tool-card UX for Tool Runtime MVP.
+
+## Objective
+Add compact tool execution cards to the instance session transcript, including historical rendering after reload and live lifecycle updates.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Tasks 01 through 04 outputs
+- [ ] `lib/lemmings_os_web/live/instance_live.ex`
+- [ ] Existing transcript component patterns
+
+## Expected Outputs
+
+- [ ] Compact tool cards in the instance transcript
+- [ ] Historical tool execution rendering after reload
+- [ ] Live transcript updates for tool lifecycle changes
+
+## Acceptance Criteria
+
+- [ ] Tool cards render inline in the existing transcript
+- [ ] Cards remain compact and avoid full raw output by default
+- [ ] Cards show tool name, lifecycle state, and summary
+- [ ] Historical persisted tool executions render in chronological order
+- [ ] Cards support inspection of persisted execution details after reload
+- [ ] Live updates reflect runtime lifecycle changes without reload
+
+## Technical Notes
+
+### Constraints
+- Keep the instance session page as the primary operator surface
+- Do not create a separate tool console for this PR
+
+## Execution Instructions
+
+### For the Agent
+1. Extend the instance transcript rendering for tool events.
+2. Keep the UI compact and aligned with current session patterns.
+3. Support both reload-based and live-update-based visibility.
+
+### For the Human Reviewer
+1. Verify the transcript UX stays compact.
+2. Verify reload/history behavior works.
+3. Verify live lifecycle updates appear correctly.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/07_frontend_transcript_tool_cards.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/07_frontend_transcript_tool_cards.md
@@ -1,8 +1,8 @@
 # Task 07: Frontend Transcript Tool Cards
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-frontend-ui-engineer`
@@ -56,7 +56,17 @@ Add compact tool execution cards to the instance session transcript, including h
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented compact transcript tool cards on the instance session page.
+
+### Work Completed
+- Interleaved persisted `ToolExecution` records with transcript messages in chronological order, including historical reload rendering and day dividers.
+- Added live transcript refresh support for `:tool_execution_upserted` PubSub events.
+- Added compact tool execution cards with tool name, lifecycle state, summary, preview, duration, and collapsed persisted detail inspection.
+- Added LiveView tests covering historical reload ordering and live lifecycle updates for tool cards.
+
+### Verification
+- `mix test test/lemmings_os_web/live/instance_live_test.exs`
+- `mix precommit`
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/08_frontend_tools_registry_runtime_catalog.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/08_frontend_tools_registry_runtime_catalog.md
@@ -1,8 +1,8 @@
 # Task 08: Frontend Tools Registry Runtime Catalog
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-frontend-ui-engineer`
@@ -52,7 +52,24 @@ Replace the placeholder tools-page runtime data with the fixed four-tool Tool Ru
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Work Performed
+- Wired `ToolsLive` to the fixed runtime catalog path by using `LemmingsOs.Tools.DefaultRuntimeFetcher` directly for snapshot build.
+- Kept policy fetch behavior unchanged to preserve current tools-page policy/degraded UX.
+- Updated tools LiveView tests to validate the MVP happy path (fixed four-tool catalog) and filtering behavior against the real tool IDs.
+- Updated partial-policy test to assert degraded state using one known policy status over the fixed catalog.
+
+### Files Modified
+- `lib/lemmings_os_web/live/tools_live.ex`
+- `test/lemmings_os_web/live/tools_live_test.exs`
+
+### Verification
+- `mix test test/lemmings_os_web/live/tools_live_test.exs test/lemmings_os_web/page_data/tools_page_snapshot_test.exs test/lemmings_os/tools/catalog_test.exs`
+- `mix precommit`
+
+### Acceptance Criteria Check
+- [x] Tools page renders the fixed four-tool catalog
+- [x] Tools page no longer depends on placeholder runtime fetch behavior for the happy path
+- [x] The page remains aligned with current tools-page UI patterns
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/08_frontend_tools_registry_runtime_catalog.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/08_frontend_tools_registry_runtime_catalog.md
@@ -1,0 +1,58 @@
+# Task 08: Frontend Tools Registry Runtime Catalog
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-frontend-ui-engineer`
+
+## Agent Invocation
+Act as `dev-frontend-ui-engineer` following `llms/constitution.md` and wire the tools registry page to the real MVP runtime catalog.
+
+## Objective
+Replace the placeholder tools-page runtime data with the fixed four-tool Tool Runtime catalog delivered by the backend slice.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 02 outputs
+- [ ] `lib/lemmings_os_web/live/tools_live.ex`
+- [ ] `lib/lemmings_os_web/page_data/tools_page_snapshot.ex`
+
+## Expected Outputs
+
+- [ ] Tools page wired to the real fixed runtime catalog
+- [ ] UI reflects the same four-tool slice used by backend execution
+
+## Acceptance Criteria
+
+- [ ] Tools page renders the fixed four-tool catalog
+- [ ] Tools page no longer depends on placeholder runtime fetch behavior for the happy path
+- [ ] The page remains aligned with current tools-page UI patterns
+
+## Technical Notes
+
+### Constraints
+- Keep this task limited to tools registry/runtime catalog wiring
+- Do not add permissions or policy UI beyond current scope
+
+## Execution Instructions
+
+### For the Agent
+1. Replace the placeholder runtime path with the real catalog path.
+2. Keep the existing tools-page UX stable.
+3. Limit the change to the approved four-tool slice.
+
+### For the Human Reviewer
+1. Verify the tools page reflects the real runtime catalog.
+2. Verify only the four approved tools appear.
+3. Verify no new out-of-scope policy UI is introduced.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/09_frontend_tests_instance_transcript_tool_ux.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/09_frontend_tests_instance_transcript_tool_ux.md
@@ -1,0 +1,60 @@
+# Task 09: Frontend Tests Instance Transcript Tool UX
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author`
+
+## Agent Invocation
+Act as `qa-elixir-test-author` following `llms/constitution.md` and implement LiveView tests for the transcript tool-card UX.
+
+## Objective
+Add frontend test coverage for the instance transcript tool-card behavior introduced in Task 07.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 07 outputs
+- [ ] Existing `instance_live` LiveView tests
+
+## Expected Outputs
+
+- [ ] LiveView coverage for transcript tool cards
+- [ ] LiveView coverage for reload/history behavior
+- [ ] LiveView coverage for live lifecycle updates
+
+## Acceptance Criteria
+
+- [ ] Tests verify tool cards render in the transcript
+- [ ] Tests verify compact lifecycle state and summary rendering
+- [ ] Tests verify historical persisted records render after reload
+- [ ] Tests verify persisted execution details can be inspected after reload
+- [ ] Tests verify live started/completed/failed updates
+
+## Technical Notes
+
+### Constraints
+- Use selector-driven assertions
+- Keep tests deterministic
+
+## Execution Instructions
+
+### For the Agent
+1. Extend `instance_live` coverage for tool-card behavior.
+2. Cover reload/history and live updates.
+3. Keep tests aligned with existing LiveView test patterns.
+
+### For the Human Reviewer
+1. Verify transcript tool-card coverage is complete.
+2. Verify reload and live-update behavior is tested.
+3. Verify tests are selector-driven and deterministic.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/09_frontend_tests_instance_transcript_tool_ux.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/09_frontend_tests_instance_transcript_tool_ux.md
@@ -1,8 +1,8 @@
 # Task 09: Frontend Tests Instance Transcript Tool UX
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-elixir-test-author`
@@ -54,7 +54,30 @@ Add frontend test coverage for the instance transcript tool-card behavior introd
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Work Performed
+- Extended `InstanceLive` LiveView coverage for transcript tool-card UX with explicit failed-lifecycle cases.
+- Added a live update test for `running -> error` tool execution card transitions via PubSub without remount.
+- Added a reload/remount test to verify persisted failed tool execution details remain inspectable.
+
+### Scenario Coverage
+- `S08b` (existing): historical transcript renders tool cards in chronological order.
+- `S08c` (existing): live `running -> ok` updates render without remount.
+- `S08e` (new): live `running -> error` updates render without remount.
+- `S08f` (new): persisted failed execution details render after page reload.
+
+### Files Modified
+- `test/lemmings_os_web/live/instance_live_test.exs`
+
+### Validation
+- `mix test test/lemmings_os_web/live/instance_live_test.exs`
+- `mix precommit`
+
+### Acceptance Criteria Check
+- [x] Tests verify tool cards render in the transcript
+- [x] Tests verify compact lifecycle state and summary rendering
+- [x] Tests verify historical persisted records render after reload
+- [x] Tests verify persisted execution details can be inspected after reload
+- [x] Tests verify live started/completed/failed updates
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/10_frontend_tests_tools_registry_runtime_catalog.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/10_frontend_tests_tools_registry_runtime_catalog.md
@@ -1,0 +1,56 @@
+# Task 10: Frontend Tests Tools Registry Runtime Catalog
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author`
+
+## Agent Invocation
+Act as `qa-elixir-test-author` following `llms/constitution.md` and implement LiveView/frontend tests for the tools registry runtime catalog behavior.
+
+## Objective
+Add frontend test coverage for the tools page behavior introduced in Task 08.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Task 08 outputs
+- [ ] Existing tools-page test patterns
+
+## Expected Outputs
+
+- [ ] LiveView/frontend coverage for tools page runtime catalog rendering
+
+## Acceptance Criteria
+
+- [ ] Tests verify the tools page renders the fixed four-tool catalog
+- [ ] Tests verify the runtime-backed path is used for the happy path
+- [ ] Tests stay aligned with existing LiveView testing patterns
+
+## Technical Notes
+
+### Constraints
+- Keep the test scope limited to the tools page catalog behavior
+- No separate verification task
+
+## Execution Instructions
+
+### For the Agent
+1. Add or extend tools-page LiveView coverage.
+2. Assert the fixed runtime catalog behavior.
+3. Keep tests deterministic and pattern-aligned.
+
+### For the Human Reviewer
+1. Verify tools-page coverage exists.
+2. Verify the fixed four-tool slice is asserted.
+3. Verify test scope stays narrow.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/10_frontend_tests_tools_registry_runtime_catalog.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/10_frontend_tests_tools_registry_runtime_catalog.md
@@ -1,8 +1,8 @@
 # Task 10: Frontend Tests Tools Registry Runtime Catalog
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-elixir-test-author`
@@ -50,7 +50,27 @@ Add frontend test coverage for the tools page behavior introduced in Task 08.
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Work Performed
+- Extended `ToolsLive` frontend coverage for runtime-catalog behavior.
+- Added an explicit assertion that the legacy/configured `MockRuntimeFetcher` path is not used on the tools-page happy path.
+- Kept test scope focused on tools catalog rendering and existing selector-driven LiveView patterns.
+
+### Scenario Coverage
+- Happy path renders the fixed four-tool runtime catalog (`fs.read_text_file`, `fs.write_text_file`, `web.search`, `web.fetch`).
+- Happy path does not call `MockRuntimeFetcher.fetch/0` (proves runtime-backed fixed catalog path is used).
+- Existing filter and partial-policy state tests remain in place.
+
+### Files Modified
+- `test/lemmings_os_web/live/tools_live_test.exs`
+
+### Validation
+- `mix test test/lemmings_os_web/live/tools_live_test.exs`
+- `mix precommit`
+
+### Acceptance Criteria Check
+- [x] Tests verify the tools page renders the fixed four-tool catalog
+- [x] Tests verify the runtime-backed path is used for the happy path
+- [x] Tests stay aligned with existing LiveView testing patterns
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/11_update_adrs.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/11_update_adrs.md
@@ -1,8 +1,8 @@
 # Task 11: Update ADRs
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `docs-feature-documentation-author`
@@ -44,7 +44,16 @@ Document the Tool Runtime MVP slice as implemented, without expanding into out-o
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Updated ADRs and architecture docs to match the implemented Tool Runtime MVP slice:
+
+- `docs/adr/0005-tool-execution-model.md` now documents the fixed four-tool catalog, direct executor-to-runtime call path, durable tool execution rows, and explicit out-of-scope governance layers.
+- `docs/adr/0016-tool-execution-isolation-model.md` now documents the MVP work-area/filesystem boundary and clarifies that the four first-party tools run in-process.
+- `docs/adr/0018-audit-log-event-model.md` now documents implemented tool lifecycle logs, telemetry, PubSub notification, activity-log entries, and the distinction between MVP runtime history and future audit-event storage.
+- `docs/adr/0021-core-domain-schema.md` now includes `lemming_instance_tool_executions` as a Phase 1 runtime-history table.
+- `docs/adr/0024-observability-and-monitoring-model.md` now lists the implemented tool execution telemetry metrics.
+- `docs/architecture.md` now includes the Tool Runtime layer, direct tool-call flow, persistence table, and live-only interaction trace behavior.
+
+Scope kept to the implemented MVP. Did not reintroduce approvals, MCP, Docker sandboxing, generic command execution, broader policy hierarchy, or worktree/git scope as implemented behavior.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/11_update_adrs.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/11_update_adrs.md
@@ -1,0 +1,50 @@
+# Task 11: Update ADRs
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`docs-feature-documentation-author`
+
+## Agent Invocation
+Act as `docs-feature-documentation-author` following `llms/constitution.md` and update ADRs/architecture docs for the Tool Runtime MVP.
+
+## Objective
+Document the Tool Runtime MVP slice as implemented, without expanding into out-of-scope future governance features.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Tasks 01 through 10 outputs
+- [ ] Relevant ADRs and architecture docs under `docs/`
+
+## Expected Outputs
+
+- [ ] ADR/documentation updates aligned with the implemented MVP slice
+
+## Acceptance Criteria
+
+- [ ] Docs reflect the fixed four-tool MVP only
+- [ ] Docs reflect direct runtime-call execution
+- [ ] Docs reflect work area, transcript visibility, and observability behavior at the implemented level
+- [ ] Docs do not reopen approvals, permissions hierarchy, MCP, Docker sandboxing, or worktree scope
+
+## Execution Instructions
+
+### For the Agent
+1. Read the implemented outputs.
+2. Update only the relevant ADR/docs.
+3. Keep the documentation precise and scope-bounded.
+
+### For the Human Reviewer
+1. Verify docs match implementation.
+2. Verify out-of-scope topics were not reintroduced.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/12_pr_review.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/12_pr_review.md
@@ -1,7 +1,7 @@
 # Task 12: PR Review
 
 ## Status
-- **Status**: ⏳ PENDING
+- **Status**: ✅ COMPLETED
 - **Approved**: [ ] Human sign-off
 
 ## Assigned Agent
@@ -44,7 +44,63 @@ Review the full branch after implementation, tests, and ADR updates are complete
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Summary
+- Branch stays inside the fixed four-tool MVP execution catalog: `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch`.
+- Direct executor-to-tool-runtime call path is implemented; PubSub remains a UI notification path, not the execution mechanism.
+- Durable tool execution history, transcript tool cards, runtime telemetry, metrics, and ADR updates are present.
+- Blocker follow-up fixed workspace/artifact symlink escapes and added regression tests.
+- Artifact endpoint follow-up changed artifact responses to download-only binary responses with `nosniff`.
+- Web egress follow-up added default private-host blocking, explicit Req timeouts, and no-retry behavior.
+- `mix precommit` passed after blocker, artifact, and web egress hardening fixes on 2026-04-21.
+
+### Risk assessment
+**Low-to-medium** after follow-up fixes. The MVP tool boundary now has workspace symlink rejection, download-only artifact responses, and default web egress blocking for loopback/private/link-local host targets. Residual risk remains around future policy sophistication and DNS-based egress controls.
+
+### BLOCKER
+
+None open after blocker follow-up.
+
+### RESOLVED
+
+#### Filesystem tools can follow symlinks outside the work area
+- **Where**: `lib/lemmings_os/tools/adapters/filesystem.ex`, `lib/lemmings_os/lemming_instances.ex`
+- **Resolution**: Workspace root paths are expanded before work-area resolution, and existing path components are checked with `File.lstat/1`; symlink components now return `tool.fs.path_outside_workspace` or `:path_outside_workspace` before file IO.
+- **Tests added**: `test/lemmings_os/tools/adapters/filesystem_test.exs` covers read symlink, write symlink, and symlink parent directory escapes. `test/lemmings_os_web/live/instance_live_test.exs` covers artifact download via symlink.
+
+#### Artifact endpoint serves generated files inline with sniffed content type
+- **Where**: `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`, `show/2`
+- **Resolution**: Artifact responses now use `content-type: application/octet-stream`, `content-disposition: attachment`, and `x-content-type-options: nosniff`.
+- **Tests added**: `test/lemmings_os_web/live/instance_live_test.exs` covers `.md`, `.html`, and `.svg` artifact downloads and asserts non-inline headers.
+
+#### Web fetch has no network egress guardrails
+- **Where**: `lib/lemmings_os/tools/adapters/web.ex`, `validate_http_url/1`, `request_fetch/1`, `request_search/1`
+- **Resolution**: Fetch URLs and configured search endpoints now reject localhost, `.localhost`, loopback, private, link-local, and selected reserved IP literal targets by default. Tests can opt into private hosts via `:tools_web_allow_private_hosts`. Req calls now use configured `:tools_web_timeout_ms`, `receive_timeout`, `connect_options`, and `retry: false`.
+- **Tests added**: `test/lemmings_os/tools/adapters/web_test.exs` covers blocked fetch hosts, blocked private search endpoints, and timeout normalization. `test/lemmings_os/tools/runtime_test.exs` opts into private hosts for Bypass-backed runtime tests.
+
+### MAJOR
+
+None open.
+
+### MINOR
+
+#### Raw context page is larger than the stated transcript MVP
+- **Where**: `lib/lemmings_os_web/live/instance_raw_live.ex`, `lib/lemmings_os_web/router.ex`
+- **Why it matters**: The page is useful, but it exposes raw prompt/config/runtime internals and was not called out in the four-tool MVP plan. That increases review and privacy surface.
+- **Suggested fix**: Either document it explicitly in Task 11/ADRs as delivered behavior and keep it operator-only, or defer the route to a follow-up PR.
+
+### NITS
+- None blocking.
+
+### Test coverage notes
+- Good coverage exists for persistence, executor loop, telemetry, tool cards, tools page, and basic path traversal.
+- Added coverage for symlink escapes, artifact active-content response headers, and web egress blocking/timeout behavior.
+
+### Observability notes
+- Lifecycle logs, telemetry, metrics, activity log records, and PubSub updates are present.
+- Web egress blocking now returns stable `tool.web.egress_blocked`; timeouts normalize through `tool.web.request_failed`.
+
+### Merge recommendation
+**COMMENT_ONLY**. The previously identified BLOCKER and MAJOR findings have been addressed; remaining risk is acceptable for the fixed four-tool MVP if maintainers are comfortable deferring deeper DNS/policy egress controls.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/12_pr_review.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/12_pr_review.md
@@ -1,0 +1,50 @@
+# Task 12: PR Review
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-pr-elixir`
+
+## Agent Invocation
+Act as `audit-pr-elixir` following `llms/constitution.md` and perform the final PR review for Tool Runtime MVP on `feat/0006_tool_runtime_mvp`.
+
+## Objective
+Review the full branch after implementation, tests, and ADR updates are complete, and issue an approve/request-changes verdict.
+
+## Inputs Required
+
+- [ ] `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- [ ] Tasks 01 through 11 outputs
+- [ ] Full branch diff
+
+## Expected Outputs
+
+- [ ] Final PR review with findings and verdict
+
+## Acceptance Criteria
+
+- [ ] Review verifies the branch remains within the four-tool MVP slice
+- [ ] Review verifies runtime correctness, workspace boundary safety, transcript visibility, observability, and test coverage
+- [ ] Review verifies ADR/docs align with shipped behavior
+- [ ] Findings are concrete and actionable
+
+## Execution Instructions
+
+### For the Agent
+1. Review the branch against the plan and all task outputs.
+2. Report findings by severity.
+3. Issue a final verdict.
+
+### For the Human Reviewer
+1. Review the findings and verdict.
+2. Decide whether the branch is ready for merge or needs follow-up work.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
@@ -112,7 +112,7 @@ This execution plan breaks the Tool Runtime MVP into smaller sequential tasks gr
   - Location: `lib/lemmings_os/lemming_instances/lemming_instance.ex`
   - Existing role: durable runtime session record
   - Relevant fields today: `status`, `config_snapshot`, `started_at`, `stopped_at`, `last_activity_at`
-  - Required change for this issue: persist the instance work area path relative to `/workspace`
+  - Required change for this issue: ensure spawn-time work area creation uses the runtime workspace root layout
 - `LemmingsOs.LemmingInstances.Message`
   - Location: `lib/lemmings_os/lemming_instances/message.ex`
   - Existing role: immutable transcript entries for `user` and `assistant`
@@ -203,13 +203,13 @@ This record is required because the existing in-memory `ActivityLog` is not dura
 
 ### `work area`
 
-Use `work area` for the per-instance writable directory created at spawn time and stored relative to `/workspace`.
+Use `work area` for the writable directory created at spawn time under the runtime workspace root.
 
 The work area is:
 
 - dedicated to one `LemmingInstance`
 - created before the instance begins useful work
-- persisted on the instance record
+- derived from the lemming hierarchy at runtime
 - the default target for artifacts written during the session
 
 ### `transcript tool card`
@@ -244,7 +244,7 @@ Any broader tool catalog discussion from earlier exploration should be treated a
 
 - fixed global Tool Runtime catalog for the four approved tools only
 - direct runtime execution from the existing executor path
-- spawn-time work area creation and persistence relative to `/workspace`
+- spawn-time work area creation under the configured runtime workspace root
 - durable tool execution history with compact session transcript visibility
 - live updates plus operational visibility through logs, telemetry, and metrics
 
@@ -291,7 +291,7 @@ Any broader tool catalog discussion from earlier exploration should be treated a
 
 - Direct runtime call boundary from the existing executor path; PubSub is for live updates only.
 - Dedicated durable tool execution history is required so operators can inspect results after reload.
-- The runtime session must persist its work area location relative to `/workspace`; absolute host paths must not leak into persistence or tool-visible outputs.
+- The runtime session must create its work area under the configured runtime workspace root; absolute host paths must not leak into persisted tool records or tool-visible outputs.
 - The fixed catalog for this PR is only `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch`.
 - Tool results and errors must be normalized consistently for both model/runtime use and transcript inspection.
 - The instance session page remains the primary operator surface; tool cards stay compact and support inspection of persisted details without defaulting to raw output dumps.
@@ -358,7 +358,7 @@ As an operator maintaining the runtime, I want logs, metrics, and status records
 - **Given** a new runtime session is spawned successfully
 - **When** the spawn workflow completes
 - **Then** the instance has a dedicated work area created under the runtime workspace root
-- **And** the instance row stores the relative work area path
+- **And** the work area path resolves to `<workspace_root>/<department_id>/<lemming_id>`
 
 **Scenario: filesystem write respects workspace boundaries**
 
@@ -370,7 +370,7 @@ As an operator maintaining the runtime, I want logs, metrics, and status records
 **Criteria Checklist**
 
 - [ ] Work area is created during spawn, not lazily on first write
-- [ ] Persisted path is relative to `/workspace`
+- [ ] Work area is created at `<workspace_root>/<department_id>/<lemming_id>`
 - [ ] Filesystem tools only accept workspace-relative paths
 - [ ] Absolute paths and upward traversal are rejected
 - [ ] The final assistant response can reference the produced artifact path using the relative workspace path
@@ -444,7 +444,6 @@ Deliver the minimal persistence needed for durability and operator inspection.
 
 Planned changes:
 
-- persist the per-instance work area location on the runtime session record
 - add a dedicated durable store for tool execution records
 - add world-scoped context APIs to create, update, and list tool executions per instance
 - extend the runtime spawn workflow so work area creation happens before returning a spawned session
@@ -453,7 +452,7 @@ Expected alignment with current code:
 
 - `LemmingsOs.Runtime.spawn_session/3` remains the end-to-end spawn entrypoint
 - `LemmingsOs.LemmingInstances.spawn_instance/3` remains the durable instance persistence boundary
-- work area path belongs on `LemmingInstance`, not in transient ETS state
+- work area creation belongs in the spawn flow, not in transient ETS state
 
 ### Workstream 2: Fixed Catalog And Tool Runtime Boundary
 
@@ -541,7 +540,6 @@ Planned changes:
 ### Durability
 
 - Tool execution history must survive page reload and live update loss
-- Work area path must persist on the instance record
 - Successful and failed executions both remain inspectable
 
 ### Observability
@@ -679,7 +677,7 @@ These items must not be implemented as part of this PR.
 
 - Replaced the brief-only file with an implementation-ready staff-level plan
 - Validated the plan against the current runtime executor, session LiveView, tools registry placeholder, telemetry helper, and activity log patterns
-- Added explicit persistence requirements for `work_area_path` and durable tool execution records
+- Added explicit durable tool execution requirements and spawn-time work area creation requirements
 - Clarified how the executor, Tool Runtime, PubSub, and session transcript should interact without reopening broader architecture
 - Added user stories, acceptance criteria, edge cases, UX states, testing expectations, and non-functional requirements
 

--- a/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
@@ -258,6 +258,29 @@ Any broader tool catalog discussion from earlier exploration should be treated a
 - any broader filesystem catalog beyond `fs.read_text_file` and `fs.write_text_file`
 - git branches, worktrees, or cleanup jobs
 - generated `LEMMINGS.md`, `task_context.md`, or similar per-task artifacts
+- durable persistence of every intermediate LLM/tool loop turn; the raw interaction trace for this MVP stays live-only in the executor
+
+---
+
+## Runtime Loop Notes
+
+### Live interaction trace
+
+The MVP now includes a live-only executor trace for the LLM/tool loop.
+
+- Owner: `LemmingsOs.LemmingInstances.Executor`
+- Surface: raw context LiveView timeline
+- Persistence: none beyond the lifetime of the running executor
+
+This trace exists to debug token use, repeated tool calls, and prompt/tool handoff behavior without changing the durable transcript model.
+
+### ADR follow-up
+
+Task 11 should update `ADR-0004` with:
+
+- a simplified execution-flow diagram for the Phase 1 model/tool loop
+- explicit ownership boundaries for `Executor`, `ModelRuntime`, and `Tool Runtime`
+- clarification that the live interaction trace is ephemeral executor state, not a durable audit log
 - separate operator pages for tool audit beyond what is needed on the instance page and existing runtime surfaces
 
 ---

--- a/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
+++ b/llms/tasks/0006_implement_tool_runtime_mvp/plan.md
@@ -1,0 +1,705 @@
+# LemmingsOS -- 0006 Implement Tool Runtime MVP
+
+## Execution Metadata
+
+- Spec / Plan: `llms/tasks/0006_implement_tool_runtime_mvp/plan.md`
+- Created: `2026-04-18`
+- Status: `PLANNING`
+- Branch: `feat/0006_tool_runtime_mvp`
+- Related upstream plan: `llms/tasks/0005_implement_runtime_engine/plan.md`
+
+## Goal
+
+Deliver the first end-to-end Tool Runtime slice so a spawned `LemmingInstance` can execute a small fixed catalog of tools, receive normalized tool results, surface tool activity live in the instance session UI, and leave useful file artifacts in a dedicated per-instance work area.
+
+This PR validates the minimum product loop from runtime session to tool execution to visible transcript history to final artifact generation. It is intentionally a narrow MVP slice, not the general tool governance system.
+
+---
+
+## Execution Plan
+
+## Overview
+
+This execution plan breaks the Tool Runtime MVP into smaller sequential tasks grouped by backend, backend tests, frontend, frontend tests, ADR updates, and final PR review. Each task is intentionally scoped so it can be implemented and approved independently without introducing separate verification-only tasks.
+
+## Technical Summary
+
+### Codebase Impact
+
+- **New files**: expected across runtime persistence, tool adapters/catalog, UI components, tests, and ADR updates
+- **Modified files**: expected in runtime, model integration, LiveView transcript rendering, telemetry, and tools registry surfaces
+- **Database migrations**: Yes
+- **External dependencies**: None expected beyond existing `Req`
+
+### Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Tool call loop expands beyond the agreed four-tool MVP | Medium | High | Keep the task outputs explicitly limited to the fixed catalog and restate out-of-scope items in backend/frontend tasks |
+| Transcript history becomes split between messages and tool events in inconsistent ways | Medium | High | Make backend persistence and frontend rendering tasks share the same chronological transcript requirement |
+| World scoping or workspace path boundaries are implemented inconsistently | Medium | High | Keep world-scoped APIs and workspace-relative path handling as explicit acceptance criteria in backend and test tasks |
+| Observability becomes partial and only covers happy paths | Medium | Medium | Require lifecycle logging, telemetry, and historical inspection in backend implementation and PR review |
+
+## Roles
+
+### Human Reviewer
+
+- Approves each task before the next begins
+- Executes all git operations
+- Confirms task outputs satisfy the acceptance criteria
+- Decides whether follow-up work is needed after ADR review or PR review
+
+### Executing Agents
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| 01 | `dev-backend-elixir-engineer` | Implement persistence and spawn-time work area support |
+| 02 | `dev-backend-elixir-engineer` | Implement fixed tool catalog and MVP tool adapters |
+| 03 | `dev-backend-elixir-engineer` | Implement executor/model integration for the tool-call loop |
+| 04 | `dev-logging-daily-guardian` | Implement tool execution observability and runtime-facing backend visibility |
+| 05 | `qa-elixir-test-author` | Implement backend tests for persistence, work area, and tool adapters |
+| 06 | `qa-elixir-test-author` | Implement backend tests for executor loop and observability |
+| 07 | `dev-frontend-ui-engineer` | Implement transcript tool cards and historical session rendering |
+| 08 | `dev-frontend-ui-engineer` | Implement tools page runtime catalog wiring |
+| 09 | `qa-elixir-test-author` | Implement LiveView tests for the instance transcript tool UX |
+| 10 | `qa-elixir-test-author` | Implement LiveView tests for the tools page runtime catalog |
+| 11 | `docs-feature-documentation-author` | Update ADRs and architecture notes to reflect the delivered MVP slice |
+| 12 | `audit-pr-elixir` | Perform the final branch-level PR review |
+
+## Task Sequence
+
+| # | Task | Status | Approved |
+|---|------|--------|----------|
+| 01 | Backend: Persistence And Work Area | ⏳ PENDING | [ ] |
+| 02 | Backend: Tool Catalog And Adapters | ⏳ PENDING | [ ] |
+| 03 | Backend: Executor Tool Loop | ⏳ PENDING | [ ] |
+| 04 | Backend: Observability And Runtime Visibility | ⏳ PENDING | [ ] |
+| 05 | Backend Tests: Persistence And Adapters | ⏳ PENDING | [ ] |
+| 06 | Backend Tests: Executor And Observability | ⏳ PENDING | [ ] |
+| 07 | Frontend: Transcript Tool Cards | ⏳ PENDING | [ ] |
+| 08 | Frontend: Tools Registry Runtime Catalog | ⏳ PENDING | [ ] |
+| 09 | Frontend Tests: Instance Transcript Tool UX | ⏳ PENDING | [ ] |
+| 10 | Frontend Tests: Tools Registry Runtime Catalog | ⏳ PENDING | [ ] |
+| 11 | Update ADRs | ⏳ PENDING | [ ] |
+| 12 | PR Review | ⏳ PENDING | [ ] |
+
+## Assumptions
+
+1. The current `plan.md` is the approved source of truth for scope and is ready for tech-lead task decomposition.
+2. No additional product slicing is needed beyond the four approved tools.
+3. The existing runtime executor remains the correct implementation seam for tool invocation.
+4. The instance session page remains the primary UX surface for tool execution visibility in this PR.
+5. ADR updates should document implemented behavior only and should not reopen out-of-scope governance topics.
+
+## Open Questions
+
+1. None currently blocking Task 01.
+
+## Change Log
+
+| Date | Task | Change | Reason |
+|------|------|--------|--------|
+| 2026-04-18 | Plan | Initial functional plan created | PO analysis |
+| 2026-04-18 | Plan | Added execution task breakdown and approval sequence | TL architecture planning |
+
+---
+
+## Project Context
+
+### Related Entities
+
+- `LemmingsOs.LemmingInstances.LemmingInstance`
+  - Location: `lib/lemmings_os/lemming_instances/lemming_instance.ex`
+  - Existing role: durable runtime session record
+  - Relevant fields today: `status`, `config_snapshot`, `started_at`, `stopped_at`, `last_activity_at`
+  - Required change for this issue: persist the instance work area path relative to `/workspace`
+- `LemmingsOs.LemmingInstances.Message`
+  - Location: `lib/lemmings_os/lemming_instances/message.ex`
+  - Existing role: immutable transcript entries for `user` and `assistant`
+  - Constraint: current message role taxonomy should not be overloaded to represent tool lifecycle records
+- `LemmingsOs.LemmingInstances`
+  - Location: `lib/lemmings_os/lemming_instances.ex`
+  - Existing role: durable session persistence boundary and transcript access
+  - Relevant seam: `spawn_instance/3`, `list_messages/2`, `enqueue_work/3`, world-scoped query patterns
+- `LemmingsOs.LemmingInstances.Executor`
+  - Location: `lib/lemmings_os/lemming_instances/executor.ex`
+  - Existing role: per-instance work queue, status transitions, model execution, PubSub updates
+  - Relevant seam: this is where model output currently converges back into runtime behavior
+- `LemmingsOs.ModelRuntime`
+  - Location: `lib/lemmings_os/model_runtime.ex`
+  - Existing role: provider boundary for structured assistant output
+  - Constraint discovered in tests: current contract accepts `reply` and explicitly rejects `tool_call`
+- `LemmingsOs.LemmingInstances.PubSub`
+  - Location: `lib/lemmings_os/lemming_instances/pubsub.ex`
+  - Existing role: live status/message updates for the session page
+  - Constraint: appropriate for live UI fanout only; not appropriate as the primary tool execution mechanism
+- `LemmingsOs.Runtime.ActivityLog`
+  - Location: `lib/lemmings_os/runtime/activity_log.ex`
+  - Existing role: in-memory operator feed for recent runtime events
+  - Constraint: useful for live/operator visibility, but not sufficient for durable tool execution history
+- `LemmingsOs.LemmingInstances.Telemetry`
+  - Location: `lib/lemmings_os/lemming_instances/telemetry.ex`
+  - Existing role: safe telemetry helper with full hierarchy metadata
+  - Relevant seam: correct place to extend event emission for tool execution lifecycle
+
+### Related Features
+
+- **Instance Session Page**
+  - Locations: `lib/lemmings_os_web/live/instance_live.ex`, `lib/lemmings_os_web/live/instance_live.html.heex`
+  - Existing behavior: compact streamed transcript with status banner, follow-up composer, and PubSub-driven updates
+  - Pattern to follow: add compact timeline entries/cards instead of a separate raw log screen
+- **Tools Registry Page**
+  - Locations: `lib/lemmings_os_web/live/tools_live.ex`, `lib/lemmings_os_web/page_data/tools_page_snapshot.ex`
+  - Existing behavior: page already expects a runtime-backed tool registry but still uses placeholder fetchers
+  - Pattern to follow: replace the placeholder runtime fetcher with the actual fixed catalog for this PR
+- **Runtime Dashboard / Logs**
+  - Locations: `lib/lemmings_os/runtime/status.ex`, `lib/lemmings_os_web/telemetry.ex`, `lib/lemmings_os_web/live/runtime_dashboard_live.ex`
+  - Existing behavior: runtime counts, telemetry polling, in-memory activity feed
+  - Pattern to follow: add metrics and activity log events rather than introducing a second observability stack
+
+### Naming Conventions Observed
+
+- Context / boundary modules use `LemmingsOs.<PluralOrRuntimeName>`
+- Durable runtime schemas live under their context namespace
+- Instance session features use `LemmingsOs.LemmingInstances.*` and `LemmingsOsWeb.InstanceLive`
+- Fixed runtime registry data is already conceptually represented under `LemmingsOs.Tools.*`
+- Telemetry event naming follows `[:lemmings_os, :domain, :transition]`
+- World-scoped context APIs require explicit `world_id` or `%World{}`
+
+### Permissions / Actor Model
+
+- No application-level authenticated role system is implemented in the current codebase
+- The functional actor in this issue is the platform operator using the runtime UI
+- Tool permissions, approvals, and hierarchy filtering are explicitly out of scope for this PR
+
+---
+
+## Terminology Alignment
+
+### `Tool Runtime`
+
+Use `Tool Runtime` for the direct execution boundary that validates args, resolves workspace-relative paths, executes the tool adapter, persists a tool execution record, and returns a normalized result to the executor.
+
+This is distinct from:
+
+- `LemmingsOs.Tools.*` as catalog/read-model concerns
+- PubSub as a live-update mechanism
+- `ModelRuntime`, which chooses when a tool call should happen but must not execute tools itself
+
+### `tool execution`
+
+Use `tool execution` for the durable record of one attempted tool invocation.
+
+This record must include:
+
+- tool identity
+- normalized args
+- status
+- short preview / summary
+- normalized result or normalized error
+- timestamps / duration
+
+This record is required because the existing in-memory `ActivityLog` is not durable enough to satisfy the history requirement.
+
+### `work area`
+
+Use `work area` for the per-instance writable directory created at spawn time and stored relative to `/workspace`.
+
+The work area is:
+
+- dedicated to one `LemmingInstance`
+- created before the instance begins useful work
+- persisted on the instance record
+- the default target for artifacts written during the session
+
+### `transcript tool card`
+
+Use `transcript tool card` for the compact session UI representation of a tool execution.
+
+This card is not a raw stdout dump. It should show:
+
+- tool name
+- running / ok / error status
+- short summary
+- optional preview
+
+### `catalog`
+
+For this PR, `catalog` means the fixed global list of four supported tools only:
+
+- `fs.read_text_file`
+- `fs.write_text_file`
+- `web.search`
+- `web.fetch`
+
+No permission filtering, policy reconciliation, or effective-per-lemming catalog work belongs in this issue.
+
+Any broader tool catalog discussion from earlier exploration should be treated as background context only, not as part of the implementation brief for this PR.
+
+---
+
+## Scope Boundaries
+
+### In Scope
+
+- fixed global Tool Runtime catalog for the four approved tools only
+- direct runtime execution from the existing executor path
+- spawn-time work area creation and persistence relative to `/workspace`
+- durable tool execution history with compact session transcript visibility
+- live updates plus operational visibility through logs, telemetry, and metrics
+
+### Out of Scope
+
+- hierarchical tool permissions, allowlists, denylists, or limit enforcement
+- approval workflows
+- MCP configuration
+- Docker sandboxing
+- any command-execution surface such as `exec.run`
+- any broader filesystem catalog beyond `fs.read_text_file` and `fs.write_text_file`
+- git branches, worktrees, or cleanup jobs
+- generated `LEMMINGS.md`, `task_context.md`, or similar per-task artifacts
+- separate operator pages for tool audit beyond what is needed on the instance page and existing runtime surfaces
+
+---
+
+## Validation Findings Against Current Codebase
+
+1. The current runtime already has the correct execution owner: `LemmingsOs.LemmingInstances.Executor`.
+   Tool execution should extend that path instead of introducing a second async execution pipeline.
+
+2. The current session page already has the right UI shell: a streamed transcript with compact cards and PubSub updates.
+   Tool visibility should be added into this transcript rather than building a separate tool console first.
+
+3. The current `Message` schema is intentionally scoped to `user` and `assistant`.
+   Tool executions should be persisted in a dedicated schema instead of overloading transcript messages with another pseudo-role.
+
+4. The current `ActivityLog` is useful but ephemeral.
+   A durable `tool executions` store is required to meet the brief’s history requirement.
+
+5. The current telemetry helper and runtime dashboard patterns are already in place.
+   This PR should extend those patterns rather than invent a second observability model.
+
+6. The current tools page is already prepared for a runtime-backed catalog.
+   This PR should replace the placeholder runtime fetcher with the fixed Tool Runtime catalog.
+
+7. The current `ModelRuntime` test suite explicitly rejects `tool_call`.
+   The implementation plan must include the minimum structured-output extension required for tool invocation and final reply completion.
+
+---
+
+## Confirmed Constraints For This PR
+
+- Direct runtime call boundary from the existing executor path; PubSub is for live updates only.
+- Dedicated durable tool execution history is required so operators can inspect results after reload.
+- The runtime session must persist its work area location relative to `/workspace`; absolute host paths must not leak into persistence or tool-visible outputs.
+- The fixed catalog for this PR is only `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch`.
+- Tool results and errors must be normalized consistently for both model/runtime use and transcript inspection.
+- The instance session page remains the primary operator surface; tool cards stay compact and support inspection of persisted details without defaulting to raw output dumps.
+
+---
+
+## User Stories
+
+### US-1: Execute fixed catalog tools from a runtime session
+
+As an operator running a lemming session, I want the session to execute the approved MVP tools, so that the instance can read/write files and gather web context during a task.
+
+### US-2: Produce artifacts inside a dedicated work area
+
+As an operator, I want each spawned instance to have its own writable work area, so that generated artifacts are isolated, predictable, and inspectable after the run.
+
+### US-3: See tool activity live in the session transcript
+
+As an operator watching a runtime session, I want compact tool execution cards to appear in the transcript in real time, so that I can understand what the instance is doing without reading raw output dumps.
+
+### US-4: Inspect historical tool executions after the live event
+
+As an operator returning to a session later, I want tool execution history to remain visible and inspectable, so that I can audit what happened even after the live updates are gone.
+
+### US-5: Observe success, failure, and runtime health operationally
+
+As an operator maintaining the runtime, I want logs, metrics, and status records for every tool execution, so that failures and latency trends are diagnosable from day 0.
+
+---
+
+## Acceptance Criteria
+
+### US-1: Execute fixed catalog tools from a runtime session
+
+**Scenario: tool call succeeds**
+
+- **Given** an active `LemmingInstance` with a valid config snapshot
+- **When** the model returns a structured `tool_call` action for one of the four approved tools
+- **Then** the executor invokes Tool Runtime directly
+- **And** Tool Runtime validates args against the tool schema
+- **And** a durable tool execution record is created
+- **And** the normalized tool result is returned to the executor for continued reasoning
+
+**Scenario: unsupported tool requested**
+
+- **Given** the model returns a tool name outside the fixed catalog
+- **When** the executor resolves the requested tool
+- **Then** the tool execution is recorded as `error`
+- **And** the error is normalized with a stable `code`
+- **And** the session remains alive unless broader retry logic decides otherwise
+
+**Criteria Checklist**
+
+- [ ] Only `fs.read_text_file`, `fs.write_text_file`, `web.search`, and `web.fetch` can execute
+- [ ] Tool args are validated before adapter execution
+- [ ] Tool Runtime is called directly from runtime code, not through PubSub
+- [ ] Tool results and errors use one normalized public shape
+- [ ] `ModelRuntime` contract supports the minimum `tool_call` action needed for this PR
+
+### US-2: Produce artifacts inside a dedicated work area
+
+**Scenario: work area created at spawn**
+
+- **Given** a new runtime session is spawned successfully
+- **When** the spawn workflow completes
+- **Then** the instance has a dedicated work area created under the runtime workspace root
+- **And** the instance row stores the relative work area path
+
+**Scenario: filesystem write respects workspace boundaries**
+
+- **Given** the instance calls `fs.write_text_file`
+- **When** the target path resolves outside `/workspace`
+- **Then** the write is rejected with a normalized error
+- **And** no file is written
+
+**Criteria Checklist**
+
+- [ ] Work area is created during spawn, not lazily on first write
+- [ ] Persisted path is relative to `/workspace`
+- [ ] Filesystem tools only accept workspace-relative paths
+- [ ] Absolute paths and upward traversal are rejected
+- [ ] The final assistant response can reference the produced artifact path using the relative workspace path
+
+### US-3: See tool activity live in the session transcript
+
+**Scenario: running card appears**
+
+- **Given** a connected operator on the instance session page
+- **When** a tool execution starts
+- **Then** a compact tool card appears in the transcript with `running` status
+
+**Scenario: completion updates the same card**
+
+- **Given** a running tool card already shown in the transcript
+- **When** the execution completes or fails
+- **Then** the card updates to `ok` or `error`
+- **And** the card shows a short summary and optional preview
+- **And** full raw output is not rendered inline by default
+
+**Criteria Checklist**
+
+- [ ] Tool cards render inside the existing session transcript timeline
+- [ ] Live updates use PubSub broadcasts from persisted lifecycle changes
+- [ ] Cards remain visually compact
+- [ ] Default rendering favors summary/preview over raw payload dumps
+
+### US-4: Inspect historical tool executions after the live event
+
+**Scenario: session page reload retains history**
+
+- **Given** a session with completed tool executions
+- **When** the operator reloads the instance page later
+- **Then** prior tool cards reappear from persisted records in transcript order
+- **And** each record remains inspectable
+
+**Criteria Checklist**
+
+- [ ] Tool executions are persisted durably, not only broadcast live
+- [ ] Reloading the instance page reconstructs transcript history with tool cards included
+- [ ] Success and failure records are both inspectable after reload
+
+### US-5: Observe success, failure, and runtime health operationally
+
+**Scenario: successful execution emits observability signals**
+
+- **Given** a tool call completes successfully
+- **When** the lifecycle transitions occur
+- **Then** structured logs, telemetry events, and counters/duration metrics are emitted
+
+**Scenario: failed execution emits observability signals**
+
+- **Given** a tool call fails validation or adapter execution
+- **When** the failure is persisted
+- **Then** structured logs and telemetry still emit with normalized reason metadata
+
+**Criteria Checklist**
+
+- [ ] Lifecycle transitions are logged
+- [ ] `started`, `completed`, and `failed` transitions emit telemetry
+- [ ] Metrics cover volume, success/error rate, and duration
+- [ ] All tool execution observability metadata includes full hierarchy context plus `tool_name`
+
+---
+
+## Implementation Plan
+
+### Workstream 1: Data Model And Spawn-Time Work Area
+
+Deliver the minimal persistence needed for durability and operator inspection.
+
+Planned changes:
+
+- persist the per-instance work area location on the runtime session record
+- add a dedicated durable store for tool execution records
+- add world-scoped context APIs to create, update, and list tool executions per instance
+- extend the runtime spawn workflow so work area creation happens before returning a spawned session
+
+Expected alignment with current code:
+
+- `LemmingsOs.Runtime.spawn_session/3` remains the end-to-end spawn entrypoint
+- `LemmingsOs.LemmingInstances.spawn_instance/3` remains the durable instance persistence boundary
+- work area path belongs on `LemmingInstance`, not in transient ETS state
+
+### Workstream 2: Fixed Catalog And Tool Runtime Boundary
+
+Create a minimal Tool Runtime layer with one direct call entrypoint and a fixed catalog definition.
+
+Planned changes:
+
+- introduce a dedicated tool-execution runtime boundary aligned with existing runtime naming and layering conventions
+- define one fixed global catalog that both the runtime and tools UI can read
+- define structured arg schemas and normalized result/error contracts
+- implement four adapters only:
+  - `fs.read_text_file`
+  - `fs.write_text_file`
+  - `web.search`
+  - `web.fetch`
+
+Implementation constraints:
+
+- filesystem adapters must resolve relative paths against `/workspace`
+- `fs.write_text_file` must support artifact creation in the instance work area
+- web adapters should use `Req`
+- no generic shell or command execution path belongs here
+
+### Workstream 3: Executor / Model Integration
+
+Extend the runtime loop so tool calls are first-class but still minimal.
+
+Planned changes:
+
+- extend the structured output contract so the model can request a `tool_call`
+- keep `reply` as the assistant completion action
+- update the executor to:
+  - detect `tool_call`
+  - persist and broadcast lifecycle transitions
+  - invoke Tool Runtime directly
+  - append normalized tool results into the model context for continued reasoning
+  - continue until a final assistant reply is produced or a bounded runtime failure occurs
+
+Important constraint:
+
+- this PR should support one clean iterative loop for tool use and final answer generation, but it should not open multi-agent delegation, tool approvals, or general workflow orchestration
+
+### Workstream 4: Session UI And Historical Inspection
+
+Extend the existing instance transcript to include compact tool execution cards.
+
+Planned changes:
+
+- update `InstanceLive` transcript composition to interleave persisted messages and persisted tool execution records chronologically
+- add PubSub-driven live updates for tool execution lifecycle changes
+- add one compact tool card component consistent with the current transcript aesthetic
+- support lightweight detail inspection for persisted normalized result/error data without defaulting to raw payload dumps
+
+Important constraint:
+
+- tool cards belong on the existing session page
+- no new primary navigation area is needed for this PR
+
+### Workstream 5: Observability And Registry Surfaces
+
+Extend existing observability and registry patterns rather than creating new ones.
+
+Planned changes:
+
+- add `tool_call.started`, `tool_call.completed`, and `tool_call.failed` lifecycle events
+- record structured log lines for each lifecycle transition
+- add `ActivityLog.record/4` entries for operator-facing runtime awareness
+- add metrics in `LemmingsOsWeb.Telemetry` for:
+  - tool call volume
+  - success/error counts
+  - duration
+- replace the placeholder tools runtime fetcher with the actual fixed catalog
+
+---
+
+## Non-Functional Requirements
+
+### Safety / Boundary Rules
+
+- Paths must remain relative to `/workspace`
+- Tool adapters must reject boundary-escaping paths deterministically
+- Tool Runtime must never expose host absolute paths in persisted records or model-visible outputs
+- All web requests must use `Req`
+
+### Durability
+
+- Tool execution history must survive page reload and live update loss
+- Work area path must persist on the instance record
+- Successful and failed executions both remain inspectable
+
+### Observability
+
+- Logs exist for lifecycle transitions
+- Metrics cover count, success/error, and duration
+- Telemetry metadata includes `world_id`, `city_id`, `department_id`, `lemming_id`, `instance_id`, and `tool_name`
+
+### UX
+
+- Tool UI is compact by default
+- Running, success, and error states are clearly distinguishable
+- Raw payloads are not shown inline by default
+
+### Performance / Operational Restraint
+
+- This PR should remain lightweight and synchronous at the execution boundary
+- It should not introduce additional queueing layers or distributed execution semantics
+- It should not create a second long-lived process per tool invocation unless a later issue requires it
+
+---
+
+## Edge Cases
+
+### Filesystem
+
+- [ ] Read target does not exist
+- [ ] Read target is outside `/workspace`
+- [ ] Write target attempts `../` traversal
+- [ ] Write target parent directory does not exist
+- [ ] Write target overwrites an existing file
+
+### Web
+
+- [ ] Search returns no results
+- [ ] Fetch receives a bad URL or unsupported URL form
+- [ ] Fetch fails due to timeout or transport error
+- [ ] Fetch succeeds but content is too noisy or too large for default preview
+
+### Runtime / Model Loop
+
+- [ ] Model requests an unknown tool
+- [ ] Model sends invalid args for a known tool
+- [ ] Tool call fails but the session remains recoverable
+- [ ] Tool execution is persisted as `running` but completion fails to broadcast; reload must still show the final durable state
+
+### UI
+
+- [ ] Historical transcript contains messages and tool cards on the same day
+- [ ] Tool cards preserve chronological order across reloads
+- [ ] Transcript remains usable when a session has many tool executions
+
+---
+
+## UX States
+
+### Instance Session Transcript Tool Card
+
+| State | Behavior |
+|---|---|
+| `running` | Compact card with tool name, running status, brief in-progress summary |
+| `ok` | Compact card with success status, summary, optional preview |
+| `error` | Compact card with error status, summary, normalized error copy |
+| `reloaded history` | Same compact card shape reconstructed from persisted records |
+
+### Tools Registry Page
+
+| State | Behavior |
+|---|---|
+| `catalog available` | Shows the four fixed tools from the real runtime fetcher |
+| `catalog unavailable` | Existing degraded/unknown state remains valid |
+
+---
+
+## Testing Expectations
+
+This issue changes executable runtime logic and must satisfy the constitution’s testing rules.
+
+Required test coverage:
+
+- context tests for work area creation and persistence
+- Tool Runtime unit tests for arg validation and result normalization
+- adapter tests for each of the four tools
+- executor tests for the `tool_call` -> runtime -> final reply loop
+- telemetry tests for lifecycle events and metrics metadata
+- LiveView tests for transcript tool cards, live updates, and reload persistence
+- tools page tests proving the fixed catalog is exposed through the runtime fetcher
+
+Testing style should follow the existing runtime engine approach:
+
+- deterministic tests
+- `start_supervised/1` for runtime processes
+- explicit world-scoped setup
+- LiveView assertions via IDs and element presence rather than raw HTML snapshots
+
+---
+
+## Delivery Notes For The Implementing Engineer
+
+1. Keep the PR slice narrow. Do not add adjacent tools or governance features.
+2. Reuse existing runtime seams first:
+   - `LemmingsOs.Runtime`
+   - `LemmingsOs.LemmingInstances`
+   - `LemmingsOs.LemmingInstances.Executor`
+   - `LemmingsOs.LemmingInstances.PubSub`
+   - `LemmingsOs.LemmingInstances.Telemetry`
+3. Do not model tool execution as a fake transcript message role.
+4. Do not use PubSub as the primary execution mechanism.
+5. Do not leak absolute host paths into persisted rows, transcript cards, or model-visible tool results.
+6. Do not reopen permissions, approvals, MCP, Docker sandboxing, or git worktree design in this PR.
+
+---
+
+## Out of Scope
+
+Explicitly excluded from this feature:
+
+1. Hierarchical tool permissions by World / City / Department / Lemming
+2. Approval workflows for risky tools
+3. MCP connectors and remote tool registration
+4. Docker-based sandbox execution
+5. `exec.run` and any shell-style tool surface
+6. Broader filesystem mutation and management commands outside the four approved tools
+7. Git branch/worktree lifecycle management
+8. Cleanup jobs for work areas
+9. Generated contextual docs such as `LEMMINGS.md` or `task_context.md`
+
+These items must not be implemented as part of this PR.
+
+---
+
+## PO Review Summary
+
+### Changes Made
+
+- Replaced the brief-only file with an implementation-ready staff-level plan
+- Validated the plan against the current runtime executor, session LiveView, tools registry placeholder, telemetry helper, and activity log patterns
+- Added explicit persistence requirements for `work_area_path` and durable tool execution records
+- Clarified how the executor, Tool Runtime, PubSub, and session transcript should interact without reopening broader architecture
+- Added user stories, acceptance criteria, edge cases, UX states, testing expectations, and non-functional requirements
+
+### Clarifications / Corrections
+
+| Topic | Clarification |
+|---|---|
+| Branch name | Canonical branch for this task is `feat/0006_tool_runtime_mvp`. |
+| History requirement | Existing `ActivityLog` is not durable enough; a persisted tool execution record is required |
+| Transcript modeling | Tool executions should not be stored as `Message` rows with a synthetic role |
+| UI direction | Existing instance transcript is the correct primary surface for tool cards |
+| Runtime boundary | Executor must call Tool Runtime directly; PubSub is live-update infrastructure only |
+| Catalog source | Tools page and executor should share one fixed catalog definition for this PR |
+
+### Key Findings
+
+- The current codebase already provides the correct runtime seams for this feature
+- The major missing pieces are durable tool execution persistence, work area persistence, and the structured output extension for `tool_call`
+- The tools page can be made real in this PR without reopening permissions or policy work
+
+### Status
+
+✅ **READY FOR TECH LEAD REVIEW**

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -270,22 +270,32 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "Lemming deletion is not available because safety cannot yet be proven."
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:69
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:87
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:72
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:90
 #: lib/lemmings_os/lemming_instances/message.ex:62
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:84
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:113
 #, elixir-autogen, elixir-format
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:99
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:142
 #, elixir-autogen, elixir-format
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:68
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:86
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:71
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os_web/live/instance_live.ex:553
 #, elixir-autogen, elixir-format
 msgid ".required"
+msgstr ""
+
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:88
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:117
+#, elixir-autogen, elixir-format
+msgid ".invalid_value"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -289,7 +289,7 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
-#: lib/lemmings_os_web/live/instance_live.ex:553
+#: lib/lemmings_os_web/live/instance_live.ex:574
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -223,7 +223,7 @@ msgstr "Departments"
 msgid ".page_title_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/live/tools_live.ex:13
+#: lib/lemmings_os_web/live/tools_live.ex:14
 #, elixir-autogen
 msgid ".page_title_tools"
 msgstr "Tools"
@@ -323,12 +323,12 @@ msgstr " · Agent Operations"
 msgid ".breadcrumb_new"
 msgstr "New"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:57
+#: lib/lemmings_os_web/live/tools_live.html.heex:56
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_subtitle"
 msgstr "Filter the current runtime tool set without implying install or policy completeness."
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:56
+#: lib/lemmings_os_web/live/tools_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_title"
 msgstr "Runtime Tool Set"
@@ -354,48 +354,49 @@ msgid ".tools_card_usage_label"
 msgstr "Usage"
 
 #: lib/lemmings_os_web/components/system_components.ex:23
+#: lib/lemmings_os_web/live/tools_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_description_unavailable"
 msgstr "No runtime description available."
 
-#: lib/lemmings_os_web/live/tools_live.ex:107
+#: lib/lemmings_os_web/live/tools_live.ex:112
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_copy"
 msgstr "The runtime capability source is available but returned no tool entries."
 
-#: lib/lemmings_os_web/live/tools_live.ex:108
+#: lib/lemmings_os_web/live/tools_live.ex:113
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_copy"
 msgstr "Adjust the local filter to inspect the current runtime capability set."
 
-#: lib/lemmings_os_web/live/tools_live.ex:103
+#: lib/lemmings_os_web/live/tools_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_title"
 msgstr "No tools match this filter"
 
-#: lib/lemmings_os_web/live/tools_live.ex:105
-#: lib/lemmings_os_web/live/tools_live.ex:106
+#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:111
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_runtime_copy"
 msgstr "The runtime capability source is unavailable, so no tool entries can be shown yet."
 
-#: lib/lemmings_os_web/live/tools_live.ex:100
-#: lib/lemmings_os_web/live/tools_live.ex:101
+#: lib/lemmings_os_web/live/tools_live.ex:105
+#: lib/lemmings_os_web/live/tools_live.ex:106
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_runtime_title"
 msgstr "Runtime capability unavailable"
 
-#: lib/lemmings_os_web/live/tools_live.ex:102
+#: lib/lemmings_os_web/live/tools_live.ex:107
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_title"
 msgstr "No runtime tools registered"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:69
+#: lib/lemmings_os_web/live/tools_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_label"
 msgstr "Local Filter"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:70
+#: lib/lemmings_os_web/live/tools_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_placeholder"
 msgstr "Search by name, category, or risk"
@@ -405,97 +406,97 @@ msgstr "Search by name, category, or risk"
 msgid ".tools_health_title"
 msgstr "Page Health"
 
-#: lib/lemmings_os_web/live/tools_live.ex:143
+#: lib/lemmings_os_web/live/tools_live.ex:148
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_action"
 msgstr "Treat policy state as partial until reconciliation is implemented."
 
-#: lib/lemmings_os_web/live/tools_live.ex:129
+#: lib/lemmings_os_web/live/tools_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_detail"
 msgstr "%{count} runtime tools still have deferred policy reconciliation."
 
-#: lib/lemmings_os_web/live/tools_live.ex:118
+#: lib/lemmings_os_web/live/tools_live.ex:123
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_summary"
 msgstr "Policy reconciliation is partial"
 
-#: lib/lemmings_os_web/live/tools_live.ex:146
+#: lib/lemmings_os_web/live/tools_live.ex:151
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_action"
 msgstr "Use runtime capability facts as primary until policy state is available."
 
-#: lib/lemmings_os_web/live/tools_live.ex:135
+#: lib/lemmings_os_web/live/tools_live.ex:140
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_detail"
 msgstr "The runtime tool set is available, but policy reconciliation could not be loaded."
 
-#: lib/lemmings_os_web/live/tools_live.ex:121
+#: lib/lemmings_os_web/live/tools_live.ex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_summary"
 msgstr "Policy state unavailable"
 
-#: lib/lemmings_os_web/live/tools_live.ex:140
+#: lib/lemmings_os_web/live/tools_live.ex:145
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_action"
 msgstr "Verify the runtime capability source before relying on tool availability."
 
-#: lib/lemmings_os_web/live/tools_live.ex:126
+#: lib/lemmings_os_web/live/tools_live.ex:131
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_detail"
 msgstr "The page could not obtain runtime capability data from the current source."
 
-#: lib/lemmings_os_web/live/tools_live.ex:115
+#: lib/lemmings_os_web/live/tools_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_summary"
 msgstr "Runtime capability source unavailable"
 
-#: lib/lemmings_os_web/live/tools_live.ex:112
+#: lib/lemmings_os_web/live/tools_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_many"
 msgstr "%{count} issues detected"
 
-#: lib/lemmings_os_web/live/tools_live.ex:111
+#: lib/lemmings_os_web/live/tools_live.ex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_one"
 msgstr "1 issue detected"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:94
+#: lib/lemmings_os_web/live/tools_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_subtitle"
 msgstr "Unknown and degraded states are listed explicitly."
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:93
+#: lib/lemmings_os_web/live/tools_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_title"
 msgstr "Issues"
 
-#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_zero"
 msgstr "No issues detected"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:100
+#: lib/lemmings_os_web/live/tools_live.html.heex:133
 #, elixir-autogen, elixir-format
 msgid ".tools_no_issues"
 msgstr "No issues detected."
 
-#: lib/lemmings_os_web/live/tools_live.ex:78
+#: lib/lemmings_os_web/live/tools_live.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_deferred"
 msgstr "Policy reconciliation is still deferred."
 
-#: lib/lemmings_os_web/live/tools_live.ex:83
+#: lib/lemmings_os_web/live/tools_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_known"
 msgstr "Runtime and policy facts are aligned."
 
-#: lib/lemmings_os_web/live/tools_live.ex:81
+#: lib/lemmings_os_web/live/tools_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_partial"
 msgstr "Some runtime tools still have partial policy state."
 
-#: lib/lemmings_os_web/live/tools_live.ex:84
+#: lib/lemmings_os_web/live/tools_live.ex:89
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_unknown"
 msgstr "Policy state is not yet available."
@@ -523,23 +524,23 @@ msgstr "Partial"
 msgid ".tools_policy_title"
 msgstr "Policy Reconciliation"
 
-#: lib/lemmings_os_web/live/tools_live.ex:90
+#: lib/lemmings_os_web/live/tools_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_many"
 msgstr "%{count} runtime tools observed"
 
-#: lib/lemmings_os_web/live/tools_live.ex:96
+#: lib/lemmings_os_web/live/tools_live.ex:101
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unavailable"
 msgstr "Runtime source unavailable"
 
-#: lib/lemmings_os_web/live/tools_live.ex:93
 #: lib/lemmings_os_web/live/tools_live.ex:98
+#: lib/lemmings_os_web/live/tools_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unknown"
 msgstr "Runtime source not implemented"
 
-#: lib/lemmings_os_web/live/tools_live.ex:87
+#: lib/lemmings_os_web/live/tools_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_zero"
 msgstr "Runtime source available with no tools"
@@ -553,31 +554,6 @@ msgstr "Runtime Capability"
 #, elixir-autogen, elixir-format
 msgid ".tools_usage_unknown"
 msgstr "Unknown"
-
-#: lib/lemmings_os_web/live/tools_live.ex:179
-#, elixir-autogen, elixir-format
-msgid ".tools_list_item_copy"
-msgstr "%{name} (%{risk} risk)"
-
-#: lib/lemmings_os_web/live/tools_live.ex:182
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_high"
-msgstr "high"
-
-#: lib/lemmings_os_web/live/tools_live.ex:183
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_medium"
-msgstr "medium"
-
-#: lib/lemmings_os_web/live/tools_live.ex:184
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_low"
-msgstr "low"
-
-#: lib/lemmings_os_web/live/tools_live.ex:185
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_unknown"
-msgstr "unknown"
 
 #: lib/lemmings_os_web/components/home_components.ex:260
 #: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
@@ -848,3 +824,28 @@ msgstr "Persisted Topology"
 #, elixir-autogen, elixir-format
 msgid ".home_card_topology_lemming_count_label"
 msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:168
+#, elixir-autogen, elixir-format
+msgid ".tools_list_item_copy"
+msgstr "%{name} (%{risk} risk)"
+
+#: lib/lemmings_os_web/live/tools_live.ex:171
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_high"
+msgstr "high"
+
+#: lib/lemmings_os_web/live/tools_live.ex:173
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_low"
+msgstr "low"
+
+#: lib/lemmings_os_web/live/tools_live.ex:172
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_medium"
+msgstr "medium"
+
+#: lib/lemmings_os_web/live/tools_live.ex:174
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_unknown"
+msgstr "unknown"

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -554,6 +554,31 @@ msgstr "Runtime Capability"
 msgid ".tools_usage_unknown"
 msgstr "Unknown"
 
+#: lib/lemmings_os_web/live/tools_live.ex:179
+#, elixir-autogen, elixir-format
+msgid ".tools_list_item_copy"
+msgstr "%{name} (%{risk} risk)"
+
+#: lib/lemmings_os_web/live/tools_live.ex:182
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_high"
+msgstr "high"
+
+#: lib/lemmings_os_web/live/tools_live.ex:183
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_medium"
+msgstr "medium"
+
+#: lib/lemmings_os_web/live/tools_live.ex:184
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_low"
+msgstr "low"
+
+#: lib/lemmings_os_web/live/tools_live.ex:185
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_unknown"
+msgstr "unknown"
+
 #: lib/lemmings_os_web/components/home_components.ex:260
 #: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
 #, elixir-autogen, elixir-format

--- a/priv/gettext/en/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/en/LC_MESSAGES/lemmings.po
@@ -628,30 +628,30 @@ msgstr "Stable identifier used in URLs and topology records. It is auto-generate
 msgid ".tooltip_create_status"
 msgstr "Initial lifecycle state for the new lemming type."
 
-#: lib/lemmings_os_web/components/instance_components.ex:308
-#: lib/lemmings_os_web/live/instance_live.ex:516
+#: lib/lemmings_os_web/components/instance_components.ex:451
+#: lib/lemmings_os_web/live/instance_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:300
-#: lib/lemmings_os_web/live/instance_live.ex:508
+#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:294
-#: lib/lemmings_os_web/live/instance_live.ex:502
+#: lib/lemmings_os_web/components/instance_components.ex:437
+#: lib/lemmings_os_web/live/instance_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:317
+#: lib/lemmings_os_web/live/instance_live.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:356
+#: lib/lemmings_os_web/components/instance_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -661,29 +661,29 @@ msgstr ""
 msgid "Back to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:160
-#: lib/lemmings_os_web/live/instance_live.html.heex:215
+#: lib/lemmings_os_web/live/instance_live.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Chronological messages"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:212
+#: lib/lemmings_os_web/live/instance_live.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Conversation Transcript"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:64
-#: lib/lemmings_os_web/live/instance_live.html.heex:152
+#: lib/lemmings_os_web/live/instance_live.html.heex:162
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:410
+#: lib/lemmings_os_web/live/instance_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:364
+#: lib/lemmings_os_web/live/instance_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -693,12 +693,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:453
+#: lib/lemmings_os_web/components/instance_components.ex:541
+#: lib/lemmings_os_web/live/instance_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -708,19 +709,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:266
-#: lib/lemmings_os_web/live/instance_live.html.heex:304
+#: lib/lemmings_os_web/live/instance_live.html.heex:284
+#: lib/lemmings_os_web/live/instance_live.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:452
+#: lib/lemmings_os_web/live/instance_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:251
-#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:394
+#: lib/lemmings_os_web/live/instance_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -730,55 +731,56 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:332
+#: lib/lemmings_os_web/live/instance_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:20
+#: lib/lemmings_os_web/live/instance_live.ex:21
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:561
+#: lib/lemmings_os_web/live/instance_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:558
-#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:579
+#: lib/lemmings_os_web/live/instance_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:557
-#: lib/lemmings_os_web/live/instance_live.ex:590
+#: lib/lemmings_os_web/live/instance_live.ex:578
+#: lib/lemmings_os_web/live/instance_live.ex:611
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:27
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:338
+#: lib/lemmings_os_web/live/instance_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:138
+#: lib/lemmings_os_web/live/instance_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/live/instance_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:68
-#: lib/lemmings_os_web/live/instance_live.html.heex:221
+#: lib/lemmings_os_web/live/instance_live.html.heex:231
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -788,54 +790,54 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:238
-#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/components/instance_components.ex:381
+#: lib/lemmings_os_web/live/instance_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:587
+#: lib/lemmings_os_web/live/instance_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:76
-#: lib/lemmings_os_web/live/instance_live.html.heex:180
+#: lib/lemmings_os_web/live/instance_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:589
+#: lib/lemmings_os_web/live/instance_live.ex:610
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:221
-#: lib/lemmings_os_web/components/instance_components.ex:244
-#: lib/lemmings_os_web/live/instance_live.ex:433
-#: lib/lemmings_os_web/live/instance_live.ex:469
+#: lib/lemmings_os_web/components/instance_components.ex:364
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:88
-#: lib/lemmings_os_web/live/instance_live.html.heex:168
+#: lib/lemmings_os_web/live/instance_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:449
+#: lib/lemmings_os_web/live/instance_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:588
-#: lib/lemmings_os_web/live/instance_live.html.heex:103
+#: lib/lemmings_os_web/live/instance_live.ex:609
+#: lib/lemmings_os_web/live/instance_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
 msgstr ""
@@ -845,57 +847,58 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:257
-#: lib/lemmings_os_web/live/instance_live.ex:482
+#: lib/lemmings_os_web/components/instance_components.ex:400
+#: lib/lemmings_os_web/live/instance_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:256
-#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/components/instance_components.ex:399
+#: lib/lemmings_os_web/live/instance_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:401
-#: lib/lemmings_os_web/live/instance_live.ex:403
+#: lib/lemmings_os_web/live/instance_live.ex:422
+#: lib/lemmings_os_web/live/instance_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:343
+#: lib/lemmings_os_web/live/instance_live.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:340
+#: lib/lemmings_os_web/live/instance_live.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:121
+#: lib/lemmings_os_web/live/instance_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
-#: lib/lemmings_os_web/components/instance_components.ex:258
-#: lib/lemmings_os_web/live/instance_live.ex:441
-#: lib/lemmings_os_web/live/instance_live.ex:455
-#: lib/lemmings_os_web/live/instance_live.ex:457
-#: lib/lemmings_os_web/live/instance_live.ex:483
-#: lib/lemmings_os_web/live/instance_live.ex:585
-#: lib/lemmings_os_web/live/instance_live.ex:592
+#: lib/lemmings_os_web/components/instance_components.ex:375
+#: lib/lemmings_os_web/components/instance_components.ex:401
+#: lib/lemmings_os_web/live/instance_live.ex:462
+#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/live/instance_live.ex:478
+#: lib/lemmings_os_web/live/instance_live.ex:504
+#: lib/lemmings_os_web/live/instance_live.ex:606
+#: lib/lemmings_os_web/live/instance_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:30
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -905,62 +908,62 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:570
-#: lib/lemmings_os_web/live/instance_live.ex:576
+#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:573
+#: lib/lemmings_os_web/live/instance_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:413
+#: lib/lemmings_os_web/components/instance_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:348
+#: lib/lemmings_os_web/live/instance_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:358
+#: lib/lemmings_os_web/components/instance_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:235
-#: lib/lemmings_os_web/live/instance_live.ex:442
-#: lib/lemmings_os_web/live/instance_live.ex:460
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:378
+#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/live/instance_live.ex:607
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:256
+#: lib/lemmings_os_web/live/instance_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:325
+#: lib/lemmings_os_web/live/instance_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
-#: lib/lemmings_os_web/live/instance_live.ex:499
+#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/live/instance_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:186
+#: lib/lemmings_os_web/live/instance_live.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:166
+#: lib/lemmings_os_web/live/instance_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -970,12 +973,12 @@ msgstr ""
 msgid "Operator action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:107
+#: lib/lemmings_os_web/live/instance_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:160
+#: lib/lemmings_os_web/live/instance_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -985,28 +988,28 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:170
+#: lib/lemmings_os_web/live/instance_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:153
-#: lib/lemmings_os_web/live/instance_live.ex:177
+#: lib/lemmings_os_web/live/instance_live.ex:161
+#: lib/lemmings_os_web/live/instance_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:419
+#: lib/lemmings_os_web/components/instance_components.ex:707
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:201
+#: lib/lemmings_os_web/live/instance_live.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Across transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:195
+#: lib/lemmings_os_web/live/instance_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Total tokens"
 msgstr ""
@@ -1472,3 +1475,159 @@ msgstr "Runtime Dashboard"
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
 msgstr "Spawn instance"
+
+#: lib/lemmings_os_web/components/instance_components.ex:650
+#, elixir-autogen, elixir-format
+msgid "%{count} args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:644
+#, elixir-autogen, elixir-format
+msgid "%{count} ms"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#, elixir-autogen, elixir-format
+msgid "0 args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:293
+#, elixir-autogen, elixir-format
+msgid "Arguments"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Back to session"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:225
+#, elixir-autogen, elixir-format
+msgid "Chronological session activity"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:540
+#, elixir-autogen, elixir-format
+msgid "Completed"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:226
+#, elixir-autogen, elixir-format
+msgid "Config snapshot"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Context messages"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:315
+#, elixir-autogen, elixir-format
+msgid "Error"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "Inspect persisted details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:142
+#, elixir-autogen, elixir-format
+msgid "Inspect raw details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:22
+#, elixir-autogen, elixir-format
+msgid "Instance Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Interaction timeline"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "Latest provider request"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Live executor trace is unavailable. This fallback only shows persisted transcript and tool rows, not every intermediate LLM turn."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "No interaction trace is available yet."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:828
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Raw context"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:304
+#, elixir-autogen, elixir-format
+msgid "Result"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:539
+#, elixir-autogen, elixir-format
+msgid "Running"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "Runtime debug surface"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:214
+#, elixir-autogen, elixir-format
+msgid "Runtime state"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:230
+#, elixir-autogen, elixir-format
+msgid "Tool"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:550
+#, elixir-autogen, elixir-format
+msgid "Tool execution completed successfully."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:556
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed with code %{code}."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:558
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:547
+#, elixir-autogen, elixir-format
+msgid "Tool execution is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "Tool execution recorded."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Tool run"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/world.po
+++ b/priv/gettext/en/LC_MESSAGES/world.po
@@ -44,7 +44,8 @@ msgstr "Unknown"
 #: lib/lemmings_os_web/components/world_components.ex:1135
 #: lib/lemmings_os_web/components/world_components.ex:1139
 #: lib/lemmings_os_web/components/world_components.ex:1160
-#: lib/lemmings_os_web/live/instance_live.ex:277
+#: lib/lemmings_os_web/live/instance_live.ex:298
+#: lib/lemmings_os_web/live/instance_raw_live.ex:842
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "Not available"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -267,22 +267,32 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:69
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:87
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:72
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:90
 #: lib/lemmings_os/lemming_instances/message.ex:62
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:84
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:113
 #, elixir-autogen, elixir-format
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:99
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:142
 #, elixir-autogen, elixir-format
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:68
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:86
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:71
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os_web/live/instance_live.ex:553
 #, elixir-autogen, elixir-format
 msgid ".required"
+msgstr ""
+
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:88
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:117
+#, elixir-autogen, elixir-format
+msgid ".invalid_value"
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -286,7 +286,7 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
-#: lib/lemmings_os_web/live/instance_live.ex:553
+#: lib/lemmings_os_web/live/instance_live.ex:574
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -270,22 +270,32 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "La eliminacion del lemming no esta disponible porque todavia no se puede demostrar que sea segura."
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:69
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:87
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:72
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:90
 #: lib/lemmings_os/lemming_instances/message.ex:62
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:84
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:113
 #, elixir-autogen, elixir-format
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:99
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:142
 #, elixir-autogen, elixir-format
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:68
-#: lib/lemmings_os/lemming_instances/lemming_instance.ex:86
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:71
+#: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os_web/live/instance_live.ex:553
 #, elixir-autogen, elixir-format
 msgid ".required"
+msgstr ""
+
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:88
+#: lib/lemmings_os/lemming_instances/tool_execution.ex:117
+#, elixir-autogen, elixir-format
+msgid ".invalid_value"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -289,7 +289,7 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:89
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
-#: lib/lemmings_os_web/live/instance_live.ex:553
+#: lib/lemmings_os_web/live/instance_live.ex:574
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -224,7 +224,7 @@ msgstr "Departamentos"
 msgid ".page_title_world"
 msgstr "Mundo"
 
-#: lib/lemmings_os_web/live/tools_live.ex:13
+#: lib/lemmings_os_web/live/tools_live.ex:14
 #, elixir-autogen
 msgid ".page_title_tools"
 msgstr "Herramientas"
@@ -324,12 +324,12 @@ msgstr " - Lemmings OS"
 msgid ".breadcrumb_new"
 msgstr "Nuevo"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:57
+#: lib/lemmings_os_web/live/tools_live.html.heex:56
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_subtitle"
 msgstr "Filtra el conjunto actual de herramientas del entorno sin implicar instalación ni completitud de política."
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:56
+#: lib/lemmings_os_web/live/tools_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_title"
 msgstr "Conjunto de herramientas del entorno"
@@ -355,48 +355,49 @@ msgid ".tools_card_usage_label"
 msgstr "Uso"
 
 #: lib/lemmings_os_web/components/system_components.ex:23
+#: lib/lemmings_os_web/live/tools_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_description_unavailable"
 msgstr "No hay descripción disponible del entorno."
 
-#: lib/lemmings_os_web/live/tools_live.ex:107
+#: lib/lemmings_os_web/live/tools_live.ex:112
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_copy"
 msgstr "La fuente de capacidades del entorno está disponible, pero no devolvió ninguna herramienta."
 
-#: lib/lemmings_os_web/live/tools_live.ex:108
+#: lib/lemmings_os_web/live/tools_live.ex:113
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_copy"
 msgstr "Ajusta el filtro local para inspeccionar el conjunto actual de herramientas del entorno."
 
-#: lib/lemmings_os_web/live/tools_live.ex:103
+#: lib/lemmings_os_web/live/tools_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_title"
 msgstr "Ningun tool coincide con este filtro"
 
-#: lib/lemmings_os_web/live/tools_live.ex:105
-#: lib/lemmings_os_web/live/tools_live.ex:106
+#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:111
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_runtime_copy"
 msgstr "La fuente de capacidades del entorno no está disponible, así que todavía no se pueden mostrar herramientas."
 
-#: lib/lemmings_os_web/live/tools_live.ex:100
-#: lib/lemmings_os_web/live/tools_live.ex:101
+#: lib/lemmings_os_web/live/tools_live.ex:105
+#: lib/lemmings_os_web/live/tools_live.ex:106
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_runtime_title"
 msgstr "Capacidad del entorno no disponible"
 
-#: lib/lemmings_os_web/live/tools_live.ex:102
+#: lib/lemmings_os_web/live/tools_live.ex:107
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_title"
 msgstr "No hay herramientas del entorno registradas"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:69
+#: lib/lemmings_os_web/live/tools_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_label"
 msgstr "Filtro local"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:70
+#: lib/lemmings_os_web/live/tools_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_placeholder"
 msgstr "Buscar por nombre, categoria o riesgo"
@@ -406,97 +407,97 @@ msgstr "Buscar por nombre, categoria o riesgo"
 msgid ".tools_health_title"
 msgstr "Salud de la pagina"
 
-#: lib/lemmings_os_web/live/tools_live.ex:143
+#: lib/lemmings_os_web/live/tools_live.ex:148
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_action"
 msgstr "Trata el estado de policy como parcial hasta que exista reconciliacion."
 
-#: lib/lemmings_os_web/live/tools_live.ex:129
+#: lib/lemmings_os_web/live/tools_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_detail"
 msgstr "%{count} tools runtime todavia tienen reconciliacion de policy diferida."
 
-#: lib/lemmings_os_web/live/tools_live.ex:118
+#: lib/lemmings_os_web/live/tools_live.ex:123
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_summary"
 msgstr "La reconciliacion de policy es parcial"
 
-#: lib/lemmings_os_web/live/tools_live.ex:146
+#: lib/lemmings_os_web/live/tools_live.ex:151
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_action"
 msgstr "Usa las capacidades runtime como fuente primaria hasta que exista el estado de policy."
 
-#: lib/lemmings_os_web/live/tools_live.ex:135
+#: lib/lemmings_os_web/live/tools_live.ex:140
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_detail"
 msgstr "El set runtime de tools esta disponible, pero no se pudo cargar la reconciliacion de policy."
 
-#: lib/lemmings_os_web/live/tools_live.ex:121
+#: lib/lemmings_os_web/live/tools_live.ex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_summary"
 msgstr "Estado de policy no disponible"
 
-#: lib/lemmings_os_web/live/tools_live.ex:140
+#: lib/lemmings_os_web/live/tools_live.ex:145
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_action"
 msgstr "Verifica la fuente de capacidades runtime antes de confiar en la disponibilidad de tools."
 
-#: lib/lemmings_os_web/live/tools_live.ex:126
+#: lib/lemmings_os_web/live/tools_live.ex:131
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_detail"
 msgstr "La pagina no pudo obtener datos de capacidades runtime desde la fuente actual."
 
-#: lib/lemmings_os_web/live/tools_live.ex:115
+#: lib/lemmings_os_web/live/tools_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_summary"
 msgstr "Fuente de capacidades runtime no disponible"
 
-#: lib/lemmings_os_web/live/tools_live.ex:112
+#: lib/lemmings_os_web/live/tools_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_many"
 msgstr "Se detectaron %{count} incidencias"
 
-#: lib/lemmings_os_web/live/tools_live.ex:111
+#: lib/lemmings_os_web/live/tools_live.ex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_one"
 msgstr "Se detectó 1 incidencia"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:94
+#: lib/lemmings_os_web/live/tools_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_subtitle"
 msgstr "Los estados unknown y degraded se listan explicitamente."
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:93
+#: lib/lemmings_os_web/live/tools_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_title"
 msgstr "Incidencias"
 
-#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_zero"
 msgstr "No se detectaron incidencias"
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:100
+#: lib/lemmings_os_web/live/tools_live.html.heex:133
 #, elixir-autogen, elixir-format
 msgid ".tools_no_issues"
 msgstr "No se detectaron incidencias."
 
-#: lib/lemmings_os_web/live/tools_live.ex:78
+#: lib/lemmings_os_web/live/tools_live.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_deferred"
 msgstr "La reconciliacion de policy sigue diferida."
 
-#: lib/lemmings_os_web/live/tools_live.ex:83
+#: lib/lemmings_os_web/live/tools_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_known"
 msgstr "Los datos del entorno y de política están alineados."
 
-#: lib/lemmings_os_web/live/tools_live.ex:81
+#: lib/lemmings_os_web/live/tools_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_partial"
 msgstr "Algunas herramientas del entorno siguen con estado de política parcial."
 
-#: lib/lemmings_os_web/live/tools_live.ex:84
+#: lib/lemmings_os_web/live/tools_live.ex:89
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_unknown"
 msgstr "El estado de policy todavia no esta disponible."
@@ -524,23 +525,23 @@ msgstr "Parcial"
 msgid ".tools_policy_title"
 msgstr "Reconciliacion de Policy"
 
-#: lib/lemmings_os_web/live/tools_live.ex:90
+#: lib/lemmings_os_web/live/tools_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_many"
 msgstr "Se observaron %{count} herramientas del entorno"
 
-#: lib/lemmings_os_web/live/tools_live.ex:96
+#: lib/lemmings_os_web/live/tools_live.ex:101
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unavailable"
 msgstr "Fuente del entorno no disponible"
 
-#: lib/lemmings_os_web/live/tools_live.ex:93
 #: lib/lemmings_os_web/live/tools_live.ex:98
+#: lib/lemmings_os_web/live/tools_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unknown"
 msgstr "Fuente del entorno no implementada"
 
-#: lib/lemmings_os_web/live/tools_live.ex:87
+#: lib/lemmings_os_web/live/tools_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_zero"
 msgstr "Fuente del entorno disponible sin herramientas"
@@ -554,31 +555,6 @@ msgstr "Capacidad del entorno"
 #, elixir-autogen, elixir-format
 msgid ".tools_usage_unknown"
 msgstr "Desconocido"
-
-#: lib/lemmings_os_web/live/tools_live.ex:179
-#, elixir-autogen, elixir-format
-msgid ".tools_list_item_copy"
-msgstr "%{name} (riesgo %{risk})"
-
-#: lib/lemmings_os_web/live/tools_live.ex:182
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_high"
-msgstr "alto"
-
-#: lib/lemmings_os_web/live/tools_live.ex:183
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_medium"
-msgstr "medio"
-
-#: lib/lemmings_os_web/live/tools_live.ex:184
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_low"
-msgstr "bajo"
-
-#: lib/lemmings_os_web/live/tools_live.ex:185
-#, elixir-autogen, elixir-format
-msgid ".tools_risk_unknown"
-msgstr "desconocido"
 
 #: lib/lemmings_os_web/components/home_components.ex:260
 #: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
@@ -849,3 +825,28 @@ msgstr "Topologia persistida"
 #, elixir-autogen, elixir-format
 msgid ".home_card_topology_lemming_count_label"
 msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:168
+#, elixir-autogen, elixir-format
+msgid ".tools_list_item_copy"
+msgstr "%{name} (riesgo %{risk})"
+
+#: lib/lemmings_os_web/live/tools_live.ex:171
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_high"
+msgstr "alto"
+
+#: lib/lemmings_os_web/live/tools_live.ex:173
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_low"
+msgstr "bajo"
+
+#: lib/lemmings_os_web/live/tools_live.ex:172
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_medium"
+msgstr "medio"
+
+#: lib/lemmings_os_web/live/tools_live.ex:174
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_unknown"
+msgstr "desconocido"

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -555,6 +555,31 @@ msgstr "Capacidad del entorno"
 msgid ".tools_usage_unknown"
 msgstr "Desconocido"
 
+#: lib/lemmings_os_web/live/tools_live.ex:179
+#, elixir-autogen, elixir-format
+msgid ".tools_list_item_copy"
+msgstr "%{name} (riesgo %{risk})"
+
+#: lib/lemmings_os_web/live/tools_live.ex:182
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_high"
+msgstr "alto"
+
+#: lib/lemmings_os_web/live/tools_live.ex:183
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_medium"
+msgstr "medio"
+
+#: lib/lemmings_os_web/live/tools_live.ex:184
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_low"
+msgstr "bajo"
+
+#: lib/lemmings_os_web/live/tools_live.ex:185
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_unknown"
+msgstr "desconocido"
+
 #: lib/lemmings_os_web/components/home_components.ex:260
 #: lib/lemmings_os_web/page_data/home_dashboard_snapshot.ex:263
 #, elixir-autogen, elixir-format

--- a/priv/gettext/es/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/es/LC_MESSAGES/lemmings.po
@@ -629,30 +629,30 @@ msgstr "Identificador estable usado en URLs y registros de topología. Se genera
 msgid ".tooltip_create_status"
 msgstr "Estado inicial del ciclo de vida para el nuevo tipo de lemming."
 
-#: lib/lemmings_os_web/components/instance_components.ex:308
-#: lib/lemmings_os_web/live/instance_live.ex:516
+#: lib/lemmings_os_web/components/instance_components.ex:451
+#: lib/lemmings_os_web/live/instance_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:300
-#: lib/lemmings_os_web/live/instance_live.ex:508
+#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:294
-#: lib/lemmings_os_web/live/instance_live.ex:502
+#: lib/lemmings_os_web/components/instance_components.ex:437
+#: lib/lemmings_os_web/live/instance_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:317
+#: lib/lemmings_os_web/live/instance_live.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:356
+#: lib/lemmings_os_web/components/instance_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -662,29 +662,29 @@ msgstr ""
 msgid "Back to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:160
-#: lib/lemmings_os_web/live/instance_live.html.heex:215
+#: lib/lemmings_os_web/live/instance_live.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Chronological messages"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:212
+#: lib/lemmings_os_web/live/instance_live.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Conversation Transcript"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:64
-#: lib/lemmings_os_web/live/instance_live.html.heex:152
+#: lib/lemmings_os_web/live/instance_live.html.heex:162
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:410
+#: lib/lemmings_os_web/live/instance_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:364
+#: lib/lemmings_os_web/live/instance_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -694,12 +694,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:453
+#: lib/lemmings_os_web/components/instance_components.ex:541
+#: lib/lemmings_os_web/live/instance_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -709,19 +710,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:266
-#: lib/lemmings_os_web/live/instance_live.html.heex:304
+#: lib/lemmings_os_web/live/instance_live.html.heex:284
+#: lib/lemmings_os_web/live/instance_live.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:452
+#: lib/lemmings_os_web/live/instance_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:251
-#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:394
+#: lib/lemmings_os_web/live/instance_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -731,55 +732,56 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:332
+#: lib/lemmings_os_web/live/instance_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:20
+#: lib/lemmings_os_web/live/instance_live.ex:21
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:561
+#: lib/lemmings_os_web/live/instance_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:558
-#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:579
+#: lib/lemmings_os_web/live/instance_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:557
-#: lib/lemmings_os_web/live/instance_live.ex:590
+#: lib/lemmings_os_web/live/instance_live.ex:578
+#: lib/lemmings_os_web/live/instance_live.ex:611
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:27
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:338
+#: lib/lemmings_os_web/live/instance_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:138
+#: lib/lemmings_os_web/live/instance_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/live/instance_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:68
-#: lib/lemmings_os_web/live/instance_live.html.heex:221
+#: lib/lemmings_os_web/live/instance_live.html.heex:231
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -789,54 +791,54 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:238
-#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/components/instance_components.ex:381
+#: lib/lemmings_os_web/live/instance_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:587
+#: lib/lemmings_os_web/live/instance_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:76
-#: lib/lemmings_os_web/live/instance_live.html.heex:180
+#: lib/lemmings_os_web/live/instance_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:589
+#: lib/lemmings_os_web/live/instance_live.ex:610
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:221
-#: lib/lemmings_os_web/components/instance_components.ex:244
-#: lib/lemmings_os_web/live/instance_live.ex:433
-#: lib/lemmings_os_web/live/instance_live.ex:469
+#: lib/lemmings_os_web/components/instance_components.ex:364
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:88
-#: lib/lemmings_os_web/live/instance_live.html.heex:168
+#: lib/lemmings_os_web/live/instance_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:449
+#: lib/lemmings_os_web/live/instance_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:588
-#: lib/lemmings_os_web/live/instance_live.html.heex:103
+#: lib/lemmings_os_web/live/instance_live.ex:609
+#: lib/lemmings_os_web/live/instance_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
 msgstr ""
@@ -846,57 +848,58 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:257
-#: lib/lemmings_os_web/live/instance_live.ex:482
+#: lib/lemmings_os_web/components/instance_components.ex:400
+#: lib/lemmings_os_web/live/instance_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:256
-#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/components/instance_components.ex:399
+#: lib/lemmings_os_web/live/instance_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:401
-#: lib/lemmings_os_web/live/instance_live.ex:403
+#: lib/lemmings_os_web/live/instance_live.ex:422
+#: lib/lemmings_os_web/live/instance_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:343
+#: lib/lemmings_os_web/live/instance_live.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:340
+#: lib/lemmings_os_web/live/instance_live.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:121
+#: lib/lemmings_os_web/live/instance_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
-#: lib/lemmings_os_web/components/instance_components.ex:258
-#: lib/lemmings_os_web/live/instance_live.ex:441
-#: lib/lemmings_os_web/live/instance_live.ex:455
-#: lib/lemmings_os_web/live/instance_live.ex:457
-#: lib/lemmings_os_web/live/instance_live.ex:483
-#: lib/lemmings_os_web/live/instance_live.ex:585
-#: lib/lemmings_os_web/live/instance_live.ex:592
+#: lib/lemmings_os_web/components/instance_components.ex:375
+#: lib/lemmings_os_web/components/instance_components.ex:401
+#: lib/lemmings_os_web/live/instance_live.ex:462
+#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/live/instance_live.ex:478
+#: lib/lemmings_os_web/live/instance_live.ex:504
+#: lib/lemmings_os_web/live/instance_live.ex:606
+#: lib/lemmings_os_web/live/instance_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:30
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -906,62 +909,62 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:570
-#: lib/lemmings_os_web/live/instance_live.ex:576
+#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:573
+#: lib/lemmings_os_web/live/instance_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:413
+#: lib/lemmings_os_web/components/instance_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:348
+#: lib/lemmings_os_web/live/instance_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:358
+#: lib/lemmings_os_web/components/instance_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:235
-#: lib/lemmings_os_web/live/instance_live.ex:442
-#: lib/lemmings_os_web/live/instance_live.ex:460
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:378
+#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/live/instance_live.ex:607
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:256
+#: lib/lemmings_os_web/live/instance_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:325
+#: lib/lemmings_os_web/live/instance_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
-#: lib/lemmings_os_web/live/instance_live.ex:499
+#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/live/instance_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:186
+#: lib/lemmings_os_web/live/instance_live.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:166
+#: lib/lemmings_os_web/live/instance_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -971,12 +974,12 @@ msgstr ""
 msgid "Operator action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:107
+#: lib/lemmings_os_web/live/instance_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:160
+#: lib/lemmings_os_web/live/instance_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -986,28 +989,28 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:170
+#: lib/lemmings_os_web/live/instance_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:153
-#: lib/lemmings_os_web/live/instance_live.ex:177
+#: lib/lemmings_os_web/live/instance_live.ex:161
+#: lib/lemmings_os_web/live/instance_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:419
+#: lib/lemmings_os_web/components/instance_components.ex:707
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:201
+#: lib/lemmings_os_web/live/instance_live.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Across transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:195
+#: lib/lemmings_os_web/live/instance_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Total tokens"
 msgstr ""
@@ -1473,3 +1476,159 @@ msgstr "Dashboard runtime"
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
 msgstr "Lanzar instancia"
+
+#: lib/lemmings_os_web/components/instance_components.ex:650
+#, elixir-autogen, elixir-format
+msgid "%{count} args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:644
+#, elixir-autogen, elixir-format
+msgid "%{count} ms"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#, elixir-autogen, elixir-format
+msgid "0 args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:293
+#, elixir-autogen, elixir-format
+msgid "Arguments"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Back to session"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:225
+#, elixir-autogen, elixir-format
+msgid "Chronological session activity"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:540
+#, elixir-autogen, elixir-format
+msgid "Completed"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:226
+#, elixir-autogen, elixir-format
+msgid "Config snapshot"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Context messages"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:315
+#, elixir-autogen, elixir-format
+msgid "Error"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "Inspect persisted details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:142
+#, elixir-autogen, elixir-format
+msgid "Inspect raw details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:22
+#, elixir-autogen, elixir-format
+msgid "Instance Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Interaction timeline"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "Latest provider request"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Live executor trace is unavailable. This fallback only shows persisted transcript and tool rows, not every intermediate LLM turn."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "No interaction trace is available yet."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:828
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Raw context"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:304
+#, elixir-autogen, elixir-format
+msgid "Result"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:539
+#, elixir-autogen, elixir-format
+msgid "Running"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "Runtime debug surface"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:214
+#, elixir-autogen, elixir-format
+msgid "Runtime state"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:230
+#, elixir-autogen, elixir-format
+msgid "Tool"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:550
+#, elixir-autogen, elixir-format
+msgid "Tool execution completed successfully."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:556
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed with code %{code}."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:558
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:547
+#, elixir-autogen, elixir-format
+msgid "Tool execution is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "Tool execution recorded."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Tool run"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/world.po
+++ b/priv/gettext/es/LC_MESSAGES/world.po
@@ -44,7 +44,8 @@ msgstr "Desconocido"
 #: lib/lemmings_os_web/components/world_components.ex:1135
 #: lib/lemmings_os_web/components/world_components.ex:1139
 #: lib/lemmings_os_web/components/world_components.ex:1160
-#: lib/lemmings_os_web/live/instance_live.ex:277
+#: lib/lemmings_os_web/live/instance_live.ex:298
+#: lib/lemmings_os_web/live/instance_raw_live.ex:842
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr "No disponible"

--- a/priv/gettext/layout.pot
+++ b/priv/gettext/layout.pot
@@ -219,7 +219,7 @@ msgstr ""
 msgid ".page_title_world"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:13
+#: lib/lemmings_os_web/live/tools_live.ex:14
 #, elixir-autogen
 msgid ".page_title_tools"
 msgstr ""
@@ -319,12 +319,12 @@ msgstr ""
 msgid ".breadcrumb_new"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:57
+#: lib/lemmings_os_web/live/tools_live.html.heex:56
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_subtitle"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:56
+#: lib/lemmings_os_web/live/tools_live.html.heex:55
 #, elixir-autogen, elixir-format
 msgid ".tools_capability_panel_title"
 msgstr ""
@@ -350,48 +350,49 @@ msgid ".tools_card_usage_label"
 msgstr ""
 
 #: lib/lemmings_os_web/components/system_components.ex:23
+#: lib/lemmings_os_web/live/tools_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_description_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:107
+#: lib/lemmings_os_web/live/tools_live.ex:112
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:108
+#: lib/lemmings_os_web/live/tools_live.ex:113
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:103
+#: lib/lemmings_os_web/live/tools_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_filtered_title"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:111
+#, elixir-autogen, elixir-format
+msgid ".tools_empty_runtime_copy"
 msgstr ""
 
 #: lib/lemmings_os_web/live/tools_live.ex:105
 #: lib/lemmings_os_web/live/tools_live.ex:106
 #, elixir-autogen, elixir-format
-msgid ".tools_empty_runtime_copy"
-msgstr ""
-
-#: lib/lemmings_os_web/live/tools_live.ex:100
-#: lib/lemmings_os_web/live/tools_live.ex:101
-#, elixir-autogen, elixir-format
 msgid ".tools_empty_runtime_title"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:102
+#: lib/lemmings_os_web/live/tools_live.ex:107
 #, elixir-autogen, elixir-format
 msgid ".tools_empty_title"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:69
+#: lib/lemmings_os_web/live/tools_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_label"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:70
+#: lib/lemmings_os_web/live/tools_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid ".tools_filter_placeholder"
 msgstr ""
@@ -401,97 +402,97 @@ msgstr ""
 msgid ".tools_health_title"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:143
+#: lib/lemmings_os_web/live/tools_live.ex:148
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:129
+#: lib/lemmings_os_web/live/tools_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:118
+#: lib/lemmings_os_web/live/tools_live.ex:123
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_partial_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:146
+#: lib/lemmings_os_web/live/tools_live.ex:151
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:135
+#: lib/lemmings_os_web/live/tools_live.ex:140
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:121
+#: lib/lemmings_os_web/live/tools_live.ex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_policy_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:140
+#: lib/lemmings_os_web/live/tools_live.ex:145
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:126
+#: lib/lemmings_os_web/live/tools_live.ex:131
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:115
+#: lib/lemmings_os_web/live/tools_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".tools_issue_runtime_source_unavailable_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:112
+#: lib/lemmings_os_web/live/tools_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_many"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:111
+#: lib/lemmings_os_web/live/tools_live.ex:116
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_one"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:94
+#: lib/lemmings_os_web/live/tools_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_subtitle"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:93
+#: lib/lemmings_os_web/live/tools_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_panel_title"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:110
+#: lib/lemmings_os_web/live/tools_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".tools_issues_zero"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.html.heex:100
+#: lib/lemmings_os_web/live/tools_live.html.heex:133
 #, elixir-autogen, elixir-format
 msgid ".tools_no_issues"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:78
+#: lib/lemmings_os_web/live/tools_live.ex:83
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:83
+#: lib/lemmings_os_web/live/tools_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_known"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:81
+#: lib/lemmings_os_web/live/tools_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_partial"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:84
+#: lib/lemmings_os_web/live/tools_live.ex:89
 #, elixir-autogen, elixir-format
 msgid ".tools_policy_copy_unknown"
 msgstr ""
@@ -519,23 +520,23 @@ msgstr ""
 msgid ".tools_policy_title"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:90
+#: lib/lemmings_os_web/live/tools_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_many"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:96
+#: lib/lemmings_os_web/live/tools_live.ex:101
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:93
 #: lib/lemmings_os_web/live/tools_live.ex:98
+#: lib/lemmings_os_web/live/tools_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/live/tools_live.ex:87
+#: lib/lemmings_os_web/live/tools_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".tools_runtime_count_zero"
 msgstr ""
@@ -818,4 +819,29 @@ msgstr ""
 #: lib/lemmings_os_web/components/home_components.ex:203
 #, elixir-autogen, elixir-format
 msgid ".home_card_topology_lemming_count_label"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:168
+#, elixir-autogen, elixir-format
+msgid ".tools_list_item_copy"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:171
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_high"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:173
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_low"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:172
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_medium"
+msgstr ""
+
+#: lib/lemmings_os_web/live/tools_live.ex:174
+#, elixir-autogen, elixir-format
+msgid ".tools_risk_unknown"
 msgstr ""

--- a/priv/gettext/lemmings.pot
+++ b/priv/gettext/lemmings.pot
@@ -616,30 +616,30 @@ msgstr ""
 msgid ".tooltip_create_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:308
-#: lib/lemmings_os_web/live/instance_live.ex:516
+#: lib/lemmings_os_web/components/instance_components.ex:451
+#: lib/lemmings_os_web/live/instance_live.ex:537
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:300
-#: lib/lemmings_os_web/live/instance_live.ex:508
+#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:529
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:294
-#: lib/lemmings_os_web/live/instance_live.ex:502
+#: lib/lemmings_os_web/components/instance_components.ex:437
+#: lib/lemmings_os_web/live/instance_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:317
+#: lib/lemmings_os_web/live/instance_live.html.heex:335
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:356
+#: lib/lemmings_os_web/components/instance_components.ex:499
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -649,29 +649,29 @@ msgstr ""
 msgid "Back to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:160
-#: lib/lemmings_os_web/live/instance_live.html.heex:215
+#: lib/lemmings_os_web/live/instance_live.html.heex:170
 #, elixir-autogen, elixir-format
 msgid "Chronological messages"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:212
+#: lib/lemmings_os_web/live/instance_live.html.heex:222
 #, elixir-autogen, elixir-format
 msgid "Conversation Transcript"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:64
-#: lib/lemmings_os_web/live/instance_live.html.heex:152
+#: lib/lemmings_os_web/live/instance_live.html.heex:162
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:410
+#: lib/lemmings_os_web/live/instance_live.ex:431
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:364
+#: lib/lemmings_os_web/live/instance_live.ex:385
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -681,12 +681,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:475
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:453
+#: lib/lemmings_os_web/components/instance_components.ex:541
+#: lib/lemmings_os_web/live/instance_live.ex:474
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -696,19 +697,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:266
-#: lib/lemmings_os_web/live/instance_live.html.heex:304
+#: lib/lemmings_os_web/live/instance_live.html.heex:284
+#: lib/lemmings_os_web/live/instance_live.html.heex:322
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:452
+#: lib/lemmings_os_web/live/instance_live.ex:473
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:251
-#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:394
+#: lib/lemmings_os_web/live/instance_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -718,55 +719,56 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:332
+#: lib/lemmings_os_web/live/instance_live.ex:353
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:20
+#: lib/lemmings_os_web/live/instance_live.ex:21
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:561
+#: lib/lemmings_os_web/live/instance_live.ex:582
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:558
-#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:579
+#: lib/lemmings_os_web/live/instance_live.ex:612
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:557
-#: lib/lemmings_os_web/live/instance_live.ex:590
+#: lib/lemmings_os_web/live/instance_live.ex:578
+#: lib/lemmings_os_web/live/instance_live.ex:611
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:27
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:19
 #, elixir-autogen, elixir-format
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:338
+#: lib/lemmings_os_web/live/instance_live.ex:359
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:138
+#: lib/lemmings_os_web/live/instance_live.html.heex:148
 #, elixir-autogen, elixir-format
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/live/instance_live.ex:428
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:68
-#: lib/lemmings_os_web/live/instance_live.html.heex:221
+#: lib/lemmings_os_web/live/instance_live.html.heex:231
 #, elixir-autogen, elixir-format
 msgid "Live"
 msgstr ""
@@ -776,54 +778,54 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:443
+#: lib/lemmings_os_web/live/instance_live.ex:464
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:238
-#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/components/instance_components.ex:381
+#: lib/lemmings_os_web/live/instance_live.ex:484
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:587
+#: lib/lemmings_os_web/live/instance_live.ex:608
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:76
-#: lib/lemmings_os_web/live/instance_live.html.heex:180
+#: lib/lemmings_os_web/live/instance_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:589
+#: lib/lemmings_os_web/live/instance_live.ex:610
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:221
-#: lib/lemmings_os_web/components/instance_components.ex:244
-#: lib/lemmings_os_web/live/instance_live.ex:433
-#: lib/lemmings_os_web/live/instance_live.ex:469
+#: lib/lemmings_os_web/components/instance_components.ex:364
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/live/instance_live.ex:454
+#: lib/lemmings_os_web/live/instance_live.ex:490
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
 #: lib/lemmings_os_web/components/instance_components.ex:88
-#: lib/lemmings_os_web/live/instance_live.html.heex:168
+#: lib/lemmings_os_web/live/instance_live.html.heex:178
 #, elixir-autogen, elixir-format
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:449
+#: lib/lemmings_os_web/live/instance_live.ex:470
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:588
-#: lib/lemmings_os_web/live/instance_live.html.heex:103
+#: lib/lemmings_os_web/live/instance_live.ex:609
+#: lib/lemmings_os_web/live/instance_live.html.heex:113
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
 msgstr ""
@@ -833,57 +835,58 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:257
-#: lib/lemmings_os_web/live/instance_live.ex:482
+#: lib/lemmings_os_web/components/instance_components.ex:400
+#: lib/lemmings_os_web/live/instance_live.ex:503
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:256
-#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/components/instance_components.ex:399
+#: lib/lemmings_os_web/live/instance_live.ex:502
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:401
-#: lib/lemmings_os_web/live/instance_live.ex:403
+#: lib/lemmings_os_web/live/instance_live.ex:422
+#: lib/lemmings_os_web/live/instance_live.ex:424
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:343
+#: lib/lemmings_os_web/live/instance_live.html.heex:361
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:340
+#: lib/lemmings_os_web/live/instance_live.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:121
+#: lib/lemmings_os_web/live/instance_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
-#: lib/lemmings_os_web/components/instance_components.ex:258
-#: lib/lemmings_os_web/live/instance_live.ex:441
-#: lib/lemmings_os_web/live/instance_live.ex:455
-#: lib/lemmings_os_web/live/instance_live.ex:457
-#: lib/lemmings_os_web/live/instance_live.ex:483
-#: lib/lemmings_os_web/live/instance_live.ex:585
-#: lib/lemmings_os_web/live/instance_live.ex:592
+#: lib/lemmings_os_web/components/instance_components.ex:375
+#: lib/lemmings_os_web/components/instance_components.ex:401
+#: lib/lemmings_os_web/live/instance_live.ex:462
+#: lib/lemmings_os_web/live/instance_live.ex:476
+#: lib/lemmings_os_web/live/instance_live.ex:478
+#: lib/lemmings_os_web/live/instance_live.ex:504
+#: lib/lemmings_os_web/live/instance_live.ex:606
+#: lib/lemmings_os_web/live/instance_live.ex:613
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
 
 #: lib/lemmings_os_web/live/instance_live.html.heex:30
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:22
 #, elixir-autogen, elixir-format
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:616
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -893,62 +896,62 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:570
-#: lib/lemmings_os_web/live/instance_live.ex:576
+#: lib/lemmings_os_web/live/instance_live.ex:591
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:573
+#: lib/lemmings_os_web/live/instance_live.ex:594
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:413
+#: lib/lemmings_os_web/components/instance_components.ex:701
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:348
+#: lib/lemmings_os_web/live/instance_live.ex:369
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:358
+#: lib/lemmings_os_web/components/instance_components.ex:501
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:235
-#: lib/lemmings_os_web/live/instance_live.ex:442
-#: lib/lemmings_os_web/live/instance_live.ex:460
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:378
+#: lib/lemmings_os_web/live/instance_live.ex:463
+#: lib/lemmings_os_web/live/instance_live.ex:481
+#: lib/lemmings_os_web/live/instance_live.ex:607
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:256
+#: lib/lemmings_os_web/live/instance_live.html.heex:274
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:325
+#: lib/lemmings_os_web/live/instance_live.ex:346
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
-#: lib/lemmings_os_web/live/instance_live.ex:499
+#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/live/instance_live.ex:520
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:186
+#: lib/lemmings_os_web/live/instance_live.html.heex:196
 #, elixir-autogen, elixir-format
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:166
+#: lib/lemmings_os_web/live/instance_live.ex:174
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -958,12 +961,12 @@ msgstr ""
 msgid "Operator action"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:107
+#: lib/lemmings_os_web/live/instance_live.html.heex:117
 #, elixir-autogen, elixir-format
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:160
+#: lib/lemmings_os_web/live/instance_live.ex:168
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -973,28 +976,28 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:170
+#: lib/lemmings_os_web/live/instance_live.ex:178
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:153
-#: lib/lemmings_os_web/live/instance_live.ex:177
+#: lib/lemmings_os_web/live/instance_live.ex:161
+#: lib/lemmings_os_web/live/instance_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:419
+#: lib/lemmings_os_web/components/instance_components.ex:707
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:201
+#: lib/lemmings_os_web/live/instance_live.html.heex:211
 #, elixir-autogen, elixir-format
 msgid "Across transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:195
+#: lib/lemmings_os_web/live/instance_live.html.heex:205
 #, elixir-autogen, elixir-format
 msgid "Total tokens"
 msgstr ""
@@ -1459,4 +1462,160 @@ msgstr ""
 #: lib/lemmings_os_web/components/lemming_components.ex:588
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:650
+#, elixir-autogen, elixir-format
+msgid "%{count} args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:644
+#, elixir-autogen, elixir-format
+msgid "%{count} ms"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#, elixir-autogen, elixir-format
+msgid "0 args"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:293
+#, elixir-autogen, elixir-format
+msgid "Arguments"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:57
+#, elixir-autogen, elixir-format
+msgid "Back to session"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:225
+#, elixir-autogen, elixir-format
+msgid "Chronological session activity"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:540
+#, elixir-autogen, elixir-format
+msgid "Completed"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:226
+#, elixir-autogen, elixir-format
+msgid "Config snapshot"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Context messages"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:315
+#, elixir-autogen, elixir-format
+msgid "Error"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:287
+#, elixir-autogen, elixir-format
+msgid "Inspect persisted details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:142
+#, elixir-autogen, elixir-format
+msgid "Inspect raw details"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:22
+#, elixir-autogen, elixir-format
+msgid "Instance Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:65
+#, elixir-autogen, elixir-format
+msgid "Interaction timeline"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:170
+#, elixir-autogen, elixir-format
+msgid "Latest provider request"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Live executor trace is unavailable. This fallback only shows persisted transcript and tool rows, not every intermediate LLM turn."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:90
+#, elixir-autogen, elixir-format
+msgid "No interaction trace is available yet."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.ex:828
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:39
+#, elixir-autogen, elixir-format
+msgid "Raw Context"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.html.heex:96
+#, elixir-autogen, elixir-format
+msgid "Raw context"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:304
+#, elixir-autogen, elixir-format
+msgid "Result"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:539
+#, elixir-autogen, elixir-format
+msgid "Running"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:36
+#, elixir-autogen, elixir-format
+msgid "Runtime debug surface"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:214
+#, elixir-autogen, elixir-format
+msgid "Runtime state"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_raw_live.html.heex:42
+#, elixir-autogen, elixir-format
+msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:230
+#, elixir-autogen, elixir-format
+msgid "Tool"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:550
+#, elixir-autogen, elixir-format
+msgid "Tool execution completed successfully."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:556
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed with code %{code}."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:558
+#, elixir-autogen, elixir-format
+msgid "Tool execution failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:547
+#, elixir-autogen, elixir-format
+msgid "Tool execution is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:562
+#, elixir-autogen, elixir-format
+msgid "Tool execution recorded."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:232
+#, elixir-autogen, elixir-format
+msgid "Tool run"
 msgstr ""

--- a/priv/gettext/world.pot
+++ b/priv/gettext/world.pot
@@ -40,7 +40,8 @@ msgstr ""
 #: lib/lemmings_os_web/components/world_components.ex:1135
 #: lib/lemmings_os_web/components/world_components.ex:1139
 #: lib/lemmings_os_web/components/world_components.ex:1160
-#: lib/lemmings_os_web/live/instance_live.ex:277
+#: lib/lemmings_os_web/live/instance_live.ex:298
+#: lib/lemmings_os_web/live/instance_raw_live.ex:842
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
 msgstr ""

--- a/priv/repo/migrations/20260418120000_add_work_area_and_tool_executions.exs
+++ b/priv/repo/migrations/20260418120000_add_work_area_and_tool_executions.exs
@@ -1,0 +1,42 @@
+defmodule LemmingsOs.Repo.Migrations.AddWorkAreaAndToolExecutions do
+  use Ecto.Migration
+
+  def up do
+    create table(:lemming_instance_tool_executions, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :lemming_instance_id,
+          references(:lemming_instances, type: :binary_id, on_delete: :delete_all),
+          null: false
+
+      add :world_id, references(:worlds, type: :binary_id, on_delete: :delete_all), null: false
+      add :tool_name, :string, null: false
+      add :status, :string, null: false, default: "running"
+      add :args, :map, null: false
+      add :result, :map
+      add :error, :map
+      add :summary, :text
+      add :preview, :text
+      add :started_at, :utc_datetime
+      add :completed_at, :utc_datetime
+      add :duration_ms, :integer
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:lemming_instance_tool_executions, [:lemming_instance_id])
+    create index(:lemming_instance_tool_executions, [:world_id])
+    create index(:lemming_instance_tool_executions, [:tool_name])
+    create index(:lemming_instance_tool_executions, [:status])
+
+    create index(
+             :lemming_instance_tool_executions,
+             [:lemming_instance_id, :inserted_at],
+             name: :lemming_instance_tool_executions_instance_inserted_at_index
+           )
+  end
+
+  def down do
+    drop table(:lemming_instance_tool_executions)
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -196,11 +196,19 @@ lemming_seeds = %{
     %{
       slug: "budget-brief",
       name: "Budget Brief",
-      status: "draft",
+      status: "active",
       description: "Builds concise budget summaries for operators.",
       instructions:
-        "Summarize budget status, upcoming risks, and the biggest current cost drivers.",
-      tools_config: %{"allowed_tools" => ["github"], "denied_tools" => []}
+        "Summarize budget status, upcoming risks, and the biggest current cost drivers. When the user asks you to create or update a file, use fs.write_text_file with a workspace-relative path instead of only describing the content. When you need external context, use web.search or web.fetch.",
+      tools_config: %{
+        "allowed_tools" => [
+          "fs.read_text_file",
+          "fs.write_text_file",
+          "web.search",
+          "web.fetch"
+        ],
+        "denied_tools" => []
+      }
     },
     %{
       slug: "variance-review",
@@ -277,8 +285,8 @@ world
   |> Lemmings.list_lemmings()
   |> Enum.each(fn lemming -> Repo.delete!(lemming) end)
 
-  world
-  |> Departments.list_departments(city)
+  city
+  |> Departments.list_departments()
   |> Enum.each(fn department -> Repo.delete!(department) end)
 
   Repo.delete!(city)

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -3,6 +3,8 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   import ExUnit.CaptureLog
   require Logger
 
+  @moduletag capture_log: true
+
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.DetsStore
   alias LemmingsOs.LemmingInstances.Executor
@@ -54,6 +56,19 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     end
   end
 
+  defmodule InvalidStructuredOutputModelRuntime do
+    def run(_config_snapshot, _context_messages, _current_item) do
+      {:error,
+       {:invalid_structured_output,
+        %{
+          provider: "fake",
+          model: "broken-model",
+          content: "not-json",
+          raw: %{content: "not-json", provider: "fake", model: "broken-model"}
+        }}}
+    end
+  end
+
   defmodule ToolLoopModelRuntime do
     def run(config_snapshot, context_messages, current_item) do
       observer_pid = Map.get(config_snapshot, :observer_pid)
@@ -62,7 +77,10 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
         send(observer_pid, {:tool_loop_model_run, context_messages, current_item})
       end
 
-      if Enum.any?(context_messages, &String.contains?(&1.content, "Tool web.fetch status=ok")) do
+      if Enum.any?(
+           context_messages,
+           &String.contains?(&1.content, "As response to your previous tool request")
+         ) do
         {:ok,
          Response.new(
            action: :reply,
@@ -79,6 +97,143 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
            tool_args: %{"url" => "https://example.com"},
            provider: "fake",
            model: "tool-loop-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule FinalizationAwareModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:finalization_model_run, context_messages, current_item})
+      end
+
+      if String.contains?(current_item.content, "Finalization Phase:") do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply: "Created sample.md with mock budget data for your boss.",
+           provider: "fake",
+           model: "finalization-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "fs.write_text_file",
+           tool_args: %{"path" => "sample.md", "content" => "# Sample budget"},
+           provider: "fake",
+           model: "finalization-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule RepairOnceModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:repair_model_run, context_messages, current_item})
+      end
+
+      cond do
+        String.contains?(current_item.content, "Repair Notice:") ->
+          {:ok,
+           Response.new(
+             action: :reply,
+             reply: "Created sample.md successfully. It now contains mock budget data.",
+             provider: "fake",
+             model: "repair-model",
+             raw: %{current_item: current_item, context_messages: context_messages}
+           )}
+
+        String.contains?(current_item.content, "Finalization Phase:") ->
+          {:error,
+           {:invalid_structured_output,
+            %{
+              provider: "fake",
+              model: "repair-model",
+              content: "",
+              raw: %{content: "", provider: "fake", model: "repair-model"}
+            }}}
+
+        true ->
+          {:ok,
+           Response.new(
+             action: :tool_call,
+             tool_name: "fs.write_text_file",
+             tool_args: %{"path" => "sample.md", "content" => "# Sample budget"},
+             provider: "fake",
+             model: "repair-model",
+             raw: %{current_item: current_item, context_messages: context_messages}
+           )}
+      end
+    end
+  end
+
+  defmodule RepairFailsModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:repair_fails_model_run, context_messages, current_item})
+      end
+
+      if String.contains?(current_item.content, "Finalization Phase:") do
+        {:error,
+         {:invalid_structured_output,
+          %{
+            provider: "fake",
+            model: "repair-fails-model",
+            content: "",
+            raw: %{content: "", provider: "fake", model: "repair-fails-model"}
+          }}}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "fs.write_text_file",
+           tool_args: %{"path" => "sample.md", "content" => "# Sample budget"},
+           provider: "fake",
+           model: "repair-fails-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule MoreWorkFinalizationModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:more_work_model_run, context_messages, current_item})
+      end
+
+      if String.contains?(current_item.content, "Finalization Phase:") do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply:
+             "sample.md is ready. The next step is to review the figures and adjust them to your real budget before presenting.",
+           provider: "fake",
+           model: "more-work-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "fs.write_text_file",
+           tool_args: %{"path" => "sample.md", "content" => "# Sample budget"},
+           provider: "fake",
+           model: "more-work-model",
            raw: %{current_item: current_item, context_messages: context_messages}
          )}
       end
@@ -159,6 +314,25 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
          summary: "Fetched https://example.com",
          preview: "example preview",
          result: %{url: "https://example.com", status: 200, body: "example body"}
+       }}
+    end
+
+    def execute(_world, _instance, "fs.write_text_file", %{
+          "path" => "sample.md",
+          "content" => content
+        }) do
+      {:ok,
+       %{
+         tool_name: "fs.write_text_file",
+         args: %{"path" => "sample.md", "content" => content},
+         summary: "Wrote file sample.md",
+         preview: String.slice(content, 0, 80),
+         result: %{
+           path: "sample.md",
+           workspace_path: "/workspace/test/sample.md",
+           root_path: "/workspace/test",
+           bytes: byte_size(content)
+         }
        }}
     end
   end
@@ -939,6 +1113,36 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
     assert_receive {:status_changed, %{status: "idle"}}
 
+    assert_receive {:tool_loop_model_run, first_context_messages,
+                    %{content: "Use a tool then reply"}}
+
+    assert_receive {:tool_loop_model_run, second_context_messages, second_current_item}
+
+    assert String.contains?(second_current_item.content, "Finalization Phase:")
+    assert String.contains?(second_current_item.content, "Original user goal:")
+    assert String.contains?(second_current_item.content, "Use a tool then reply")
+    assert String.contains?(second_current_item.content, "Return action=reply")
+
+    assert Enum.count(
+             first_context_messages,
+             &(&1.role == "user" and &1.content == "Use a tool then reply")
+           ) == 1
+
+    assert Enum.count(
+             second_context_messages,
+             &(&1.role == "user" and &1.content == "Use a tool then reply")
+           ) == 1
+
+    assert Enum.any?(
+             second_context_messages,
+             &String.contains?(&1.content, "Assistant requested tool web.fetch with arguments:")
+           )
+
+    assert Enum.any?(
+             second_context_messages,
+             &String.contains?(&1.content, "As response to your previous tool request")
+           )
+
     messages = LemmingInstances.list_messages(instance)
 
     assert Enum.any?(
@@ -952,6 +1156,27 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
     assert [%{status: "ok", summary: "Fetched https://example.com", result: result}] = executions
     assert result["status"] == 200
+
+    model_steps = Executor.snapshot(pid).model_steps
+
+    assert [
+             %{
+               step_index: 1,
+               status: "ok",
+               parsed_output: %{"action" => "tool_call", "tool_name" => "web.fetch"},
+               tool_execution_id: tool_execution_id
+             },
+             %{
+               step_index: 2,
+               status: "ok",
+               parsed_output: %{
+                 "action" => "reply",
+                 "reply" => "final response with tool context"
+               }
+             }
+           ] = model_steps
+
+    assert is_binary(tool_execution_id)
 
     assert Enum.any?(
              ActivityLog.recent_events(),
@@ -967,6 +1192,137 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
     detach(started_ref)
     detach(completed_ref)
+    GenServer.stop(pid)
+  end
+
+  test "S08b: tool success enters finalization phase and returns normal final response", %{
+    instance: instance
+  } do
+    resource_key = "ollama:finalization-model"
+    assert :ok = PubSub.subscribe_instance(instance.id)
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{observer_pid: self(), model: "finalization-model"},
+        context_mod: LemmingInstances,
+        model_mod: FinalizationAwareModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: nil,
+        name: nil
+      )
+
+    start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Create sample.md for my boss")
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert eventually_status(pid, "idle")
+
+    assert_receive {:finalization_model_run, _first_context_messages,
+                    %{content: "Create sample.md for my boss"}}
+
+    assert_receive {:finalization_model_run, _second_context_messages, finalization_item}
+    assert String.contains?(finalization_item.content, "Finalization Phase:")
+    assert String.contains?(finalization_item.content, "Artifacts created:")
+    assert String.contains?(finalization_item.content, "- sample.md")
+
+    assert Enum.any?(
+             LemmingInstances.list_messages(instance),
+             &(&1.role == "assistant" and
+                 &1.content == "Created sample.md with mock budget data for your boss.")
+           )
+
+    GenServer.stop(pid)
+  end
+
+  test "S08c: tool success empty final response triggers one repair retry", %{instance: instance} do
+    resource_key = "ollama:repair-model"
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{observer_pid: self(), model: "repair-model"},
+        context_mod: LemmingInstances,
+        model_mod: RepairOnceModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: nil,
+        name: nil
+      )
+
+    start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Create sample.md for my boss")
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert eventually_status(pid, "idle")
+
+    assert_receive {:repair_model_run, _context_messages,
+                    %{content: "Create sample.md for my boss"}}
+
+    assert_receive {:repair_model_run, _context_messages, finalization_item}
+    assert String.contains?(finalization_item.content, "Finalization Phase:")
+    refute String.contains?(finalization_item.content, "Repair Notice:")
+
+    assert_receive {:repair_model_run, _context_messages, repaired_item}
+    assert String.contains?(repaired_item.content, "Repair Notice:")
+
+    assert Enum.any?(
+             LemmingInstances.list_messages(instance),
+             &(&1.role == "assistant" and
+                 &1.content == "Created sample.md successfully. It now contains mock budget data.")
+           )
+
+    model_steps = Executor.snapshot(pid).model_steps
+    assert length(model_steps) == 3
+    assert Enum.at(model_steps, 1).status == "error"
+    assert Enum.at(model_steps, 2).status == "ok"
+
+    GenServer.stop(pid)
+  end
+
+  test "S08d: final response can communicate next step after tool success", %{instance: instance} do
+    resource_key = "ollama:more-work-model"
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{observer_pid: self(), model: "more-work-model"},
+        context_mod: LemmingInstances,
+        model_mod: MoreWorkFinalizationModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: nil,
+        name: nil
+      )
+
+    start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Create sample.md for my boss")
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert eventually_status(pid, "idle")
+
+    assert Enum.any?(
+             LemmingInstances.list_messages(instance),
+             &(&1.role == "assistant" and
+                 String.contains?(&1.content, "The next step is to review the figures"))
+           )
+
     GenServer.stop(pid)
   end
 
@@ -1050,6 +1406,103 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
       detach(failed_ref)
       GenServer.stop(pid)
     end)
+  end
+
+  test "S10: invalid structured output keeps raw provider content in model steps", %{
+    instance: instance
+  } do
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{observer_pid: self(), model: "broken-model"},
+        context_mod: LemmingInstances,
+        model_mod: InvalidStructuredOutputModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: nil,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: nil
+      )
+
+    assert :ok = Executor.enqueue_work(pid, "Break structured output")
+    Executor.admit(pid)
+    assert eventually_status(pid, "failed")
+
+    assert %{
+             status: "failed",
+             last_error: "Model returned invalid structured output."
+           } = Executor.snapshot(pid)
+
+    assert [
+             %{
+               step_index: 1,
+               status: "error",
+               response_payload: %{"content" => "not-json"},
+               error: %{"kind" => "invalid_structured_output", "content" => "not-json"}
+             },
+             %{
+               step_index: 2,
+               status: "error",
+               response_payload: %{"content" => "not-json"},
+               error: %{"kind" => "invalid_structured_output", "content" => "not-json"}
+             },
+             %{
+               step_index: 3,
+               status: "error",
+               response_payload: %{"content" => "not-json"},
+               error: %{"kind" => "invalid_structured_output", "content" => "not-json"}
+             }
+           ] = Executor.snapshot(pid).model_steps
+
+    GenServer.stop(pid)
+  end
+
+  test "S10b: finalization repair runs only once and does not loop forever", %{instance: instance} do
+    resource_key = "ollama:repair-fails-model"
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{observer_pid: self(), model: "repair-fails-model"},
+        context_mod: LemmingInstances,
+        model_mod: RepairFailsModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: nil,
+        name: nil
+      )
+
+    start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Create sample.md for my boss")
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert eventually_status(pid, "failed")
+
+    assert_receive {:repair_fails_model_run, _context_messages,
+                    %{content: "Create sample.md for my boss"}}
+
+    assert_receive {:repair_fails_model_run, _context_messages, finalization_item}
+    assert String.contains?(finalization_item.content, "Finalization Phase:")
+    refute String.contains?(finalization_item.content, "Repair Notice:")
+
+    assert_receive {:repair_fails_model_run, _context_messages, repaired_item}
+    assert String.contains?(repaired_item.content, "Repair Notice:")
+
+    refute_receive {:repair_fails_model_run, _context_messages, _current_item}, 100
+
+    model_steps = Executor.snapshot(pid).model_steps
+    assert length(model_steps) == 3
+    assert Enum.at(model_steps, 0).status == "ok"
+    assert Enum.at(model_steps, 1).status == "error"
+    assert Enum.at(model_steps, 2).status == "error"
+
+    GenServer.stop(pid)
   end
 
   test "S10: tool_call success emits structured started/completed lifecycle logs", %{
@@ -1268,6 +1721,21 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
   defp wait_for_pool_status(resource_key, expected_status, 0) do
     assert ResourcePool.status(resource_key) == expected_status
+  end
+
+  defp eventually_status(pid, expected_status, attempts \\ 20)
+
+  defp eventually_status(pid, expected_status, attempts) when attempts > 0 do
+    if Executor.status(pid).status == expected_status do
+      true
+    else
+      Process.sleep(10)
+      eventually_status(pid, expected_status, attempts - 1)
+    end
+  end
+
+  defp eventually_status(pid, expected_status, 0) do
+    assert Executor.status(pid).status == expected_status
   end
 
   defp capture_info_log(fun) when is_function(fun, 0) do

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -10,6 +10,7 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   alias LemmingsOs.LemmingInstances.RuntimeTableOwner
   alias LemmingsOs.LemmingTools
   alias LemmingsOs.ModelRuntime.Response
+  alias LemmingsOs.Runtime.ActivityLog
   alias LemmingsOs.Worlds.World
 
   defmodule FakeModelRuntime do
@@ -161,6 +162,8 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
   setup do
     start_supervised!(RuntimeTableOwner)
+    ensure_process_started!(ActivityLog)
+    ActivityLog.clear()
     ensure_registry!(LemmingsOs.LemmingInstances.ExecutorRegistry)
     ensure_registry!(LemmingsOs.LemmingInstances.PoolRegistry)
     ensure_dynamic_supervisor!(LemmingsOs.LemmingInstances.PoolSupervisor)
@@ -842,6 +845,9 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   test "S08: tool_call loop executes tool runtime and continues until final reply", %{
     instance: instance
   } do
+    started_ref = attach([:lemmings_os, :runtime, :tool_execution, :started])
+    completed_ref = attach([:lemmings_os, :runtime, :tool_execution, :completed])
+
     resource_key = "ollama:tool-loop-model"
     assert :ok = PubSub.subscribe_instance(instance.id)
     assert :ok = PubSub.subscribe_instance_messages(instance.id)
@@ -877,6 +883,25 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     assert_receive {:status_changed, %{status: "processing"}}
     assert_receive {:tool_execution_upserted, %{status: "running"}}
     assert_receive {:tool_execution_upserted, %{status: "ok"}}
+
+    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :started],
+                    %{count: 1}, started_metadata}
+
+    assert started_metadata.instance_id == instance.id
+    assert started_metadata.world_id == instance.world_id
+    assert started_metadata.city_id == instance.city_id
+    assert started_metadata.department_id == instance.department_id
+    assert started_metadata.lemming_id == instance.lemming_id
+    assert started_metadata.tool_name == "web.fetch"
+
+    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :completed],
+                    %{count: 1, duration_ms: duration_ms}, completed_metadata}
+
+    assert duration_ms >= 0
+    assert completed_metadata.instance_id == instance.id
+    assert completed_metadata.tool_name == "web.fetch"
+    assert completed_metadata.tool_status == "ok"
+
     assert_receive {:status_changed, %{status: "idle"}}
 
     messages = LemmingInstances.list_messages(instance)
@@ -893,10 +918,27 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     assert [%{status: "ok", summary: "Fetched https://example.com", result: result}] = executions
     assert result["status"] == 200
 
+    assert Enum.any?(
+             ActivityLog.recent_events(),
+             &(&1.agent == "tool_execution" and &1.action == "Tool started" and
+                 &1.metadata[:tool_name] == "web.fetch")
+           )
+
+    assert Enum.any?(
+             ActivityLog.recent_events(),
+             &(&1.agent == "tool_execution" and &1.action == "Tool completed" and
+                 &1.metadata[:tool_name] == "web.fetch")
+           )
+
+    detach(started_ref)
+    detach(completed_ref)
     GenServer.stop(pid)
   end
 
   test "S09: tool_call errors are persisted and reasoning can continue", %{instance: instance} do
+    started_ref = attach([:lemmings_os, :runtime, :tool_execution, :started])
+    failed_ref = attach([:lemmings_os, :runtime, :tool_execution, :failed])
+
     resource_key = "ollama:tool-loop-error-model"
     assert :ok = PubSub.subscribe_instance(instance.id)
     assert :ok = PubSub.subscribe_instance_messages(instance.id)
@@ -934,6 +976,19 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     assert_receive {:status_changed, %{status: "processing"}}
     assert_receive {:tool_execution_upserted, %{status: "running"}}
     assert_receive {:tool_execution_upserted, %{status: "error"}}
+
+    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :started],
+                    %{count: 1}, _started_metadata}
+
+    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :failed],
+                    %{count: 1, duration_ms: duration_ms}, failed_metadata}
+
+    assert duration_ms >= 0
+    assert failed_metadata.instance_id == instance.id
+    assert failed_metadata.tool_name == "web.fetch"
+    assert failed_metadata.tool_status == "error"
+    assert failed_metadata.reason == "tool.web.request_failed"
+
     assert_receive {:status_changed, %{status: "idle"}}
 
     messages = LemmingInstances.list_messages(instance)
@@ -949,6 +1004,14 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
     assert [%{status: "error", error: %{"code" => "tool.web.request_failed"}}] = executions
 
+    assert Enum.any?(
+             ActivityLog.recent_events(),
+             &(&1.agent == "tool_execution" and &1.action == "Tool failed" and
+                 &1.metadata[:reason] == "tool.web.request_failed")
+           )
+
+    detach(started_ref)
+    detach(failed_ref)
     GenServer.stop(pid)
   end
 
@@ -972,6 +1035,38 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
         start_supervised!({DynamicSupervisor, name: name, strategy: :one_for_one})
         :ok
     end
+  end
+
+  defp ensure_process_started!(child) do
+    case Process.whereis(child) do
+      pid when is_pid(pid) ->
+        :ok
+
+      nil ->
+        start_supervised!(child)
+        :ok
+    end
+  end
+
+  defp attach(event) do
+    ref = make_ref()
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        "executor-telemetry-test-#{inspect(ref)}",
+        event,
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+    ref
+  end
+
+  defp detach(ref) do
+    :telemetry.detach("executor-telemetry-test-#{inspect(ref)}")
   end
 
   defp wait_for_pool_status(resource_key, expected_status, attempts \\ 20)

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -1,6 +1,7 @@
 defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   use LemmingsOs.DataCase, async: false
   import ExUnit.CaptureLog
+  require Logger
 
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.DetsStore
@@ -109,6 +110,40 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
            tool_args: %{"url" => "https://broken.example.invalid"},
            provider: "fake",
            model: "tool-loop-error-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule UnsupportedToolLoopModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:unsupported_tool_model_run, context_messages, current_item})
+      end
+
+      if Enum.any?(
+           context_messages,
+           &String.contains?(&1.content, "\"code\":\"tool.unsupported\"")
+         ) do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply: "final response after unsupported tool",
+           provider: "fake",
+           model: "unsupported-tool-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "exec.run",
+           tool_args: %{},
+           provider: "fake",
+           model: "unsupported-tool-model",
            raw: %{current_item: current_item, context_messages: context_messages}
          )}
       end
@@ -1017,6 +1052,152 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     end)
   end
 
+  test "S10: tool_call success emits structured started/completed lifecycle logs", %{
+    instance: instance
+  } do
+    log =
+      capture_info_log(fn ->
+        resource_key = "ollama:tool-loop-log-success"
+        assert :ok = PubSub.subscribe_instance(instance.id)
+        assert :ok = PubSub.subscribe_instance_messages(instance.id)
+
+        {:ok, pid} =
+          Executor.start_link(
+            instance: instance,
+            config_snapshot: %{
+              model: "tool-loop-log-success",
+              observer_pid: self(),
+              models_config: %{
+                profiles: %{default: %{provider: "ollama", model: "tool-loop-log-success"}}
+              }
+            },
+            context_mod: LemmingInstances,
+            model_mod: ToolLoopModelRuntime,
+            tools_context_mod: LemmingTools,
+            tool_runtime_mod: SuccessToolRuntime,
+            pool_mod: ResourcePool,
+            pubsub_mod: Phoenix.PubSub,
+            dets_mod: nil,
+            ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+            name: nil
+          )
+
+        {:ok, _pool_pid} =
+          start_supervised(
+            {ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil}
+          )
+
+        assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+        assert :ok = Executor.enqueue_work(pid, "Use a tool and log success")
+        assert_receive {:status_changed, %{status: "queued"}}
+
+        send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+        assert_receive {:status_changed, %{status: "processing"}}
+        assert_receive {:tool_execution_upserted, %{status: "running"}}
+        assert_receive {:tool_execution_upserted, %{status: "ok"}}
+        assert_receive {:status_changed, %{status: "idle"}}
+
+        GenServer.stop(pid)
+      end)
+
+    assert log =~ "event=instance.executor.tool_execution.started"
+    assert log =~ "event=instance.executor.tool_execution.completed"
+    assert log =~ "operation=web.fetch"
+    assert log =~ "status=running"
+    assert log =~ "status=ok"
+  end
+
+  test "S11: unsupported tool requests persist error and emit failed lifecycle logs", %{
+    instance: instance
+  } do
+    log =
+      capture_info_log(fn ->
+        started_ref = attach([:lemmings_os, :runtime, :tool_execution, :started])
+        failed_ref = attach([:lemmings_os, :runtime, :tool_execution, :failed])
+
+        resource_key = "ollama:unsupported-tool-model"
+        assert :ok = PubSub.subscribe_instance(instance.id)
+        assert :ok = PubSub.subscribe_instance_messages(instance.id)
+
+        {:ok, pid} =
+          Executor.start_link(
+            instance: instance,
+            config_snapshot: %{
+              model: "unsupported-tool-model",
+              observer_pid: self(),
+              models_config: %{
+                profiles: %{default: %{provider: "ollama", model: "unsupported-tool-model"}}
+              }
+            },
+            context_mod: LemmingInstances,
+            model_mod: UnsupportedToolLoopModelRuntime,
+            tools_context_mod: LemmingTools,
+            tool_runtime_mod: LemmingsOs.Tools.Runtime,
+            pool_mod: ResourcePool,
+            pubsub_mod: Phoenix.PubSub,
+            dets_mod: nil,
+            ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+            name: nil
+          )
+
+        {:ok, _pool_pid} =
+          start_supervised(
+            {ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil}
+          )
+
+        assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+        assert :ok = Executor.enqueue_work(pid, "Use unsupported tool then recover")
+        assert_receive {:status_changed, %{status: "queued"}}
+
+        send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+        assert_receive {:status_changed, %{status: "processing"}}
+        assert_receive {:tool_execution_upserted, %{status: "running"}}
+        assert_receive {:tool_execution_upserted, %{status: "error"}}
+
+        assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :started],
+                        %{count: 1}, started_metadata}
+
+        assert started_metadata.tool_name == "exec.run"
+        assert started_metadata.instance_id == instance.id
+
+        assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :failed],
+                        %{count: 1, duration_ms: duration_ms}, failed_metadata}
+
+        assert duration_ms >= 0
+        assert failed_metadata.tool_name == "exec.run"
+        assert failed_metadata.tool_status == "error"
+        assert failed_metadata.reason == "tool.unsupported"
+
+        assert_receive {:status_changed, %{status: "idle"}}
+
+        messages = LemmingInstances.list_messages(instance)
+
+        assert Enum.any?(
+                 messages,
+                 &(&1.role == "assistant" and
+                     &1.content == "final response after unsupported tool")
+               )
+
+        executions =
+          LemmingTools.list_tool_executions(%World{id: instance.world_id}, instance)
+          |> Enum.filter(&(&1.tool_name == "exec.run"))
+
+        assert [%{status: "error", error: %{"code" => "tool.unsupported"}}] = executions
+
+        detach(started_ref)
+        detach(failed_ref)
+        GenServer.stop(pid)
+      end)
+
+    assert log =~ "event=instance.executor.tool_execution.started"
+    assert log =~ "event=instance.executor.tool_execution.failed"
+    assert log =~ "operation=exec.run"
+    assert log =~ "reason=tool.unsupported"
+    assert log =~ "status=error"
+  end
+
   defp ensure_registry!(name) do
     case Process.whereis(name) do
       pid when is_pid(pid) ->
@@ -1087,5 +1268,19 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
   defp wait_for_pool_status(resource_key, expected_status, 0) do
     assert ResourcePool.status(resource_key) == expected_status
+  end
+
+  defp capture_info_log(fun) when is_function(fun, 0) do
+    previous_level = Logger.level()
+
+    try do
+      Logger.configure(level: :info)
+
+      capture_log([level: :info], fn ->
+        fun.()
+      end)
+    after
+      Logger.configure(level: previous_level)
+    end
   end
 end

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -8,7 +8,9 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   alias LemmingsOs.LemmingInstances.PubSub
   alias LemmingsOs.LemmingInstances.ResourcePool
   alias LemmingsOs.LemmingInstances.RuntimeTableOwner
+  alias LemmingsOs.LemmingTools
   alias LemmingsOs.ModelRuntime.Response
+  alias LemmingsOs.Worlds.World
 
   defmodule FakeModelRuntime do
     def run(config_snapshot, context_messages, current_item) do
@@ -20,6 +22,7 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
 
       {:ok,
        Response.new(
+         action: :reply,
          reply: "processed",
          provider: "fake",
          model: Map.get(config_snapshot, :model, "fake-model"),
@@ -46,6 +49,93 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   defmodule ProviderHttpErrorModelRuntime do
     def run(_config_snapshot, _context_messages, _current_item) do
       {:error, {:provider_http_error, %{provider: "ollama", status: 500, detail: "boom"}}}
+    end
+  end
+
+  defmodule ToolLoopModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:tool_loop_model_run, context_messages, current_item})
+      end
+
+      if Enum.any?(context_messages, &String.contains?(&1.content, "Tool web.fetch status=ok")) do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply: "final response with tool context",
+           provider: "fake",
+           model: "tool-loop-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "web.fetch",
+           tool_args: %{"url" => "https://example.com"},
+           provider: "fake",
+           model: "tool-loop-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule ToolLoopErrorModelRuntime do
+    def run(config_snapshot, context_messages, current_item) do
+      observer_pid = Map.get(config_snapshot, :observer_pid)
+
+      if is_pid(observer_pid) do
+        send(observer_pid, {:tool_loop_error_model_run, context_messages, current_item})
+      end
+
+      if Enum.any?(context_messages, &String.contains?(&1.content, "status=error")) do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply: "final response after tool error",
+           provider: "fake",
+           model: "tool-loop-error-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "web.fetch",
+           tool_args: %{"url" => "https://broken.example.invalid"},
+           provider: "fake",
+           model: "tool-loop-error-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule SuccessToolRuntime do
+    def execute(_world, _instance, "web.fetch", %{"url" => "https://example.com"}) do
+      {:ok,
+       %{
+         tool_name: "web.fetch",
+         args: %{"url" => "https://example.com"},
+         summary: "Fetched https://example.com",
+         preview: "example preview",
+         result: %{url: "https://example.com", status: 200, body: "example body"}
+       }}
+    end
+  end
+
+  defmodule ErrorToolRuntime do
+    def execute(_world, _instance, "web.fetch", _args) do
+      {:error,
+       %{
+         tool_name: "web.fetch",
+         code: "tool.web.request_failed",
+         message: "Web fetch request failed",
+         details: %{reason: "dns"}
+       }}
     end
   end
 
@@ -745,6 +835,119 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
                     %{content: "Second queued item"}}
 
     assert_receive {:status_changed, %{status: "idle"}}
+
+    GenServer.stop(pid)
+  end
+
+  test "S08: tool_call loop executes tool runtime and continues until final reply", %{
+    instance: instance
+  } do
+    resource_key = "ollama:tool-loop-model"
+    assert :ok = PubSub.subscribe_instance(instance.id)
+    assert :ok = PubSub.subscribe_instance_messages(instance.id)
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{
+          model: "tool-loop-model",
+          observer_pid: self(),
+          models_config: %{profiles: %{default: %{provider: "ollama", model: "tool-loop-model"}}}
+        },
+        context_mod: LemmingInstances,
+        model_mod: ToolLoopModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: SuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+        name: nil
+      )
+
+    {:ok, _pool_pid} =
+      start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Use a tool then reply")
+    assert_receive {:status_changed, %{status: "queued"}}
+
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert_receive {:status_changed, %{status: "processing"}}
+    assert_receive {:tool_execution_upserted, %{status: "running"}}
+    assert_receive {:tool_execution_upserted, %{status: "ok"}}
+    assert_receive {:status_changed, %{status: "idle"}}
+
+    messages = LemmingInstances.list_messages(instance)
+
+    assert Enum.any?(
+             messages,
+             &(&1.role == "assistant" and &1.content == "final response with tool context")
+           )
+
+    executions =
+      LemmingTools.list_tool_executions(%World{id: instance.world_id}, instance)
+      |> Enum.filter(&(&1.tool_name == "web.fetch"))
+
+    assert [%{status: "ok", summary: "Fetched https://example.com", result: result}] = executions
+    assert result["status"] == 200
+
+    GenServer.stop(pid)
+  end
+
+  test "S09: tool_call errors are persisted and reasoning can continue", %{instance: instance} do
+    resource_key = "ollama:tool-loop-error-model"
+    assert :ok = PubSub.subscribe_instance(instance.id)
+    assert :ok = PubSub.subscribe_instance_messages(instance.id)
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{
+          model: "tool-loop-error-model",
+          observer_pid: self(),
+          models_config: %{
+            profiles: %{default: %{provider: "ollama", model: "tool-loop-error-model"}}
+          }
+        },
+        context_mod: LemmingInstances,
+        model_mod: ToolLoopErrorModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: ErrorToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+        name: nil
+      )
+
+    {:ok, _pool_pid} =
+      start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Use a failing tool then reply")
+    assert_receive {:status_changed, %{status: "queued"}}
+
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert_receive {:status_changed, %{status: "processing"}}
+    assert_receive {:tool_execution_upserted, %{status: "running"}}
+    assert_receive {:tool_execution_upserted, %{status: "error"}}
+    assert_receive {:status_changed, %{status: "idle"}}
+
+    messages = LemmingInstances.list_messages(instance)
+
+    assert Enum.any?(
+             messages,
+             &(&1.role == "assistant" and &1.content == "final response after tool error")
+           )
+
+    executions =
+      LemmingTools.list_tool_executions(%World{id: instance.world_id}, instance)
+      |> Enum.filter(&(&1.tool_name == "web.fetch"))
+
+    assert [%{status: "error", error: %{"code" => "tool.web.request_failed"}}] = executions
 
     GenServer.stop(pid)
   end

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -936,83 +936,85 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
   end
 
   test "S09: tool_call errors are persisted and reasoning can continue", %{instance: instance} do
-    started_ref = attach([:lemmings_os, :runtime, :tool_execution, :started])
-    failed_ref = attach([:lemmings_os, :runtime, :tool_execution, :failed])
+    capture_log(fn ->
+      started_ref = attach([:lemmings_os, :runtime, :tool_execution, :started])
+      failed_ref = attach([:lemmings_os, :runtime, :tool_execution, :failed])
 
-    resource_key = "ollama:tool-loop-error-model"
-    assert :ok = PubSub.subscribe_instance(instance.id)
-    assert :ok = PubSub.subscribe_instance_messages(instance.id)
+      resource_key = "ollama:tool-loop-error-model"
+      assert :ok = PubSub.subscribe_instance(instance.id)
+      assert :ok = PubSub.subscribe_instance_messages(instance.id)
 
-    {:ok, pid} =
-      Executor.start_link(
-        instance: instance,
-        config_snapshot: %{
-          model: "tool-loop-error-model",
-          observer_pid: self(),
-          models_config: %{
-            profiles: %{default: %{provider: "ollama", model: "tool-loop-error-model"}}
-          }
-        },
-        context_mod: LemmingInstances,
-        model_mod: ToolLoopErrorModelRuntime,
-        tools_context_mod: LemmingTools,
-        tool_runtime_mod: ErrorToolRuntime,
-        pool_mod: ResourcePool,
-        pubsub_mod: Phoenix.PubSub,
-        dets_mod: nil,
-        ets_mod: LemmingsOs.LemmingInstances.EtsStore,
-        name: nil
-      )
+      {:ok, pid} =
+        Executor.start_link(
+          instance: instance,
+          config_snapshot: %{
+            model: "tool-loop-error-model",
+            observer_pid: self(),
+            models_config: %{
+              profiles: %{default: %{provider: "ollama", model: "tool-loop-error-model"}}
+            }
+          },
+          context_mod: LemmingInstances,
+          model_mod: ToolLoopErrorModelRuntime,
+          tools_context_mod: LemmingTools,
+          tool_runtime_mod: ErrorToolRuntime,
+          pool_mod: ResourcePool,
+          pubsub_mod: Phoenix.PubSub,
+          dets_mod: nil,
+          ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+          name: nil
+        )
 
-    {:ok, _pool_pid} =
-      start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+      {:ok, _pool_pid} =
+        start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
 
-    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
-    assert :ok = Executor.enqueue_work(pid, "Use a failing tool then reply")
-    assert_receive {:status_changed, %{status: "queued"}}
+      assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+      assert :ok = Executor.enqueue_work(pid, "Use a failing tool then reply")
+      assert_receive {:status_changed, %{status: "queued"}}
 
-    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+      send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
 
-    assert_receive {:status_changed, %{status: "processing"}}
-    assert_receive {:tool_execution_upserted, %{status: "running"}}
-    assert_receive {:tool_execution_upserted, %{status: "error"}}
+      assert_receive {:status_changed, %{status: "processing"}}
+      assert_receive {:tool_execution_upserted, %{status: "running"}}
+      assert_receive {:tool_execution_upserted, %{status: "error"}}
 
-    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :started],
-                    %{count: 1}, _started_metadata}
+      assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :started],
+                      %{count: 1}, _started_metadata}
 
-    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :failed],
-                    %{count: 1, duration_ms: duration_ms}, failed_metadata}
+      assert_receive {:telemetry_event, [:lemmings_os, :runtime, :tool_execution, :failed],
+                      %{count: 1, duration_ms: duration_ms}, failed_metadata}
 
-    assert duration_ms >= 0
-    assert failed_metadata.instance_id == instance.id
-    assert failed_metadata.tool_name == "web.fetch"
-    assert failed_metadata.tool_status == "error"
-    assert failed_metadata.reason == "tool.web.request_failed"
+      assert duration_ms >= 0
+      assert failed_metadata.instance_id == instance.id
+      assert failed_metadata.tool_name == "web.fetch"
+      assert failed_metadata.tool_status == "error"
+      assert failed_metadata.reason == "tool.web.request_failed"
 
-    assert_receive {:status_changed, %{status: "idle"}}
+      assert_receive {:status_changed, %{status: "idle"}}
 
-    messages = LemmingInstances.list_messages(instance)
+      messages = LemmingInstances.list_messages(instance)
 
-    assert Enum.any?(
-             messages,
-             &(&1.role == "assistant" and &1.content == "final response after tool error")
-           )
+      assert Enum.any?(
+               messages,
+               &(&1.role == "assistant" and &1.content == "final response after tool error")
+             )
 
-    executions =
-      LemmingTools.list_tool_executions(%World{id: instance.world_id}, instance)
-      |> Enum.filter(&(&1.tool_name == "web.fetch"))
+      executions =
+        LemmingTools.list_tool_executions(%World{id: instance.world_id}, instance)
+        |> Enum.filter(&(&1.tool_name == "web.fetch"))
 
-    assert [%{status: "error", error: %{"code" => "tool.web.request_failed"}}] = executions
+      assert [%{status: "error", error: %{"code" => "tool.web.request_failed"}}] = executions
 
-    assert Enum.any?(
-             ActivityLog.recent_events(),
-             &(&1.agent == "tool_execution" and &1.action == "Tool failed" and
-                 &1.metadata[:reason] == "tool.web.request_failed")
-           )
+      assert Enum.any?(
+               ActivityLog.recent_events(),
+               &(&1.agent == "tool_execution" and &1.action == "Tool failed" and
+                   &1.metadata[:reason] == "tool.web.request_failed")
+             )
 
-    detach(started_ref)
-    detach(failed_ref)
-    GenServer.stop(pid)
+      detach(started_ref)
+      detach(failed_ref)
+      GenServer.stop(pid)
+    end)
   end
 
   defp ensure_registry!(name) do

--- a/test/lemmings_os/lemming_instances/tool_execution_test.exs
+++ b/test/lemmings_os/lemming_instances/tool_execution_test.exs
@@ -1,0 +1,99 @@
+defmodule LemmingsOs.LemmingInstances.ToolExecutionTest do
+  use LemmingsOs.DataCase, async: true
+
+  alias LemmingsOs.LemmingInstances.ToolExecution
+  alias LemmingsOs.Repo
+
+  test "create_changeset/2 accepts valid attrs with nullable result fields" do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+    lemming = insert(:lemming, world: world, city: city, department: department, status: "active")
+    {:ok, instance} = LemmingsOs.LemmingInstances.spawn_instance(lemming, "Initial request")
+
+    changeset =
+      ToolExecution.create_changeset(%ToolExecution{}, %{
+        lemming_instance_id: instance.id,
+        world_id: world.id,
+        tool_name: "fs.read_text_file",
+        status: "running",
+        args: %{"path" => "notes.txt"},
+        result: nil,
+        error: nil,
+        summary: nil,
+        preview: nil,
+        started_at: nil,
+        completed_at: nil,
+        duration_ms: nil
+      })
+
+    assert changeset.valid?
+  end
+
+  test "create_changeset/2 validates required fields, status inclusion, and map types" do
+    changeset =
+      ToolExecution.create_changeset(%ToolExecution{}, %{
+        tool_name: "fs.read_text_file",
+        status: "bogus",
+        args: "nope",
+        result: "invalid",
+        error: "invalid",
+        duration_ms: -1
+      })
+
+    refute changeset.valid?
+
+    errors = errors_on(changeset)
+
+    assert errors.lemming_instance_id == [".required"]
+    assert errors.world_id == [".required"]
+    assert {".invalid_choice", _details} = Keyword.fetch!(changeset.errors, :status)
+    assert "is invalid" in errors.args
+    assert "is invalid" in errors.result
+    assert "is invalid" in errors.error
+    assert ".invalid_value" in errors.duration_ms
+  end
+
+  test "create_changeset/2 enforces foreign-key constraints" do
+    attrs = %{
+      lemming_instance_id: Ecto.UUID.generate(),
+      world_id: Ecto.UUID.generate(),
+      tool_name: "fs.read_text_file",
+      status: "running",
+      args: %{"path" => "notes.txt"}
+    }
+
+    assert {:error, changeset} =
+             %ToolExecution{}
+             |> ToolExecution.create_changeset(attrs)
+             |> Repo.insert()
+
+    refute changeset.valid?
+    assert changeset.constraints != []
+  end
+
+  test "update_changeset/2 accepts valid persisted result updates" do
+    changeset =
+      ToolExecution.update_changeset(%ToolExecution{}, %{
+        status: "ok",
+        result: %{"content" => "done"},
+        duration_ms: 12
+      })
+
+    assert changeset.valid?
+  end
+
+  test "update_changeset/2 validates status inclusion and map types" do
+    changeset =
+      ToolExecution.update_changeset(%ToolExecution{}, %{
+        status: "bogus",
+        result: "invalid",
+        error: "invalid"
+      })
+
+    refute changeset.valid?
+    assert {".invalid_choice", _details} = Keyword.fetch!(changeset.errors, :status)
+    assert "is invalid" in errors_on(changeset).result
+    assert "is invalid" in errors_on(changeset).error
+  end
+end

--- a/test/lemmings_os/lemming_instances_test.exs
+++ b/test/lemmings_os/lemming_instances_test.exs
@@ -9,10 +9,12 @@ defmodule LemmingsOs.LemmingInstancesTest do
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.LemmingInstances.DetsStore
+  alias LemmingsOs.LemmingTools
   alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.LemmingInstances.Message
+  alias LemmingsOs.LemmingInstances.ToolExecution
   alias LemmingsOs.Repo
   alias LemmingsOs.Worlds.World
 
@@ -161,6 +163,32 @@ defmodule LemmingsOs.LemmingInstancesTest do
     assert is_map(instance.config_snapshot)
     refute Map.has_key?(instance.config_snapshot, :__meta__)
     refute Map.has_key?(instance.config_snapshot, "__meta__")
+  end
+
+  test "S03b: spawn_instance creates the lemming work area under the runtime workspace root" do
+    world = insert(:world, name: "Ops World", slug: "ops-world")
+    city = insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")
+    department = insert(:department, world: world, city: city, name: "Support", slug: "support")
+
+    lemming =
+      insert(:lemming,
+        world: world,
+        city: city,
+        department: department,
+        name: "Incident Triage",
+        slug: "incident-triage",
+        status: "active"
+      )
+
+    assert {:ok, instance} =
+             LemmingInstances.spawn_instance(lemming, "Investigate the outage", preload: false)
+
+    assert instance.department_id == department.id
+    assert instance.lemming_id == lemming.id
+
+    work_area_root = Application.fetch_env!(:lemmings_os, :runtime_workspace_root)
+
+    assert File.dir?(Path.join(work_area_root, Path.join([department.id, lemming.id])))
   end
 
   test "S04: get_runtime_state/1 normalizes persisted runtime state from DETS" do
@@ -347,6 +375,50 @@ defmodule LemmingsOs.LemmingInstancesTest do
              "Investigate the outage",
              "Continue with risks"
            ]
+  end
+
+  test "S08b: tool execution APIs remain explicitly world scoped" do
+    instance = spawn_idle_instance()
+    world = Repo.preload(instance, :world).world
+    other_world = insert(:world)
+
+    assert {:ok, tool_execution} =
+             LemmingTools.create_tool_execution(world, instance, %{
+               tool_name: "fs.read_text_file",
+               status: "running",
+               args: %{"path" => "notes.txt"},
+               started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+             })
+
+    assert {:ok, %ToolExecution{id: id}} =
+             LemmingTools.get_tool_execution(world, instance, tool_execution.id)
+
+    assert id == tool_execution.id
+
+    assert [listed_execution] = LemmingTools.list_tool_executions(world, instance)
+    assert listed_execution.id == tool_execution.id
+
+    assert {:ok, updated_tool_execution} =
+             LemmingTools.update_tool_execution(world, instance, tool_execution, %{
+               status: "ok",
+               result: %{"content" => "notes"},
+               completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+               duration_ms: 14
+             })
+
+    assert updated_tool_execution.status == "ok"
+    assert updated_tool_execution.result == %{"content" => "notes"}
+
+    assert [] = LemmingTools.list_tool_executions(other_world, instance)
+
+    assert {:error, :not_found} =
+             LemmingTools.get_tool_execution(other_world, instance, tool_execution.id)
+
+    assert {:error, :not_found} =
+             LemmingTools.create_tool_execution(other_world, instance, %{})
+
+    assert {:error, :not_found} =
+             LemmingTools.update_tool_execution(other_world, instance, tool_execution, %{})
   end
 
   test "S09: topology_summary/1 reports total and active instance counts" do

--- a/test/lemmings_os/lemming_instances_test.exs
+++ b/test/lemmings_os/lemming_instances_test.exs
@@ -225,8 +225,11 @@ defmodule LemmingsOs.LemmingInstancesTest do
              retry_count: 1,
              max_retries: 3,
              queue_depth: 1,
+             tool_iteration_count: 0,
              current_item: %{id: "msg-current", content: "Investigate the outage"},
+             context_messages: [],
              last_error: "provider timeout",
+             internal_error_details: nil,
              status: "retrying",
              started_at: started_at,
              last_activity_at: last_activity_at

--- a/test/lemmings_os/lemming_instances_test.exs
+++ b/test/lemmings_os/lemming_instances_test.exs
@@ -186,7 +186,10 @@ defmodule LemmingsOs.LemmingInstancesTest do
     assert instance.department_id == department.id
     assert instance.lemming_id == lemming.id
 
-    work_area_root = Application.fetch_env!(:lemmings_os, :runtime_workspace_root)
+    work_area_root =
+      :lemmings_os
+      |> Application.fetch_env!(:runtime_workspace_root)
+      |> Path.expand()
 
     assert File.dir?(Path.join(work_area_root, Path.join([department.id, lemming.id])))
   end

--- a/test/lemmings_os/lemming_tools_test.exs
+++ b/test/lemmings_os/lemming_tools_test.exs
@@ -1,5 +1,162 @@
 defmodule LemmingsOs.LemmingToolsTest do
-  use LemmingsOs.DataCase, async: false
+  use LemmingsOs.DataCase, async: true
 
-  doctest LemmingsOs.LemmingTools
+  alias LemmingsOs.LemmingTools
+  alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.LemmingInstances.ToolExecution
+  alias LemmingsOs.Repo
+
+  describe "create_tool_execution/3 and list_tool_executions/3" do
+    test "S01: persists durable tool executions and lists them chronologically" do
+      %{world: world, instance: instance} = spawn_instance_fixture()
+      started_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      assert {:ok, first_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "fs.read_text_file",
+                 status: "running",
+                 args: %{"path" => "notes-a.txt"},
+                 started_at: started_at
+               })
+
+      assert {:ok, second_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "web.search",
+                 status: "running",
+                 args: %{"query" => "phoenix"},
+                 started_at: started_at
+               })
+
+      older_inserted_at =
+        DateTime.add(DateTime.utc_now(), -5, :second) |> DateTime.truncate(:second)
+
+      {1, _} =
+        ToolExecution
+        |> where([tool_execution], tool_execution.id == ^first_execution.id)
+        |> Repo.update_all(set: [inserted_at: older_inserted_at])
+
+      assert [listed_first, listed_second] = LemmingTools.list_tool_executions(world, instance)
+      assert listed_first.id == first_execution.id
+      assert listed_second.id == second_execution.id
+      assert listed_first.status == "running"
+      assert listed_second.tool_name == "web.search"
+    end
+
+    test "S02: supports status and tool filters in world-scoped listing" do
+      %{world: world, instance: instance} = spawn_instance_fixture()
+
+      assert {:ok, ok_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "fs.read_text_file",
+                 status: "ok",
+                 args: %{"path" => "notes-a.txt"},
+                 result: %{"bytes" => 10}
+               })
+
+      assert {:ok, error_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "web.fetch",
+                 status: "error",
+                 args: %{"url" => "https://example.com"},
+                 error: %{"code" => "tool.web.request_failed"}
+               })
+
+      assert [%ToolExecution{id: id}] =
+               LemmingTools.list_tool_executions(world, instance, status: "ok")
+
+      assert id == ok_execution.id
+
+      assert [%ToolExecution{id: id}] =
+               LemmingTools.list_tool_executions(world, instance,
+                 statuses: ["error"],
+                 tool_name: "web.fetch"
+               )
+
+      assert id == error_execution.id
+    end
+  end
+
+  describe "get_tool_execution/4 and update_tool_execution/4" do
+    test "S03: updates persisted completion fields for a running execution" do
+      %{world: world, instance: instance} = spawn_instance_fixture()
+
+      assert {:ok, tool_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "fs.write_text_file",
+                 status: "running",
+                 args: %{"path" => "report.md", "content" => "done"}
+               })
+
+      completed_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      assert {:ok, updated_execution} =
+               LemmingTools.update_tool_execution(world, instance, tool_execution, %{
+                 status: "ok",
+                 summary: "Wrote file /workspace/report.md",
+                 preview: "done",
+                 result: %{"path" => "/workspace/report.md", "bytes" => 4},
+                 completed_at: completed_at,
+                 duration_ms: 19
+               })
+
+      assert updated_execution.status == "ok"
+      assert updated_execution.duration_ms == 19
+      assert updated_execution.result == %{"path" => "/workspace/report.md", "bytes" => 4}
+
+      assert {:ok, fetched_execution} =
+               LemmingTools.get_tool_execution(world, instance, tool_execution.id)
+
+      assert fetched_execution.status == "ok"
+      assert fetched_execution.summary == "Wrote file /workspace/report.md"
+      assert fetched_execution.completed_at == completed_at
+    end
+
+    test "S04: enforces world scope across create, list, get, and update APIs" do
+      %{world: world, instance: instance} = spawn_instance_fixture()
+      other_world = insert(:world)
+
+      assert {:ok, tool_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "fs.read_text_file",
+                 status: "running",
+                 args: %{"path" => "notes.txt"}
+               })
+
+      assert [] = LemmingTools.list_tool_executions(other_world, instance)
+
+      assert {:error, :not_found} =
+               LemmingTools.get_tool_execution(other_world, instance, tool_execution.id)
+
+      assert {:error, :not_found} =
+               LemmingTools.create_tool_execution(other_world, instance, %{
+                 tool_name: "fs.read_text_file",
+                 status: "running",
+                 args: %{"path" => "notes.txt"}
+               })
+
+      assert {:error, :not_found} =
+               LemmingTools.update_tool_execution(other_world, instance, tool_execution, %{
+                 status: "error",
+                 error: %{"code" => "tool.invalid_scope"}
+               })
+    end
+  end
+
+  defp spawn_instance_fixture do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+
+    lemming =
+      insert(:lemming,
+        world: world,
+        city: city,
+        department: department,
+        status: "active"
+      )
+
+    {:ok, instance} = LemmingInstances.spawn_instance(lemming, "Run task")
+
+    %{world: world, instance: instance}
+  end
 end

--- a/test/lemmings_os/lemming_tools_test.exs
+++ b/test/lemmings_os/lemming_tools_test.exs
@@ -92,22 +92,33 @@ defmodule LemmingsOs.LemmingToolsTest do
       assert {:ok, updated_execution} =
                LemmingTools.update_tool_execution(world, instance, tool_execution, %{
                  status: "ok",
-                 summary: "Wrote file /workspace/report.md",
+                 summary: "Wrote file report.md",
                  preview: "done",
-                 result: %{"path" => "/workspace/report.md", "bytes" => 4},
+                 result: %{
+                   "path" => "report.md",
+                   "root_path" => "/workspace",
+                   "workspace_path" => "/workspace/report.md",
+                   "bytes" => 4
+                 },
                  completed_at: completed_at,
                  duration_ms: 19
                })
 
       assert updated_execution.status == "ok"
       assert updated_execution.duration_ms == 19
-      assert updated_execution.result == %{"path" => "/workspace/report.md", "bytes" => 4}
+
+      assert updated_execution.result == %{
+               "path" => "report.md",
+               "root_path" => "/workspace",
+               "workspace_path" => "/workspace/report.md",
+               "bytes" => 4
+             }
 
       assert {:ok, fetched_execution} =
                LemmingTools.get_tool_execution(world, instance, tool_execution.id)
 
       assert fetched_execution.status == "ok"
-      assert fetched_execution.summary == "Wrote file /workspace/report.md"
+      assert fetched_execution.summary == "Wrote file report.md"
       assert fetched_execution.completed_at == completed_at
     end
 

--- a/test/lemmings_os/lemming_tools_test.exs
+++ b/test/lemmings_os/lemming_tools_test.exs
@@ -1,0 +1,5 @@
+defmodule LemmingsOs.LemmingToolsTest do
+  use LemmingsOs.DataCase, async: false
+
+  doctest LemmingsOs.LemmingTools
+end

--- a/test/lemmings_os/model_runtime/response_test.exs
+++ b/test/lemmings_os/model_runtime/response_test.exs
@@ -6,6 +6,7 @@ defmodule LemmingsOs.ModelRuntime.ResponseTest do
   test "S01: builds a response struct from attrs" do
     response =
       Response.new(
+        action: :reply,
         reply: "hello",
         provider: "ollama",
         model: "llama3.2",

--- a/test/lemmings_os/model_runtime_test.exs
+++ b/test/lemmings_os/model_runtime_test.exs
@@ -67,6 +67,8 @@ defmodule LemmingsOs.ModelRuntimeTest do
 
   test "S01: run/3 assembles the prompt and validates the reply" do
     config_snapshot = %{
+      name: "Budget Brief",
+      description: "Creates budget artifacts for operators.",
       instructions: "Be concise.",
       provider_module: FakeProvider,
       model: "test-model"
@@ -87,8 +89,43 @@ defmodule LemmingsOs.ModelRuntimeTest do
     assert response.total_tokens == 3
     assert response.usage == %{prompt_eval_count: 1, eval_count: 2}
     assert %{role: "system", content: system_prompt} = Enum.at(response.raw.messages, 0)
-    assert String.contains?(system_prompt, "Be concise.")
+    assert String.contains?(system_prompt, "Platform Runtime Context:")
+    assert String.contains?(system_prompt, "Configured Lemming Identity:")
+    assert String.contains?(system_prompt, "Name: Budget Brief")
+    assert String.contains?(system_prompt, "Description: Creates budget artifacts for operators.")
+    assert String.contains?(system_prompt, "Instructions:\nBe concise.")
     assert String.contains?(system_prompt, "{\"action\":\"reply\"")
+    assert String.contains?(system_prompt, "fs.write_text_file")
+    assert String.contains?(system_prompt, "Loop State Semantics:")
+    assert String.contains?(system_prompt, "Assistant requested tool <tool_name> with arguments:")
+
+    assert String.contains?(
+             system_prompt,
+             "Tool result for <tool_name>: status=<status> payload=<json>"
+           )
+
+    assert String.contains?(system_prompt, "Immediate Response Instruction:")
+
+    assert String.contains?(
+             system_prompt,
+             "Return exactly one JSON object matching the output contract below."
+           )
+
+    assert String.contains?(system_prompt, "IMPORTANT: RESPOND WITH JSON ONLY.")
+
+    assert String.contains?(
+             system_prompt,
+             "Decide what to do next by returning exactly one of these two JSON shapes:"
+           )
+
+    assert String.contains?(system_prompt, "Option A: final reply to the user.")
+    assert String.contains?(system_prompt, "Option B: one tool call for the runtime to execute.")
+
+    assert String.contains?(
+             system_prompt,
+             "For file creation or file updates, use fs.write_text_file."
+           )
+
     assert %{role: "user", content: "Hello"} = List.last(response.raw.messages)
     assert_receive {:provider_request, %{format: "json", model: "test-model"}}
   end
@@ -99,7 +136,15 @@ defmodule LemmingsOs.ModelRuntimeTest do
       model: "test-model"
     }
 
-    assert {:error, :invalid_structured_output} =
+    assert {:error,
+            {:invalid_structured_output,
+             %{
+               provider: "fake",
+               model: "test-model",
+               content: "not-json",
+               raw: %{messages: _, format: "json", model: "test-model"},
+               reason: _
+             }}} =
              ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
   end
 
@@ -123,7 +168,14 @@ defmodule LemmingsOs.ModelRuntimeTest do
       model: "test-model"
     }
 
-    assert {:error, :unknown_action} = ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
+    assert {:error,
+            {:unknown_action,
+             %{
+               provider: "fake",
+               model: "test-model",
+               content: ~s({"action":"unknown"}),
+               raw: %{messages: _, format: "json", model: "test-model"}
+             }}} = ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
   end
 
   test "S04: exposes the structured output contract and runtime rules" do
@@ -173,5 +225,84 @@ defmodule LemmingsOs.ModelRuntimeTest do
              ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
 
     assert_receive {:provider_request, %{format: "json", model: "alpha-model"}}
+  end
+
+  test "S08: debug_request/3 exposes the assembled provider payload" do
+    config_snapshot = %{
+      name: "Writer",
+      description: "Writes files on request.",
+      instructions: "Be concise.",
+      provider_module: FakeProvider,
+      model: "test-model",
+      tools_config: %{
+        allowed_tools: ["fs.write_text_file", "web.fetch"],
+        denied_tools: ["fs.read_text_file"]
+      }
+    }
+
+    history = [%{role: "user", content: "Create the file"}]
+    current_request = %{content: "Write notes/output.md"}
+
+    assert {:ok,
+            %{
+              provider: "Elixir.LemmingsOs.ModelRuntimeTest.FakeProvider",
+              model: "test-model",
+              request: request
+            }} =
+             ModelRuntime.debug_request(config_snapshot, history, current_request)
+
+    assert request.format == "json"
+    assert %{role: "system", content: system_prompt} = Enum.at(request.messages, 0)
+
+    assert String.contains?(
+             system_prompt,
+             "Available Tools:\n- fs.write_text_file: Write UTF-8 text files inside the instance work area.\n- web.fetch: Fetch HTTP(S) content from a single URL."
+           )
+
+    assert List.last(request.messages) == %{role: "user", content: "Write notes/output.md"}
+  end
+
+  test "S09: debug_request/3 keeps one user message when current request already exists in history" do
+    config_snapshot = %{
+      name: "Budget Brief",
+      instructions: "Write useful budget examples.",
+      provider_module: FakeProvider,
+      model: "test-model"
+    }
+
+    history = [
+      %{role: "user", content: "Create sample.md", request_id: "req-1"},
+      %{
+        role: "assistant",
+        content:
+          "Assistant requested tool fs.write_text_file with arguments: {\"path\":\"sample.md\"}"
+      },
+      %{
+        role: "assistant",
+        content:
+          "As response to your previous tool request, the runtime executed fs.write_text_file. Tool result for fs.write_text_file: status=ok payload={\"summary\":\"Wrote file sample.md\",\"path\":\"sample.md\",\"preview\":\"sample preview\"}. Decide what to do next."
+      }
+    ]
+
+    current_request = %{content: "Create sample.md", request_id: "req-1"}
+
+    assert {:ok, %{request: request}} =
+             ModelRuntime.debug_request(config_snapshot, history, current_request)
+
+    user_messages = Enum.filter(request.messages, &(&1.role == "user"))
+
+    assert [%{role: "user", content: "Create sample.md"}] = user_messages
+
+    assert Enum.any?(
+             request.messages,
+             &(&1.role == "assistant" and
+                 String.contains?(&1.content, "Assistant requested tool fs.write_text_file"))
+           )
+
+    assert Enum.any?(
+             request.messages,
+             &(&1.role == "assistant" and
+                 String.contains?(&1.content, "As response to your previous tool request"))
+           )
   end
 end

--- a/test/lemmings_os/model_runtime_test.exs
+++ b/test/lemmings_os/model_runtime_test.exs
@@ -41,7 +41,23 @@ defmodule LemmingsOs.ModelRuntimeTest do
     def chat(request, _opts) do
       {:ok,
        %{
-         content: ~s({"action":"tool_call","reply":"nope"}),
+         content: ~s({"action":"unknown"}),
+         provider: "fake",
+         model: request.model,
+         raw: request
+       }}
+    end
+  end
+
+  defmodule ToolCallProvider do
+    @behaviour LemmingsOs.ModelRuntime.Provider
+
+    @impl true
+    def chat(request, _opts) do
+      {:ok,
+       %{
+         content:
+           ~s({"action":"tool_call","tool_name":"web.fetch","args":{"url":"https://example.com"}}),
          provider: "fake",
          model: request.model,
          raw: request
@@ -63,6 +79,7 @@ defmodule LemmingsOs.ModelRuntimeTest do
              ModelRuntime.run(config_snapshot, history, current_request)
 
     assert response.reply == "ok"
+    assert response.action == :reply
     assert response.provider == "fake"
     assert response.model == "test-model"
     assert response.input_tokens == 1
@@ -86,7 +103,21 @@ defmodule LemmingsOs.ModelRuntimeTest do
              ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
   end
 
-  test "S03: run/3 rejects unknown actions" do
+  test "S03: run/3 supports tool_call structured output" do
+    config_snapshot = %{
+      provider_module: ToolCallProvider,
+      model: "test-model"
+    }
+
+    assert {:ok, %Response{} = response} =
+             ModelRuntime.run(config_snapshot, [], %{content: "Hello"})
+
+    assert response.action == :tool_call
+    assert response.tool_name == "web.fetch"
+    assert response.tool_args == %{"url" => "https://example.com"}
+  end
+
+  test "S03b: run/3 rejects unknown actions" do
     config_snapshot = %{
       provider_module: UnknownActionProvider,
       model: "test-model"
@@ -103,6 +134,7 @@ defmodule LemmingsOs.ModelRuntimeTest do
   test "S05: Response.new/1 builds a runtime response struct" do
     response =
       Response.new(
+        action: :reply,
         reply: "hello",
         provider: "ollama",
         model: "llama3.2",

--- a/test/lemmings_os/runtime/status_test.exs
+++ b/test/lemmings_os/runtime/status_test.exs
@@ -1,0 +1,46 @@
+defmodule LemmingsOs.Runtime.StatusTest do
+  use LemmingsOs.DataCase, async: false
+
+  alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.LemmingTools
+  alias LemmingsOs.Runtime.Status
+
+  test "dashboard_snapshot/1 includes recent persisted tool executions" do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+
+    lemming =
+      insert(:lemming,
+        world: world,
+        city: city,
+        department: department,
+        status: "active"
+      )
+
+    {:ok, instance} = LemmingInstances.spawn_instance(lemming, "Generate an artifact")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "reports/result.md", "content" => "content"},
+        summary: "Wrote file",
+        duration_ms: 12,
+        started_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        completed_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    snapshot = Status.dashboard_snapshot(recent_limit: 10)
+
+    assert is_list(snapshot.tool_executions)
+
+    assert Enum.any?(snapshot.tool_executions, fn entry ->
+             entry.id == tool_execution.id and
+               entry.instance_id == instance.id and
+               entry.tool_name == "fs.write_text_file" and
+               entry.status == "ok" and
+               entry.duration_ms == 12
+           end)
+  end
+end

--- a/test/lemmings_os/runtime_test.exs
+++ b/test/lemmings_os/runtime_test.exs
@@ -60,6 +60,13 @@ defmodule LemmingsOs.RuntimeTest do
 
     assert instance.status == "created"
 
+    assert File.dir?(
+             Path.join(
+               Application.fetch_env!(:lemmings_os, :runtime_workspace_root),
+               Path.join([department.id, lemming.id])
+             )
+           )
+
     assert eventually_status(instance.id) == "queued"
 
     [message] = LemmingInstances.list_messages(instance)

--- a/test/lemmings_os/runtime_test.exs
+++ b/test/lemmings_os/runtime_test.exs
@@ -60,12 +60,12 @@ defmodule LemmingsOs.RuntimeTest do
 
     assert instance.status == "created"
 
-    assert File.dir?(
-             Path.join(
-               Application.fetch_env!(:lemmings_os, :runtime_workspace_root),
-               Path.join([department.id, lemming.id])
-             )
-           )
+    work_area_root =
+      :lemmings_os
+      |> Application.fetch_env!(:runtime_workspace_root)
+      |> Path.expand()
+
+    assert File.dir?(Path.join(work_area_root, Path.join([department.id, lemming.id])))
 
     assert eventually_status(instance.id) == "queued"
 

--- a/test/lemmings_os/tools/adapters/filesystem_test.exs
+++ b/test/lemmings_os/tools/adapters/filesystem_test.exs
@@ -117,4 +117,50 @@ defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
     assert {:error, %{code: "tool.fs.invalid_instance_scope"}} =
              Filesystem.read_text_file(%LemmingInstance{}, %{"path" => "notes.txt"})
   end
+
+  test "S08: read_text_file rejects symlink targets outside workspace", %{
+    instance: instance,
+    work_area: work_area
+  } do
+    outside_path = Path.join(Path.dirname(work_area), "outside-secret.txt")
+    File.write!(outside_path, "do not read")
+    assert :ok = File.ln_s(outside_path, Path.join(work_area, "secret-link.txt"))
+
+    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+             Filesystem.read_text_file(instance, %{"path" => "secret-link.txt"})
+  end
+
+  test "S09: write_text_file rejects existing symlink file targets outside workspace", %{
+    instance: instance,
+    work_area: work_area
+  } do
+    outside_path = Path.join(Path.dirname(work_area), "outside-write.txt")
+    File.write!(outside_path, "unchanged")
+    assert :ok = File.ln_s(outside_path, Path.join(work_area, "write-link.txt"))
+
+    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+             Filesystem.write_text_file(instance, %{
+               "path" => "write-link.txt",
+               "content" => "mutated"
+             })
+
+    assert File.read!(outside_path) == "unchanged"
+  end
+
+  test "S10: write_text_file rejects symlink parent directories outside workspace", %{
+    instance: instance,
+    work_area: work_area
+  } do
+    outside_dir = Path.join(Path.dirname(work_area), "outside-dir")
+    File.mkdir_p!(outside_dir)
+    assert :ok = File.ln_s(outside_dir, Path.join(work_area, "linked-dir"))
+
+    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+             Filesystem.write_text_file(instance, %{
+               "path" => "linked-dir/output.txt",
+               "content" => "escaped"
+             })
+
+    refute File.exists?(Path.join(outside_dir, "output.txt"))
+  end
 end

--- a/test/lemmings_os/tools/adapters/filesystem_test.exs
+++ b/test/lemmings_os/tools/adapters/filesystem_test.exs
@@ -1,0 +1,108 @@
+defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
+  use ExUnit.Case, async: false
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Tools.Adapters.Filesystem
+
+  setup do
+    old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_tools_filesystem_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
+    File.mkdir_p!(workspace_root)
+
+    instance = %LemmingInstance{
+      id: Ecto.UUID.generate(),
+      world_id: Ecto.UUID.generate(),
+      department_id: Ecto.UUID.generate(),
+      lemming_id: Ecto.UUID.generate()
+    }
+
+    work_area = Path.join([workspace_root, instance.department_id, instance.lemming_id])
+    File.mkdir_p!(work_area)
+
+    on_exit(fn ->
+      if old_workspace_root do
+        Application.put_env(:lemmings_os, :runtime_workspace_root, old_workspace_root)
+      else
+        Application.delete_env(:lemmings_os, :runtime_workspace_root)
+      end
+
+      File.rm_rf(workspace_root)
+    end)
+
+    {:ok, instance: instance, work_area: work_area}
+  end
+
+  test "S01: write_text_file writes content inside work area with normalized result", %{
+    instance: instance
+  } do
+    assert {:ok, result} =
+             Filesystem.write_text_file(instance, %{
+               "path" => "reports/out.txt",
+               "content" => "hello filesystem"
+             })
+
+    assert result.summary =~ "Wrote file"
+
+    assert result.result.path =~
+             "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/out.txt"
+
+    assert result.result.bytes == byte_size("hello filesystem")
+    assert result.preview == "hello filesystem"
+  end
+
+  test "S02: read_text_file returns normalized content from work area", %{instance: instance} do
+    assert {:ok, _write_result} =
+             Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
+
+    assert {:ok, result} = Filesystem.read_text_file(instance, %{"path" => "notes.txt"})
+    assert result.summary =~ "Read file"
+    assert result.result.content == "hello"
+    assert result.result.bytes == 5
+    assert result.preview == "hello"
+  end
+
+  test "S03: read_text_file validates required args", %{instance: instance} do
+    assert {:error, %{code: "tool.validation.invalid_args", details: %{required: ["path"]}}} =
+             Filesystem.read_text_file(instance, %{})
+  end
+
+  test "S04: write_text_file rejects absolute paths", %{instance: instance} do
+    assert {:error, %{code: "tool.fs.path_must_be_relative"}} =
+             Filesystem.write_text_file(instance, %{
+               "path" => "/etc/passwd",
+               "content" => "blocked"
+             })
+  end
+
+  test "S05: write_text_file rejects traversal outside workspace", %{
+    instance: instance,
+    work_area: work_area
+  } do
+    escaped_path = Path.expand("../outside.txt", work_area)
+
+    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+             Filesystem.write_text_file(instance, %{
+               "path" => "../outside.txt",
+               "content" => "blocked"
+             })
+
+    refute File.exists?(escaped_path)
+  end
+
+  test "S06: read_text_file returns not_found error for missing file", %{instance: instance} do
+    assert {:error, %{code: "tool.fs.not_found", details: %{path: "missing.txt"}}} =
+             Filesystem.read_text_file(instance, %{"path" => "missing.txt"})
+  end
+
+  test "S07: filesystem adapters reject incomplete instance scope" do
+    assert {:error, %{code: "tool.fs.invalid_instance_scope"}} =
+             Filesystem.read_text_file(%LemmingInstance{}, %{"path" => "notes.txt"})
+  end
+end

--- a/test/lemmings_os/tools/adapters/filesystem_test.exs
+++ b/test/lemmings_os/tools/adapters/filesystem_test.exs
@@ -48,9 +48,13 @@ defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
                "content" => "hello filesystem"
              })
 
-    assert result.summary =~ "Wrote file"
+    assert result.summary == "Wrote file reports/out.txt"
+    assert result.result.path == "reports/out.txt"
 
-    assert result.result.path =~
+    assert result.result.root_path ==
+             "/workspace/#{instance.department_id}/#{instance.lemming_id}"
+
+    assert result.result.workspace_path ==
              "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/out.txt"
 
     assert result.result.bytes == byte_size("hello filesystem")
@@ -62,7 +66,15 @@ defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
              Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
 
     assert {:ok, result} = Filesystem.read_text_file(instance, %{"path" => "notes.txt"})
-    assert result.summary =~ "Read file"
+    assert result.summary == "Read file notes.txt"
+    assert result.result.path == "notes.txt"
+
+    assert result.result.root_path ==
+             "/workspace/#{instance.department_id}/#{instance.lemming_id}"
+
+    assert result.result.workspace_path ==
+             "/workspace/#{instance.department_id}/#{instance.lemming_id}/notes.txt"
+
     assert result.result.content == "hello"
     assert result.result.bytes == 5
     assert result.preview == "hello"

--- a/test/lemmings_os/tools/adapters/web_test.exs
+++ b/test/lemmings_os/tools/adapters/web_test.exs
@@ -5,14 +5,16 @@ defmodule LemmingsOs.Tools.Adapters.WebTest do
   alias LemmingsOs.Tools.Adapters.Web
 
   setup do
-    old_endpoint = Application.get_env(:lemmings_os, :tools_web_search_endpoint)
+    old_endpoint = Application.fetch_env(:lemmings_os, :tools_web_search_endpoint)
+    old_allow_private_hosts = Application.fetch_env(:lemmings_os, :tools_web_allow_private_hosts)
+    old_timeout = Application.fetch_env(:lemmings_os, :tools_web_timeout_ms)
+
+    Application.put_env(:lemmings_os, :tools_web_allow_private_hosts, true)
 
     on_exit(fn ->
-      if old_endpoint do
-        Application.put_env(:lemmings_os, :tools_web_search_endpoint, old_endpoint)
-      else
-        Application.delete_env(:lemmings_os, :tools_web_search_endpoint)
-      end
+      restore_env(:tools_web_search_endpoint, old_endpoint)
+      restore_env(:tools_web_allow_private_hosts, old_allow_private_hosts)
+      restore_env(:tools_web_timeout_ms, old_timeout)
     end)
 
     :ok
@@ -129,4 +131,99 @@ defmodule LemmingsOs.Tools.Adapters.WebTest do
                Web.fetch(%{"url" => "http://localhost:#{port}/content"})
     end)
   end
+
+  test "S09: fetch blocks loopback and private host targets by default" do
+    Application.put_env(:lemmings_os, :tools_web_allow_private_hosts, false)
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "localhost"}
+            }} = Web.fetch(%{"url" => "http://localhost/admin"})
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "127.0.0.1"}
+            }} = Web.fetch(%{"url" => "http://127.0.0.1/admin"})
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "169.254.169.254"}
+            }} = Web.fetch(%{"url" => "http://169.254.169.254/latest/meta-data"})
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "10.0.0.12"}
+            }} = Web.fetch(%{"url" => "http://10.0.0.12/internal"})
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "192.168.1.10"}
+            }} = Web.fetch(%{"url" => "http://192.168.1.10/internal"})
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "::1"}
+            }} = Web.fetch(%{"url" => "http://[::1]/admin"})
+  end
+
+  test "S10: search blocks private configured endpoints by default" do
+    Application.put_env(:lemmings_os, :tools_web_allow_private_hosts, false)
+    Application.put_env(:lemmings_os, :tools_web_search_endpoint, "http://localhost/search")
+
+    assert {:error,
+            %{
+              code: "tool.web.egress_blocked",
+              details: %{host: "localhost"}
+            }} = Web.search(%{"query" => "phoenix"})
+  end
+
+  test "S11: fetch applies configured request timeout" do
+    {:ok, port, server_pid} = start_silent_tcp_server()
+    Application.put_env(:lemmings_os, :tools_web_timeout_ms, 10)
+
+    capture_log(fn ->
+      assert {:error, %{code: "tool.web.request_failed", message: "Web fetch request failed"}} =
+               Web.fetch(%{"url" => "http://localhost:#{port}/slow"})
+    end)
+
+    send(server_pid, :close)
+  end
+
+  defp start_silent_tcp_server do
+    parent = self()
+    {:ok, listen_socket} = :gen_tcp.listen(0, [:binary, packet: :raw, active: false])
+    {:ok, port} = :inet.port(listen_socket)
+
+    {:ok, pid} =
+      Task.start(fn ->
+        {:ok, socket} = :gen_tcp.accept(listen_socket)
+        send(parent, :silent_tcp_server_accepted)
+        _ = :gen_tcp.recv(socket, 0, 1_000)
+
+        receive do
+          :close -> :ok
+        after
+          5_000 -> :ok
+        end
+
+        :gen_tcp.close(socket)
+        :gen_tcp.close(listen_socket)
+      end)
+
+    on_exit(fn ->
+      send(pid, :close)
+      :gen_tcp.close(listen_socket)
+    end)
+
+    {:ok, port, pid}
+  end
+
+  defp restore_env(key, {:ok, value}), do: Application.put_env(:lemmings_os, key, value)
+  defp restore_env(key, :error), do: Application.delete_env(:lemmings_os, key)
 end

--- a/test/lemmings_os/tools/adapters/web_test.exs
+++ b/test/lemmings_os/tools/adapters/web_test.exs
@@ -1,0 +1,132 @@
+defmodule LemmingsOs.Tools.Adapters.WebTest do
+  use ExUnit.Case, async: false
+  import ExUnit.CaptureLog
+
+  alias LemmingsOs.Tools.Adapters.Web
+
+  setup do
+    old_endpoint = Application.get_env(:lemmings_os, :tools_web_search_endpoint)
+
+    on_exit(fn ->
+      if old_endpoint do
+        Application.put_env(:lemmings_os, :tools_web_search_endpoint, old_endpoint)
+      else
+        Application.delete_env(:lemmings_os, :tools_web_search_endpoint)
+      end
+    end)
+
+    :ok
+  end
+
+  test "S01: search returns normalized success payload with preview" do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :lemmings_os,
+      :tools_web_search_endpoint,
+      "http://localhost:#{bypass.port}/search"
+    )
+
+    Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+
+      Plug.Conn.resp(
+        conn,
+        200,
+        ~s({"RelatedTopics":[{"Text":"Phoenix Framework","FirstURL":"https://www.phoenixframework.org"}]})
+      )
+    end)
+
+    assert {:ok, result} = Web.search(%{"query" => "phoenix"})
+    assert result.summary == "Search completed with 1 result(s)"
+    assert result.preview == "Phoenix Framework"
+
+    assert [%{title: "Phoenix Framework", url: "https://www.phoenixframework.org"}] =
+             result.result.results
+  end
+
+  test "S02: search returns empty normalized results when upstream has no topics" do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :lemmings_os,
+      :tools_web_search_endpoint,
+      "http://localhost:#{bypass.port}/search"
+    )
+
+    Bypass.expect_once(bypass, "GET", "/search", fn conn ->
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+      Plug.Conn.resp(conn, 200, ~s({"RelatedTopics":[]}))
+    end)
+
+    assert {:ok, result} = Web.search(%{"query" => "no-results"})
+    assert result.summary == "Search completed with 0 result(s)"
+    assert result.preview == nil
+    assert result.result.results == []
+  end
+
+  test "S03: search validates required query argument" do
+    assert {:error, %{code: "tool.validation.invalid_args", details: %{required: ["query"]}}} =
+             Web.search(%{})
+  end
+
+  test "S04: search returns normalized bad_status for non-2xx responses" do
+    bypass = Bypass.open()
+
+    Application.put_env(
+      :lemmings_os,
+      :tools_web_search_endpoint,
+      "http://localhost:#{bypass.port}/search"
+    )
+
+    Bypass.expect(bypass, "GET", "/search", fn conn ->
+      Plug.Conn.resp(conn, 500, "boom")
+    end)
+
+    capture_log(fn ->
+      assert {:error, %{code: "tool.web.bad_status", details: %{status: 500}}} =
+               Web.search(%{"query" => "phoenix"})
+    end)
+  end
+
+  test "S05: fetch returns normalized success payload" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/content", fn conn ->
+      Plug.Conn.resp(conn, 200, "runtime tools fetch payload")
+    end)
+
+    assert {:ok, result} = Web.fetch(%{"url" => "http://localhost:#{bypass.port}/content"})
+    assert result.summary == "Fetched http://localhost:#{bypass.port}/content"
+    assert result.preview == "runtime tools fetch payload"
+    assert result.result.status == 200
+    assert result.result.body == "runtime tools fetch payload"
+  end
+
+  test "S06: fetch validates URL format" do
+    assert {:error, %{code: "tool.web.invalid_url", details: %{url: "file:///etc/passwd"}}} =
+             Web.fetch(%{"url" => "file:///etc/passwd"})
+  end
+
+  test "S07: fetch returns normalized bad_status for non-2xx responses" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "GET", "/missing", fn conn ->
+      Plug.Conn.resp(conn, 404, "not found")
+    end)
+
+    assert {:error, %{code: "tool.web.bad_status", details: %{status: 404}}} =
+             Web.fetch(%{"url" => "http://localhost:#{bypass.port}/missing"})
+  end
+
+  test "S08: fetch returns request_failed on transport errors" do
+    bypass = Bypass.open()
+    port = bypass.port
+    Bypass.down(bypass)
+
+    capture_log(fn ->
+      assert {:error, %{code: "tool.web.request_failed", message: "Web fetch request failed"}} =
+               Web.fetch(%{"url" => "http://localhost:#{port}/content"})
+    end)
+  end
+end

--- a/test/lemmings_os/tools/catalog_test.exs
+++ b/test/lemmings_os/tools/catalog_test.exs
@@ -1,0 +1,34 @@
+defmodule LemmingsOs.Tools.CatalogTest do
+  use ExUnit.Case, async: true
+
+  alias LemmingsOs.Tools.Catalog
+  alias LemmingsOs.Tools.DefaultRuntimeFetcher
+
+  describe "list_tools/0" do
+    test "returns only the four approved tools" do
+      assert [
+               %{id: "fs.read_text_file"},
+               %{id: "fs.write_text_file"},
+               %{id: "web.search"},
+               %{id: "web.fetch"}
+             ] = Catalog.list_tools()
+    end
+  end
+
+  describe "supported_tool?/1" do
+    test "returns true for approved tools and false otherwise" do
+      assert Catalog.supported_tool?("fs.read_text_file")
+      assert Catalog.supported_tool?("fs.write_text_file")
+      assert Catalog.supported_tool?("web.search")
+      assert Catalog.supported_tool?("web.fetch")
+      refute Catalog.supported_tool?("exec.run")
+    end
+  end
+
+  describe "DefaultRuntimeFetcher.fetch/0" do
+    test "returns the fixed runtime catalog" do
+      assert {:ok, runtime_tools} = DefaultRuntimeFetcher.fetch()
+      assert runtime_tools == Catalog.list_tools()
+    end
+  end
+end

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -53,8 +53,10 @@ defmodule LemmingsOs.Tools.RuntimeTest do
                })
 
       assert write_result.tool_name == "fs.write_text_file"
+      assert write_result.summary == "Wrote file reports/result.md"
+      assert write_result.result.path == "reports/result.md"
 
-      assert write_result.result.path =~
+      assert write_result.result.workspace_path ==
                "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/result.md"
 
       assert {:ok, read_result} =
@@ -63,6 +65,8 @@ defmodule LemmingsOs.Tools.RuntimeTest do
                })
 
       assert read_result.tool_name == "fs.read_text_file"
+      assert read_result.summary == "Read file reports/result.md"
+      assert read_result.result.path == "reports/result.md"
       assert read_result.result.content == "hello from tools runtime"
     end
 

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -1,0 +1,151 @@
+defmodule LemmingsOs.Tools.RuntimeTest do
+  use ExUnit.Case, async: false
+
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Tools.Runtime
+  alias LemmingsOs.Worlds.World
+
+  setup do
+    old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+
+    workspace_root =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_tools_runtime_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
+    File.mkdir_p!(workspace_root)
+
+    on_exit(fn ->
+      if old_workspace_root do
+        Application.put_env(:lemmings_os, :runtime_workspace_root, old_workspace_root)
+      else
+        Application.delete_env(:lemmings_os, :runtime_workspace_root)
+      end
+
+      File.rm_rf(workspace_root)
+    end)
+
+    world = %World{id: Ecto.UUID.generate()}
+
+    instance = %LemmingInstance{
+      id: Ecto.UUID.generate(),
+      world_id: world.id,
+      department_id: Ecto.UUID.generate(),
+      lemming_id: Ecto.UUID.generate()
+    }
+
+    File.mkdir_p!(Path.join([workspace_root, instance.department_id, instance.lemming_id]))
+
+    {:ok, world: world, instance: instance}
+  end
+
+  describe "execute/4 with filesystem tools" do
+    test "writes and reads a file inside the instance work area", %{
+      world: world,
+      instance: instance
+    } do
+      assert {:ok, write_result} =
+               Runtime.execute(world, instance, "fs.write_text_file", %{
+                 "path" => "reports/result.md",
+                 "content" => "hello from tools runtime"
+               })
+
+      assert write_result.tool_name == "fs.write_text_file"
+
+      assert write_result.result.path =~
+               "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/result.md"
+
+      assert {:ok, read_result} =
+               Runtime.execute(world, instance, "fs.read_text_file", %{
+                 "path" => "reports/result.md"
+               })
+
+      assert read_result.tool_name == "fs.read_text_file"
+      assert read_result.result.content == "hello from tools runtime"
+    end
+
+    test "rejects absolute and escaping paths", %{world: world, instance: instance} do
+      assert {:error, %{code: "tool.fs.path_must_be_relative"}} =
+               Runtime.execute(world, instance, "fs.write_text_file", %{
+                 "path" => "/etc/passwd",
+                 "content" => "nope"
+               })
+
+      assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+               Runtime.execute(world, instance, "fs.read_text_file", %{"path" => "../secret.txt"})
+    end
+  end
+
+  describe "execute/4 with web tools" do
+    test "uses Req for web.search and returns normalized data", %{
+      world: world,
+      instance: instance
+    } do
+      bypass = Bypass.open()
+      old_endpoint = Application.get_env(:lemmings_os, :tools_web_search_endpoint)
+
+      Application.put_env(
+        :lemmings_os,
+        :tools_web_search_endpoint,
+        "http://localhost:#{bypass.port}/search"
+      )
+
+      on_exit(fn ->
+        if old_endpoint do
+          Application.put_env(:lemmings_os, :tools_web_search_endpoint, old_endpoint)
+        else
+          Application.delete_env(:lemmings_os, :tools_web_search_endpoint)
+        end
+      end)
+
+      Bypass.expect(bypass, fn conn ->
+        conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+
+        Plug.Conn.resp(
+          conn,
+          200,
+          ~s({"RelatedTopics":[{"Text":"Phoenix Framework","FirstURL":"https://www.phoenixframework.org"}]})
+        )
+      end)
+
+      assert {:ok, result} =
+               Runtime.execute(world, instance, "web.search", %{"query" => "phoenix"})
+
+      assert result.tool_name == "web.search"
+      assert [%{title: "Phoenix Framework"}] = result.result.results
+    end
+
+    test "fetches HTTP content with normalized response", %{world: world, instance: instance} do
+      bypass = Bypass.open()
+
+      Bypass.expect(bypass, fn conn ->
+        Plug.Conn.resp(conn, 200, "runtime tools fetch payload")
+      end)
+
+      assert {:ok, result} =
+               Runtime.execute(world, instance, "web.fetch", %{
+                 "url" => "http://localhost:#{bypass.port}/content"
+               })
+
+      assert result.tool_name == "web.fetch"
+      assert result.result.status == 200
+      assert result.result.body == "runtime tools fetch payload"
+    end
+  end
+
+  describe "execute/4 failures" do
+    test "rejects tools outside the fixed catalog", %{world: world, instance: instance} do
+      assert {:error, %{code: "tool.unsupported", tool_name: "exec.run"}} =
+               Runtime.execute(world, instance, "exec.run", %{})
+    end
+
+    test "enforces explicit world scope", %{instance: instance} do
+      world = %World{id: Ecto.UUID.generate()}
+
+      assert {:error, %{code: "tool.invalid_scope"}} =
+               Runtime.execute(world, instance, "web.fetch", %{"url" => "https://example.com"})
+    end
+  end
+end

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -7,6 +7,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
 
   setup do
     old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+    old_allow_private_hosts = Application.fetch_env(:lemmings_os, :tools_web_allow_private_hosts)
 
     workspace_root =
       Path.join(
@@ -15,6 +16,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
       )
 
     Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
+    Application.put_env(:lemmings_os, :tools_web_allow_private_hosts, true)
     File.mkdir_p!(workspace_root)
 
     on_exit(fn ->
@@ -23,6 +25,8 @@ defmodule LemmingsOs.Tools.RuntimeTest do
       else
         Application.delete_env(:lemmings_os, :runtime_workspace_root)
       end
+
+      restore_env(:tools_web_allow_private_hosts, old_allow_private_hosts)
 
       File.rm_rf(workspace_root)
     end)
@@ -152,4 +156,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
                Runtime.execute(world, instance, "web.fetch", %{"url" => "https://example.com"})
     end
   end
+
+  defp restore_env(key, {:ok, value}), do: Application.put_env(:lemmings_os, key, value)
+  defp restore_env(key, :error), do: Application.delete_env(:lemmings_os, key)
 end

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -4,21 +4,83 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
   import LemmingsOs.Factory
   import Phoenix.LiveViewTest
 
+  @moduletag capture_log: true
+
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.LemmingInstances.EtsStore
+  alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.Message
+  alias LemmingsOs.LemmingInstances.ToolExecution
   alias LemmingsOs.LemmingInstances.Executor
   alias LemmingsOs.LemmingInstances.PubSub
+  alias LemmingsOs.LemmingInstances.ResourcePool
+  alias LemmingsOs.LemmingTools
+  alias LemmingsOs.ModelRuntime.Response
   alias LemmingsOs.Runtime.ActivityLog
   alias LemmingsOs.Repo
   alias LemmingsOsWeb.InstanceComponents
   alias LemmingsOs.Worlds.Cache
   alias LemmingsOs.Worlds.World
 
+  defmodule RawTraceToolLoopModelRuntime do
+    def run(_config_snapshot, context_messages, current_item) do
+      if Enum.any?(
+           context_messages,
+           &String.contains?(&1.content, "As response to your previous tool request")
+         ) do
+        {:ok,
+         Response.new(
+           action: :reply,
+           reply: "File created successfully!",
+           provider: "fake",
+           model: "tool-loop-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      else
+        {:ok,
+         Response.new(
+           action: :tool_call,
+           tool_name: "web.fetch",
+           tool_args: %{"url" => "https://example.com"},
+           provider: "fake",
+           model: "tool-loop-model",
+           raw: %{current_item: current_item, context_messages: context_messages}
+         )}
+      end
+    end
+  end
+
+  defmodule RawTraceSuccessToolRuntime do
+    def execute(_world, _instance, "web.fetch", %{"url" => "https://example.com"}) do
+      {:ok,
+       %{
+         tool_name: "web.fetch",
+         args: %{"url" => "https://example.com"},
+         summary: "Fetched https://example.com",
+         preview: "example preview",
+         result: %{url: "https://example.com", status: 200, body: "example body"}
+       }}
+    end
+  end
+
+  defmodule RawTraceInvalidOutputModelRuntime do
+    def run(_config_snapshot, _context_messages, _current_item) do
+      {:error,
+       {:invalid_structured_output,
+        %{
+          provider: "fake",
+          model: "broken-model",
+          content: "not-json",
+          raw: %{content: "not-json", provider: "fake", model: "broken-model"}
+        }}}
+    end
+  end
+
   setup do
+    Repo.delete_all(ToolExecution)
     Repo.delete_all(Message)
     Repo.delete_all(LemmingInstance)
     Repo.delete_all(Lemming)
@@ -458,6 +520,158 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
            )
   end
 
+  test "S08b: historical transcript renders compact tool cards in chronological order", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    Repo.insert!(%Message{
+      lemming_instance_id: instance.id,
+      world_id: world.id,
+      role: "assistant",
+      content: "Initial assistant reply",
+      inserted_at: DateTime.add(now, 1, :second)
+    })
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "notes/output.md", "content" => "artifact"},
+        summary: "Wrote artifact to workspace.",
+        preview: "notes/output.md",
+        result: %{"path" => "notes/output.md", "bytes" => 32},
+        started_at: DateTime.add(now, 2, :second),
+        completed_at: DateTime.add(now, 2, :second),
+        duration_ms: 18
+      })
+
+    Repo.update!(
+      Ecto.Changeset.change(tool_execution, inserted_at: DateTime.add(now, 2, :second))
+    )
+
+    Repo.insert!(%Message{
+      lemming_instance_id: instance.id,
+      world_id: world.id,
+      role: "user",
+      content: "Follow-up question",
+      inserted_at: DateTime.add(now, 3, :second)
+    })
+
+    {:ok, view, html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#card-tool-execution-#{tool_execution.id}")
+    assert has_element?(view, "#tool-execution-summary-#{tool_execution.id}", "notes/output.md")
+    assert has_element?(view, "#tool-execution-preview-#{tool_execution.id}", "notes/output.md")
+    assert has_element?(view, "#tool-execution-details-#{tool_execution.id}")
+
+    assert has_element?(
+             view,
+             "#tool-execution-args-#{tool_execution.id}",
+             "\"path\": \"notes/output.md\""
+           )
+
+    assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"bytes\": 32")
+
+    assert html =~
+             ~s(/lemmings/instances/#{instance.id}/artifacts/notes/output.md?world=#{world.id})
+
+    assert text_position(html, "Initial assistant reply") <
+             text_position(html, "notes/output.md")
+
+    assert text_position(html, "notes/output.md") <
+             text_position(html, "Follow-up question")
+  end
+
+  test "S08d: tool execution artifact link opens workspace file content", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "sample.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "# Sample artifact\n")
+
+    {:ok, _tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "sample.md", "content" => "# Sample artifact\n"},
+        summary: "Wrote file sample.md",
+        preview: "# Sample artifact",
+        result: %{"path" => "sample.md", "bytes" => 18}
+      })
+
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["sample.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 200
+    assert response.resp_body == "# Sample artifact\n"
+    assert get_resp_header(response, "content-type") == ["text/markdown; charset=utf-8"]
+  end
+
+  test "S08c: tool execution broadcasts update transcript cards without remount", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_idle_runtime_session()
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "web.fetch",
+        status: "running",
+        args: %{"url" => "https://example.com"},
+        summary: "Fetching source page.",
+        started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    assert :ok =
+             PubSub.broadcast_tool_execution_upserted(
+               instance.id,
+               tool_execution.id,
+               tool_execution.status
+             )
+
+    assert eventually_has_element?(
+             view,
+             "#card-tool-execution-#{tool_execution.id}[data-status='running']"
+           )
+
+    {:ok, _updated_tool_execution} =
+      LemmingTools.update_tool_execution(world, instance, tool_execution, %{
+        status: "ok",
+        summary: "Fetched source page.",
+        preview: "https://example.com",
+        result: %{"url" => "https://example.com", "status" => 200},
+        completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        duration_ms: 45
+      })
+
+    assert :ok = PubSub.broadcast_tool_execution_upserted(instance.id, tool_execution.id, "ok")
+
+    assert eventually_has_element?(
+             view,
+             "#card-tool-execution-#{tool_execution.id}[data-status='ok']"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#tool-execution-summary-#{tool_execution.id}",
+             "Fetched source page."
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#tool-execution-preview-#{tool_execution.id}",
+             "https://example.com"
+           )
+  end
+
   test "S09: session header shows aggregate total tokens across transcript", %{conn: conn} do
     %{world: world, instance: instance} = spawn_runtime_session()
     now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -521,6 +735,238 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
     refute has_element?(view, "#bubble-message-2", "openai")
   end
 
+  test "S11: session page links to raw context view", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_idle_runtime_session()
+
+    {:ok, view, html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#instance-raw-context-link", "Raw context")
+    assert html =~ ~s(/lemmings/instances/#{instance.id}/raw?world=#{world.id})
+  end
+
+  test "S12: raw context view renders persisted runtime context and config snapshot", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    assert {:ok, _state} =
+             EtsStore.put(instance.id, %{
+               department_id: instance.department_id,
+               queue: :queue.new(),
+               current_item: %{id: "msg-current", content: "Create budget file"},
+               retry_count: 0,
+               tool_iteration_count: 2,
+               max_retries: 3,
+               context_messages: [
+                 %{role: "user", content: "Create a budget file"},
+                 %{
+                   role: "assistant",
+                   content:
+                     "As response to your previous tool request, the runtime executed fs.write_text_file. Tool result for fs.write_text_file: status=ok payload={}. Decide what to do next."
+                 }
+               ],
+               last_error: nil,
+               internal_error_details: nil,
+               status: :idle,
+               started_at: now,
+               last_activity_at: now
+             })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}/raw?#{%{world: world.id}}")
+
+    assert has_element?(view, "#instance-raw-page")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline-source",
+             "persisted transcript/tool history only"
+           )
+
+    assert has_element?(view, "#instance-raw-model-request", "\"format\": \"json\"")
+    assert has_element?(view, "#instance-raw-model-request", "fs.write_text_file")
+    assert has_element?(view, "#instance-raw-model-request-source", "live executor snapshot")
+
+    assert has_element?(
+             view,
+             "#instance-raw-model-request",
+             "\"content\": \"Create budget file\""
+           )
+
+    assert has_element?(view, "#instance-raw-context-messages", "Create a budget file")
+    assert has_element?(view, "#instance-raw-runtime-state", "\"tool_iteration_count\": 2")
+    assert has_element?(view, "#instance-raw-current-item", "Create budget file")
+    assert has_element?(view, "#instance-raw-config-snapshot", "\"tools_config\"")
+    assert has_element?(view, "#instance-raw-session-link", "Back to session")
+  end
+
+  test "S12b: raw context view reconstructs the provider request from persisted transcript", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    Repo.insert!(%Message{
+      lemming_instance_id: instance.id,
+      world_id: world.id,
+      role: "assistant",
+      content: "I can help with that."
+    })
+
+    Repo.insert!(%Message{
+      lemming_instance_id: instance.id,
+      world_id: world.id,
+      role: "user",
+      content: "Create a file at notes/budget_brief_example.md"
+    })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}/raw?#{%{world: world.id}}")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline-source",
+             "persisted transcript/tool history only"
+           )
+
+    assert has_element?(view, "#instance-raw-model-request-source", "persisted transcript")
+
+    assert has_element?(
+             view,
+             "#instance-raw-model-request",
+             "\"content\": \"Create a file at notes/budget_brief_example.md\""
+           )
+
+    refute has_element?(view, "#instance-raw-model-request", ":invalid_request")
+  end
+
+  test "S12c: raw context view renders live model interaction timeline", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+    resource_key = "ollama:tool-loop-model"
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{
+          name: "Incident Triage",
+          description: "Handles incident follow-up and operator requests.",
+          instructions: "Stay concise and use tools when needed.",
+          model: "tool-loop-model",
+          models_config: %{profiles: %{default: %{provider: "ollama", model: "tool-loop-model"}}}
+        },
+        context_mod: LemmingsOs.LemmingInstances,
+        model_mod: RawTraceToolLoopModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: RawTraceSuccessToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: EtsStore
+      )
+
+    {:ok, _pool_pid} =
+      start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Use a tool then reply")
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert eventually_executor_status(pid, "idle")
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}/raw?#{%{world: world.id}}")
+
+    assert has_element?(view, "#instance-raw-interaction-timeline-source", "live executor trace")
+    assert has_element?(view, "#instance-raw-model-request-source", "exact latest live request")
+    assert has_element?(view, "#instance-raw-model-request", "\"model\": \"tool-loop-model\"")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "1. User -> App")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "2. App -> LLM")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "SYSTEM")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Platform Runtime Context")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Configured Lemming Identity")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Name: Incident Triage")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "Description: Handles incident follow-up and operator requests."
+           )
+
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Instructions:")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "Stay concise and use tools when needed."
+           )
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "Available Tools"
+           )
+
+    assert has_element?(view, "#instance-raw-interaction-timeline", "USER")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Use a tool then reply")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Loop State Semantics")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "Immediate Response Instruction"
+           )
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "LLM requested tool web.fetch"
+           )
+
+    assert has_element?(view, "#instance-raw-interaction-timeline", "Execute web.fetch")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "web.fetch completed")
+    assert has_element?(view, "#instance-raw-interaction-timeline", "File created successfully!")
+
+    GenServer.stop(pid)
+  end
+
+  test "S12d: raw context view shows malformed provider content on invalid structured output", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        config_snapshot: %{model: "broken-model"},
+        context_mod: LemmingsOs.LemmingInstances,
+        model_mod: RawTraceInvalidOutputModelRuntime,
+        tools_context_mod: LemmingTools,
+        tool_runtime_mod: RawTraceSuccessToolRuntime,
+        pool_mod: nil,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: EtsStore
+      )
+
+    assert :ok = Executor.enqueue_work(pid, "Trigger malformed output")
+    Executor.admit(pid)
+    assert eventually_executor_status(pid, "failed")
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}/raw?#{%{world: world.id}}")
+
+    assert has_element?(
+             view,
+             "#instance-raw-interaction-timeline",
+             "LLM returned an unexpected payload"
+           )
+
+    assert has_element?(view, "#instance-raw-interaction-timeline", "not-json")
+
+    GenServer.stop(pid)
+  end
+
   defp spawn_runtime_session do
     unique = System.unique_integer([:positive])
     world = insert(:world, name: "Ops World #{unique}", slug: "ops-world-#{unique}")
@@ -547,6 +993,8 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
         city: city,
         department: department,
         name: "Incident Triage #{unique}",
+        description: "Handles incident follow-up and operator requests.",
+        instructions: "Stay concise and use tools when needed.",
         slug: "incident-triage-#{unique}",
         status: "active"
       )
@@ -607,6 +1055,21 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
       eventually_lacks_element?(view, selector, attempts - 1)
     else
       true
+    end
+  end
+
+  defp eventually_executor_status(pid, expected_status, attempts \\ 20)
+
+  defp eventually_executor_status(pid, expected_status, 0) do
+    Executor.status(pid).status == expected_status
+  end
+
+  defp eventually_executor_status(pid, expected_status, attempts) do
+    if Executor.status(pid).status == expected_status do
+      true
+    else
+      Process.sleep(50)
+      eventually_executor_status(pid, expected_status, attempts - 1)
     end
   end
 

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -612,7 +612,53 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
 
     assert response.status == 200
     assert response.resp_body == "# Sample artifact\n"
-    assert get_resp_header(response, "content-type") == ["text/markdown; charset=utf-8"]
+    assert get_resp_header(response, "content-type") == ["application/octet-stream"]
+
+    assert get_resp_header(response, "content-disposition") == [
+             ~s(attachment; filename="sample.md")
+           ]
+
+    assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
+  end
+
+  test "S08h: html and svg artifacts download without inline rendering", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    assert_artifact_download_headers(
+      conn,
+      world,
+      instance,
+      "report.html",
+      "<script>alert(1)</script>"
+    )
+
+    assert_artifact_download_headers(conn, world, instance, "diagram.svg", "<svg></svg>")
+  end
+
+  test "S08g: artifact download rejects symlink targets outside workspace", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, %{absolute_path: safe_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "safe.md")
+
+    work_area = Path.dirname(safe_path)
+    outside_path = Path.join(Path.dirname(work_area), "outside-artifact.md")
+    File.mkdir_p!(work_area)
+    File.mkdir_p!(Path.dirname(outside_path))
+    File.write!(outside_path, "# Secret artifact\n")
+    assert :ok = File.ln_s(outside_path, Path.join(work_area, "artifact-link.md"))
+
+    assert {:error, :path_outside_workspace} =
+             LemmingInstances.artifact_absolute_path(instance, "artifact-link.md")
+
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["artifact-link.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "Artifact not found"
   end
 
   test "S08c: tool execution broadcasts update transcript cards without remount", %{conn: conn} do
@@ -1206,5 +1252,27 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
       {position, _length} -> position
       :nomatch -> nil
     end
+  end
+
+  defp assert_artifact_download_headers(conn, world, instance, path, content) do
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, path)
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, content)
+
+    response =
+      conn
+      |> get(~p"/lemmings/instances/#{instance.id}/artifacts/#{[path]}?#{%{world: world.id}}")
+
+    assert response.status == 200
+    assert response.resp_body == content
+    assert get_resp_header(response, "content-type") == ["application/octet-stream"]
+
+    assert get_resp_header(response, "content-disposition") == [
+             ~s(attachment; filename="#{path}")
+           ]
+
+    assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
   end
 end

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -672,6 +672,134 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
            )
   end
 
+  test "S08e: tool execution broadcasts failed lifecycle updates without remount", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_idle_runtime_session()
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "web.fetch",
+        status: "running",
+        args: %{"url" => "https://example.invalid"},
+        summary: "Fetching source page.",
+        started_at: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+
+    assert :ok =
+             PubSub.broadcast_tool_execution_upserted(
+               instance.id,
+               tool_execution.id,
+               tool_execution.status
+             )
+
+    assert eventually_has_element?(
+             view,
+             "#card-tool-execution-#{tool_execution.id}[data-status='running']"
+           )
+
+    {:ok, _updated_tool_execution} =
+      LemmingTools.update_tool_execution(world, instance, tool_execution, %{
+        status: "error",
+        summary: "Failed to fetch source page.",
+        error: %{
+          "code" => "tool.runtime_timeout",
+          "message" => "Request timed out while fetching URL"
+        },
+        completed_at: DateTime.utc_now() |> DateTime.truncate(:second),
+        duration_ms: 75
+      })
+
+    assert :ok =
+             PubSub.broadcast_tool_execution_upserted(
+               instance.id,
+               tool_execution.id,
+               "error"
+             )
+
+    assert eventually_has_element?(
+             view,
+             "#card-tool-execution-#{tool_execution.id}[data-status='error']"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#tool-execution-summary-#{tool_execution.id}",
+             "Failed to fetch source page."
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#tool-execution-preview-#{tool_execution.id}",
+             "Request timed out while fetching URL"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#tool-execution-error-#{tool_execution.id}",
+             "\"code\": \"tool.runtime_timeout\""
+           )
+  end
+
+  test "S08f: persisted failed tool execution details render after page reload", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "web.fetch",
+        status: "error",
+        args: %{"url" => "https://example.invalid"},
+        summary: "Unable to fetch source page.",
+        error: %{
+          "code" => "tool.runtime_timeout",
+          "message" => "Request timed out while fetching URL"
+        },
+        started_at: now,
+        completed_at: DateTime.add(now, 1, :second),
+        duration_ms: 1000
+      })
+
+    Repo.update!(
+      Ecto.Changeset.change(tool_execution, inserted_at: DateTime.add(now, 2, :second))
+    )
+
+    {:ok, _initial_view, _initial_html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    {:ok, reloaded_view, _reloaded_html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(
+             reloaded_view,
+             "#card-tool-execution-#{tool_execution.id}[data-status='error']"
+           )
+
+    assert has_element?(
+             reloaded_view,
+             "#tool-execution-summary-#{tool_execution.id}",
+             "Unable to fetch source page."
+           )
+
+    assert has_element?(
+             reloaded_view,
+             "#tool-execution-details-#{tool_execution.id}"
+           )
+
+    assert has_element?(
+             reloaded_view,
+             "#tool-execution-args-#{tool_execution.id}",
+             "\"url\": \"https://example.invalid\""
+           )
+
+    assert has_element?(
+             reloaded_view,
+             "#tool-execution-error-#{tool_execution.id}",
+             "\"message\": \"Request timed out while fetching URL\""
+           )
+  end
+
   test "S09: session header shows aggregate total tokens across transcript", %{conn: conn} do
     %{world: world, instance: instance} = spawn_runtime_session()
     now = DateTime.utc_now() |> DateTime.truncate(:second)

--- a/test/lemmings_os_web/live/tools_live_test.exs
+++ b/test/lemmings_os_web/live/tools_live_test.exs
@@ -10,125 +10,50 @@ defmodule LemmingsOsWeb.ToolsLiveTest do
   setup :verify_on_exit!
 
   setup do
-    stub(MockRuntimeFetcher, :fetch, fn -> {:error, :not_implemented} end)
     stub(MockPolicyFetcher, :fetch, fn -> :deferred end)
     :ok
   end
 
-  test "renders unknown runtime state honestly when runtime data is unavailable", %{conn: conn} do
+  test "renders the fixed runtime catalog on the happy path", %{conn: conn} do
+    expect(MockRuntimeFetcher, :fetch, 0, fn -> {:error, :timeout} end)
+
     {:ok, view, _html} = live(conn, ~p"/tools")
 
     assert has_element?(view, "#tools-page")
-    assert has_element?(view, "#tools-runtime-status[data-status='unknown']")
-    assert has_element?(view, "#tools-policy-status[data-status='unknown']")
-    assert has_element?(view, "#tools-page-status[data-status='unknown']")
-    assert has_element?(view, "#tools-issues-panel")
-    assert has_element?(view, "#tools-issue-tools_runtime_source_unavailable")
-    assert has_element?(view, "#tools-empty-state")
-    refute has_element?(view, "#tool-card-terminal")
-  end
-
-  test "renders runtime tools with deferred policy reconciliation", %{conn: conn} do
-    stub(MockRuntimeFetcher, :fetch, fn -> {:ok, runtime_tools()} end)
-
-    {:ok, view, _html} = live(conn, ~p"/tools")
-
     assert has_element?(view, "#tools-runtime-status[data-status='ok']")
     assert has_element?(view, "#tools-policy-status[data-status='unknown']")
     assert has_element?(view, "#tools-page-status[data-status='ok']")
-    assert has_element?(view, "#tool-card-terminal")
-    assert has_element?(view, "#tool-card-git")
-    assert has_element?(view, "#tool-policy-status-terminal[data-status='unknown']")
-    assert has_element?(view, "#tool-policy-status-git[data-status='unknown']")
-  end
-
-  test "renders unavailable runtime state explicitly when the runtime source times out", %{
-    conn: conn
-  } do
-    stub(MockRuntimeFetcher, :fetch, fn -> {:error, :timeout} end)
-
-    {:ok, view, _html} = live(conn, ~p"/tools")
-
-    assert has_element?(view, "#tools-runtime-status[data-status='unavailable']")
-    assert has_element?(view, "#tools-page-status[data-status='unavailable']")
-    assert has_element?(view, "#tools-issue-tools_runtime_source_unavailable")
-    assert has_element?(view, "#tools-empty-state")
-    refute has_element?(view, "#tool-card-terminal")
+    assert has_element?(view, "#tools-issues-panel")
+    refute has_element?(view, "#tools-empty-state")
+    assert has_element?(view, "#tools-grouped-list")
+    assert has_element?(view, "#tool-group-filesystem")
+    assert has_element?(view, "#tool-group-web")
+    assert has_element?(view, ~s([id="tool-list-item-fs.read_text_file"]))
+    assert has_element?(view, ~s([id="tool-list-item-fs.write_text_file"]))
+    assert has_element?(view, ~s([id="tool-list-item-web.search"]))
+    assert has_element?(view, ~s([id="tool-list-item-web.fetch"]))
   end
 
   test "filters runtime tools locally without reloading the page", %{conn: conn} do
-    stub(MockRuntimeFetcher, :fetch, fn -> {:ok, runtime_tools()} end)
-
     {:ok, view, _html} = live(conn, ~p"/tools")
 
     view
     |> element("#tools-filter-form")
-    |> render_change(%{"filter" => %{"query" => "git"}})
+    |> render_change(%{"filter" => %{"query" => "web.fetch"}})
 
-    assert has_element?(view, "#tool-card-git")
-    refute has_element?(view, "#tool-card-terminal")
+    assert has_element?(view, ~s([id="tool-list-item-web.fetch"]))
+    refute has_element?(view, ~s([id="tool-list-item-web.search"]))
+    refute has_element?(view, ~s([id="tool-list-item-fs.read_text_file"]))
+    refute has_element?(view, ~s([id="tool-list-item-fs.write_text_file"]))
   end
 
   test "renders partial policy reconciliation explicitly", %{conn: conn} do
-    stub(MockRuntimeFetcher, :fetch, fn -> {:ok, runtime_tools()} end)
-    stub(MockPolicyFetcher, :fetch, fn -> {:ok, %{"terminal" => "ok"}} end)
+    stub(MockPolicyFetcher, :fetch, fn -> {:ok, %{"fs.read_text_file" => "ok"}} end)
 
     {:ok, view, _html} = live(conn, ~p"/tools")
 
     assert has_element?(view, "#tools-policy-status[data-status='degraded']")
     assert has_element?(view, "#tools-page-status[data-status='degraded']")
     assert has_element?(view, "#tools-issue-tools_policy_partial")
-    assert has_element?(view, "#tool-policy-status-terminal[data-status='ok']")
-    assert has_element?(view, "#tool-policy-status-git[data-status='unknown']")
-  end
-
-  test "renders the explicit unavailable description label for tools without description", %{
-    conn: conn
-  } do
-    stub(MockRuntimeFetcher, :fetch, fn ->
-      {:ok,
-       [
-         %{
-           id: "terminal",
-           name: "Terminal",
-           description: nil,
-           icon: "hero-command-line",
-           category: "operations",
-           risk: "high",
-           usage_count: 3
-         }
-       ]}
-    end)
-
-    {:ok, view, _html} = live(conn, ~p"/tools")
-
-    assert has_element?(
-             view,
-             "#tool-card-description-terminal",
-             "No runtime description available."
-           )
-  end
-
-  defp runtime_tools do
-    [
-      %{
-        id: "terminal",
-        name: "Terminal",
-        description: "Execute shell commands inside the runtime boundary.",
-        icon: "hero-command-line",
-        category: "operations",
-        risk: "high",
-        usage_count: 3
-      },
-      %{
-        id: "git",
-        name: "Git",
-        description: "Inspect repository history and local diffs.",
-        icon: "hero-code-bracket-square",
-        category: "development",
-        risk: "medium",
-        usage_count: 1
-      }
-    ]
   end
 end

--- a/test/lemmings_os_web/telemetry_test.exs
+++ b/test/lemmings_os_web/telemetry_test.exs
@@ -1,0 +1,15 @@
+defmodule LemmingsOsWeb.TelemetryTest do
+  use ExUnit.Case, async: true
+
+  test "metrics/0 includes tool execution lifecycle metrics" do
+    metric_names =
+      LemmingsOsWeb.Telemetry.metrics()
+      |> Enum.map(& &1.name)
+
+    assert [:lemmings_os, :runtime, :tool_execution, :started, :count] in metric_names
+    assert [:lemmings_os, :runtime, :tool_execution, :completed, :count] in metric_names
+    assert [:lemmings_os, :runtime, :tool_execution, :failed, :count] in metric_names
+    assert [:lemmings_os, :runtime, :tool_execution, :completed, :duration_ms] in metric_names
+    assert [:lemmings_os, :runtime, :tool_execution, :failed, :duration_ms] in metric_names
+  end
+end

--- a/test/lemmings_os_web/telemetry_test.exs
+++ b/test/lemmings_os_web/telemetry_test.exs
@@ -1,5 +1,7 @@
 defmodule LemmingsOsWeb.TelemetryTest do
-  use ExUnit.Case, async: true
+  use LemmingsOs.DataCase, async: false
+
+  alias LemmingsOs.LemmingInstances
 
   test "metrics/0 includes tool execution lifecycle metrics" do
     metric_names =
@@ -11,5 +13,68 @@ defmodule LemmingsOsWeb.TelemetryTest do
     assert [:lemmings_os, :runtime, :tool_execution, :failed, :count] in metric_names
     assert [:lemmings_os, :runtime, :tool_execution, :completed, :duration_ms] in metric_names
     assert [:lemmings_os, :runtime, :tool_execution, :failed, :duration_ms] in metric_names
+  end
+
+  test "emit_runtime_snapshot/0 emits aggregate runtime instance measurements" do
+    ref = attach([:lemmings_os, :runtime, :instances])
+
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+
+    lemming =
+      insert(:lemming,
+        world: world,
+        city: city,
+        department: department,
+        status: "active"
+      )
+
+    {:ok, created_instance} = LemmingInstances.spawn_instance(lemming, "created")
+    {:ok, idle_instance} = LemmingInstances.spawn_instance(lemming, "idle")
+    {:ok, failed_instance} = LemmingInstances.spawn_instance(lemming, "failed")
+
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    assert {:ok, _updated_idle_instance} =
+             LemmingInstances.update_status(idle_instance, "idle", %{last_activity_at: now})
+
+    assert {:ok, _updated_failed_instance} =
+             LemmingInstances.update_status(failed_instance, "failed", %{stopped_at: now})
+
+    LemmingsOsWeb.Telemetry.emit_runtime_snapshot()
+
+    assert_receive {:telemetry_event, [:lemmings_os, :runtime, :instances], measurements,
+                    metadata}
+
+    assert metadata.source == :poller
+    assert measurements.total >= 3
+    assert measurements.created >= 1
+    assert measurements.idle >= 1
+    assert measurements.failed >= 1
+    assert is_binary(created_instance.id)
+
+    detach(ref)
+  end
+
+  defp attach(event) do
+    ref = make_ref()
+    test_pid = self()
+
+    :ok =
+      :telemetry.attach(
+        "web-telemetry-test-#{inspect(ref)}",
+        event,
+        fn event_name, measurements, metadata, _config ->
+          send(test_pid, {:telemetry_event, event_name, measurements, metadata})
+        end,
+        nil
+      )
+
+    ref
+  end
+
+  defp detach(ref) do
+    :telemetry.detach("web-telemetry-test-#{inspect(ref)}")
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -14,6 +14,7 @@ defmodule LemmingsOs.Factory do
   alias LemmingsOs.Helpers
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.LemmingInstances.Message
+  alias LemmingsOs.LemmingInstances.ToolExecution
   alias LemmingsOs.Lemmings.Lemming
   alias LemmingsOs.Worlds.World
 
@@ -138,6 +139,25 @@ defmodule LemmingsOs.Factory do
       output_tokens: nil,
       total_tokens: nil,
       usage: nil
+    }
+  end
+
+  def tool_execution_factory do
+    instance = build(:lemming_instance)
+
+    %ToolExecution{
+      lemming_instance: instance,
+      world: instance.world,
+      tool_name: "fs.read_text_file",
+      status: "running",
+      args: %{"path" => "notes.txt"},
+      result: nil,
+      error: nil,
+      summary: nil,
+      preview: nil,
+      started_at: DateTime.utc_now() |> DateTime.truncate(:second),
+      completed_at: nil,
+      duration_ms: nil
     }
   end
 end


### PR DESCRIPTION
• ## Summary

  Describe what this PR changes and why.

  This PR delivers the Tool Runtime MVP slice end to end. A spawned instance can execute the fixed four-tool catalog, persist tool execution history,
  surface tool activity in the session transcript, and write artifacts into the instance work area. It also hardens filesystem and web-tool boundaries so
  execution stays inside the intended workspace and web calls do not reach private/local targets by default.

  ## Scope

  - [x] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Chore

  ## Linked Issues

  Closes #
  Related #

  ## Technical Notes

  - Key implementation details:
      - Added durable lemming_instance_tool_executions persistence and context APIs for create/list/get/update within explicit world scope.
      - Implemented fixed catalog tools: fs.read_text_file, fs.write_text_file, web.search, web.fetch.
      - Wired the executor tool-call loop to persist tool lifecycle state, emit telemetry/logs, and continue model reasoning after tool results.
      - Added compact tool cards in the instance transcript and runtime catalog wiring in the tools page.
      - Added workspace symlink rejection for filesystem and artifact path resolution.
      - Artifact downloads now use attachment semantics with application/octet-stream and nosniff.
      - Web tools now block localhost/private/link-local targets by default and use bounded Req timeouts with no retries.
  - Data model / migration impact:
      - New migration adds lemming_instance_tool_executions.
      - No destructive schema changes.
  - Config/env var changes:
      - :tools_web_allow_private_hosts opt-in override for tests/dev.
      - :tools_web_timeout_ms for web request timeout tuning.
  - Security/privacy considerations:
      - Tool filesystem access is constrained to the instance work area.
      - Symlink escapes are rejected before file IO.
      - Artifact responses are download-only, not inline-rendered.
      - Web egress blocks loopback/private/link-local targets by default.

  ## Validation

  - [x] mix format
  - [x] mix test
  - [x] mix precommit
  - [x] Manual validation completed

  ### Manual validation notes

  Validated with focused test runs and full precommit checks, including:

  - filesystem adapter tests for normal paths and symlink escape cases
  - instance transcript tests for artifact links and symlink rejection
  - web adapter tests for blocked hosts, request timeout handling, and normalized error responses
  - runtime tests for spawn-time work area creation under the configured runtime workspace root

  ## Screenshots / Recordings (if UI changes)

  Not attached in this update.

  ## Rollout / Rollback

  - Rollout notes:
      - Safe to deploy after migration runs.
      - No feature flag required for the MVP slice.
  - Rollback notes:
      - Revert the PR and remove the added migration if rollback is needed before any dependent data is relied on.
      - Existing runtime data remains backward compatible.

  ## Checklist

  - [x] Tests added/updated for changed behavior
  - [x] Docs updated (README/docs/ADR/runbook) when needed
  - [x] No secrets or sensitive data committed
  - [x] Backward compatibility considered
