### PR TITLE
feat: share WorkArea across delegated Lemming instances

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -6,6 +6,6 @@ export PORT="${PORT:-${MIX_PORT}}"
 
 export OLLAMA_BASE_URL=http://localhost:11434
 
-export LEMMINGS_RUNTIME_WORKSPACE_ROOT="~/.lemmings/workspace"
+export LEMMINGS_WORK_AREAS_PATH="~/.lemmings/workspace"
 
 [ -f .envrc.custom ] && source .envrc.custom

--- a/config/config.exs
+++ b/config/config.exs
@@ -99,7 +99,8 @@ config :logger, :default_formatter,
     :issue_count,
     :world_id,
     :city_id,
-    :node_name
+    :node_name,
+    :work_area_ref
   ]
 
 # Use Jason for JSON parsing in Phoenix

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -8,18 +8,18 @@ parse_optional_integer = fn env_var ->
   end
 end
 
-runtime_workspace_root =
-  System.get_env("LEMMINGS_RUNTIME_WORKSPACE_ROOT") ||
+work_areas_path =
+  System.get_env("LEMMINGS_WORK_AREAS_PATH") ||
     Application.get_env(
       :lemmings_os,
-      :runtime_workspace_root,
+      :work_areas_path,
       Path.expand("../priv/runtime/workspace", __DIR__)
     )
 
 runtime_city_node_name = System.get_env("LEMMINGS_CITY_NODE_NAME") || Atom.to_string(node())
 runtime_city_heartbeat = Application.get_env(:lemmings_os, :runtime_city_heartbeat, [])
 
-config :lemmings_os, :runtime_workspace_root, runtime_workspace_root
+config :lemmings_os, :work_areas_path, work_areas_path
 
 config :lemmings_os, :runtime_city,
   node_name: runtime_city_node_name,

--- a/config/test.exs
+++ b/config/test.exs
@@ -29,6 +29,7 @@ config :lemmings_os, :runtime_engine_on_startup, false
 config :lemmings_os, dev_routes: true
 config :lemmings_os, :runtime_dets, directory: Path.expand("../tmp/runtime/dets", __DIR__)
 config :lemmings_os, :runtime_workspace_root, Path.expand("../tmp/runtime/workspace", __DIR__)
+config :lemmings_os, :work_areas_path, Path.expand("../tmp/runtime/work_areas", __DIR__)
 
 config :lemmings_os, :model_runtime,
   provider_module: LemmingsOs.ModelRuntime.Providers.Ollama,

--- a/lib/lemmings_os/lemming_instances.ex
+++ b/lib/lemmings_os/lemming_instances.ex
@@ -80,10 +80,7 @@ defmodule LemmingsOs.LemmingInstances do
           |> snapshot_value()
           |> ConfigSnapshot.enrich()
 
-        work_area_path = build_work_area_path(lemming)
-
-        with :ok <- create_work_area(work_area_path),
-             {:ok, %{instance: instance, message: message}} <-
+        with {:ok, %{instance: instance, message: message}} <-
                persist_spawn(
                  lemming,
                  config_snapshot,
@@ -97,8 +94,7 @@ defmodule LemmingsOs.LemmingInstances do
             city_id: instance.city_id,
             department_id: instance.department_id,
             message_id: message.id,
-            status: instance.status,
-            path: work_area_path
+            status: instance.status
           )
 
           _ =
@@ -107,8 +103,7 @@ defmodule LemmingsOs.LemmingInstances do
               %{count: 1},
               Telemetry.instance_metadata(instance, %{
                 status: instance.status,
-                message_id: message.id,
-                work_area_path: work_area_path
+                message_id: message.id
               })
             )
 
@@ -116,15 +111,10 @@ defmodule LemmingsOs.LemmingInstances do
             ActivityLog.record(:runtime, "instance", "Runtime instance spawned", %{
               instance_id: instance.id,
               lemming_id: instance.lemming_id,
-              message_id: message.id,
-              work_area_path: work_area_path
+              message_id: message.id
             })
 
           {:ok, instance}
-        else
-          {:error, _reason} = error ->
-            cleanup_work_area(work_area_path)
-            error
         end
     end
   end
@@ -569,11 +559,6 @@ defmodule LemmingsOs.LemmingInstances do
     end
   end
 
-  defp build_work_area_path(%Lemming{department_id: department_id, id: lemming_id})
-       when is_binary(department_id) and is_binary(lemming_id) do
-    Path.join([department_id, lemming_id])
-  end
-
   @doc """
   Resolves a workspace-relative artifact path for an instance into an absolute path.
   """
@@ -622,46 +607,12 @@ defmodule LemmingsOs.LemmingInstances do
     end
   end
 
-  defp create_work_area(work_area_path) when is_binary(work_area_path) do
-    workspace_root()
-    |> Path.expand()
-    |> Path.join(work_area_path)
-    |> File.mkdir_p()
-    |> case do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Logger.error("runtime instance work area could not be created",
-          event: "instance.work_area.create_failed",
-          path: work_area_path,
-          reason: inspect(reason)
-        )
-
-        {:error, :work_area_unavailable}
-    end
-  end
-
-  defp cleanup_work_area(work_area_path) when is_binary(work_area_path) do
-    work_area_path
-    |> work_area_absolute_path()
-    |> File.rm_rf()
-
-    :ok
-  end
-
   defp workspace_root do
     Application.get_env(
       :lemmings_os,
       :runtime_workspace_root,
       Path.expand("../../../priv/runtime/workspace", __DIR__)
     )
-  end
-
-  defp work_area_absolute_path(work_area_path) do
-    workspace_root()
-    |> Path.expand()
-    |> Path.join(work_area_path)
   end
 
   defp path_within_root?(absolute_path, root_path)
@@ -755,6 +706,7 @@ defmodule LemmingsOs.LemmingInstances do
 
   defp normalize_runtime_state(state) do
     %{
+      work_area_ref: Map.get(state, :work_area_ref),
       retry_count: Map.get(state, :retry_count, 0),
       max_retries: Map.get(state, :max_retries, 3),
       queue_depth: runtime_queue_depth(Map.get(state, :queue)),

--- a/lib/lemmings_os/lemming_instances/executor.ex
+++ b/lib/lemmings_os/lemming_instances/executor.ex
@@ -76,6 +76,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   alias LemmingsOs.Repo
   alias LemmingsOs.Runtime.ActivityLog
   alias LemmingsOs.Tools.Runtime, as: ToolsRuntime
+  alias LemmingsOs.Tools.WorkArea
   alias LemmingsOs.Worlds.World
 
   @runtime_table :lemming_instance_runtime
@@ -106,6 +107,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   @type state :: %{
           instance_id: binary(),
+          work_area_ref: binary(),
           department_id: binary() | nil,
           instance: LemmingInstance.t() | map(),
           config_snapshot: map(),
@@ -427,9 +429,11 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       status = instance_status(instance)
       now_fun = Keyword.get(opts, :now_fun, &DateTime.utc_now/0)
       now = now_fun.()
+      work_area_ref = Keyword.get(opts, :work_area_ref, instance_id)
 
       state = %{
         instance_id: instance_id,
+        work_area_ref: work_area_ref,
         department_id: instance_department_id(instance),
         instance: instance,
         config_snapshot: config_snapshot || %{},
@@ -478,6 +482,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
         :ok ->
           state =
             state
+            |> maybe_ensure_root_work_area()
             |> maybe_load_context_messages()
             |> persist_started_at()
             |> put_runtime_state()
@@ -491,6 +496,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
             world_id: instance_world_id(state.instance),
             city_id: instance_city_id(state.instance),
             department_id: state.department_id,
+            work_area_ref: state.work_area_ref,
             status: state.status,
             queue_depth: :queue.len(state.queue),
             retry_count: state.retry_count,
@@ -504,6 +510,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
               %{count: 1},
               Telemetry.instance_metadata(state.instance, %{
                 instance_id: state.instance_id,
+                work_area_ref: state.work_area_ref,
                 status: state.status,
                 queue_depth: :queue.len(state.queue),
                 retry_count: state.retry_count,
@@ -515,6 +522,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
             ActivityLog.record(:runtime, "executor", "Executor started", %{
               instance_id: state.instance_id,
               department_id: state.department_id,
+              work_area_ref: state.work_area_ref,
               status: state.status
             })
 
@@ -566,6 +574,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   def handle_call(:snapshot, _from, state) do
     snapshot = %{
       instance_id: state.instance_id,
+      work_area_ref: state.work_area_ref,
       department_id: state.department_id,
       world_id: instance_world_id(state.instance),
       city_id: instance_city_id(state.instance),
@@ -977,11 +986,20 @@ defmodule LemmingsOs.LemmingInstances.Executor do
   end
 
   defp execute_tool_runtime(tool_runtime_mod, state, world, tool_name, tool_args) do
-    case module_loaded_and_exports?(tool_runtime_mod, :execute, 4) do
-      true ->
+    cond do
+      module_loaded_and_exports?(tool_runtime_mod, :execute, 5) ->
+        tool_runtime_mod.execute(
+          world,
+          state.instance,
+          tool_name,
+          tool_args,
+          tool_runtime_meta(state)
+        )
+
+      module_loaded_and_exports?(tool_runtime_mod, :execute, 4) ->
         tool_runtime_mod.execute(world, state.instance, tool_name, tool_args)
 
-      false ->
+      true ->
         {:error,
          %{
            tool_name: tool_name,
@@ -990,6 +1008,16 @@ defmodule LemmingsOs.LemmingInstances.Executor do
            details: %{}
          }}
     end
+  end
+
+  defp tool_runtime_meta(state) do
+    %{
+      actor_instance_id: state.instance_id,
+      work_area_ref: state.work_area_ref,
+      world_id: instance_world_id(state.instance),
+      city_id: instance_city_id(state.instance),
+      department_id: state.department_id
+    }
   end
 
   defp persist_tool_success(state, tool_execution, execution_result, started_at) do
@@ -1801,6 +1829,7 @@ defmodule LemmingsOs.LemmingInstances.Executor do
 
   defp runtime_state_map(state) do
     %{
+      work_area_ref: state.work_area_ref,
       department_id: instance_department_id(state.instance),
       world_id: instance_world_id(state.instance),
       city_id: instance_city_id(state.instance),
@@ -1824,6 +1853,34 @@ defmodule LemmingsOs.LemmingInstances.Executor do
       last_activity_at: state.last_activity_at
     }
   end
+
+  defp maybe_ensure_root_work_area(
+         %{work_area_ref: instance_id, instance_id: instance_id} = state
+       ) do
+    case WorkArea.ensure(state.work_area_ref) do
+      :ok ->
+        state
+
+      {:error, reason} ->
+        _ =
+          WorkArea.log_creation_failure(state.work_area_ref, reason, %{
+            instance_id: state.instance_id,
+            world_id: instance_world_id(state.instance),
+            city_id: instance_city_id(state.instance),
+            department_id: state.department_id
+          })
+
+        _ =
+          Events.emit(state, "runtime.work_area.create_failed", %{
+            work_area_ref: state.work_area_ref,
+            reason: inspect(reason)
+          })
+
+        state
+    end
+  end
+
+  defp maybe_ensure_root_work_area(state), do: state
 
   defp maybe_load_context_messages(%{context_mod: nil} = state), do: state
   defp maybe_load_context_messages(%{load_context_messages?: false} = state), do: state

--- a/lib/lemmings_os/lemming_instances/executor/communication.ex
+++ b/lib/lemmings_os/lemming_instances/executor/communication.ex
@@ -64,14 +64,17 @@ defmodule LemmingsOs.LemmingInstances.Executor.Communication do
       iex> LemmingsOs.LemmingInstances.Executor.Communication.request_call(nil, %{id: "instance-1"}, response)
       {:error, :lemming_call_unavailable}
   """
-  @spec request_call(module() | nil, map(), Response.t()) :: request_result()
-  def request_call(nil, _instance, _response), do: {:error, :lemming_call_unavailable}
+  @spec request_call(module() | nil, map(), Response.t(), keyword()) :: request_result()
+  def request_call(lemming_calls_mod, instance, response, opts \\ [])
 
-  def request_call(lemming_calls_mod, instance, %Response{} = response) do
+  def request_call(nil, _instance, _response, _opts), do: {:error, :lemming_call_unavailable}
+
+  def request_call(lemming_calls_mod, instance, %Response{} = response, opts)
+      when is_list(opts) do
     attrs = lemming_call_attrs(response)
 
     with true <- module_loaded_and_exports?(lemming_calls_mod, :request_call, 3),
-         {:ok, call} <- lemming_calls_mod.request_call(instance, attrs, []) do
+         {:ok, call} <- lemming_calls_mod.request_call(instance, attrs, opts) do
       {:ok, attrs, call}
     else
       false -> {:error, :lemming_call_unavailable}

--- a/lib/lemmings_os/lemming_instances/executor/communication_runtime.ex
+++ b/lib/lemmings_os/lemming_instances/executor/communication_runtime.ex
@@ -56,7 +56,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.CommunicationRuntime do
   """
   @spec resume_after_lemming_call(map(), map(), resume_deps()) ::
           {:ok, map()}
-          | {{:error, :terminal_instance | :resume_not_possible | :child_call_not_terminal}, map()}
+          | {{:error, :terminal_instance | :resume_not_possible | :child_call_not_terminal},
+             map()}
   def resume_after_lemming_call(state, call, deps)
       when is_map(state) and is_map(call) and is_map(deps) do
     _ = emit_resume_event(deps, :emit_resume_requested, state, call)
@@ -120,11 +121,28 @@ defmodule LemmingsOs.LemmingInstances.Executor.CommunicationRuntime do
     attrs = Communication.lemming_call_attrs(response)
     state = append_call_request_context(state, attrs)
 
-    case Communication.request_call(state.lemming_calls_mod, instance, response) do
+    case Communication.request_call(
+           state.lemming_calls_mod,
+           instance,
+           response,
+           request_call_opts(state)
+         ) do
       {:ok, _attrs, call} -> {:ok, state, call}
       {:error, reason} -> {:error, reason, state}
     end
   end
+
+  defp request_call_opts(%{work_area_ref: work_area_ref}) when is_binary(work_area_ref) do
+    runtime_opts = [
+      executor_opts: [
+        work_area_ref: work_area_ref
+      ]
+    ]
+
+    [runtime_opts: runtime_opts]
+  end
+
+  defp request_call_opts(_state), do: []
 
   @doc """
   Builds an instance struct/map carrying the latest runtime config snapshot.

--- a/lib/lemmings_os/lemming_instances/executor/events.ex
+++ b/lib/lemmings_os/lemming_instances/executor/events.ex
@@ -306,6 +306,7 @@ defmodule LemmingsOs.LemmingInstances.Executor.Events do
 
     %{
       instance_id: Map.get(state, :instance_id),
+      work_area_ref: Map.get(state, :work_area_ref),
       current_item_id: current_item_id(Map.get(state, :current_item)),
       phase: Map.get(state, :phase),
       retry_count: Map.get(state, :retry_count),

--- a/lib/lemmings_os/lemming_instances/executor/tool_lifecycle.ex
+++ b/lib/lemmings_os/lemming_instances/executor/tool_lifecycle.ex
@@ -39,6 +39,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
       world_id: map_field(Map.get(state, :instance), :world_id),
       city_id: map_field(Map.get(state, :instance), :city_id),
       department_id: Map.get(state, :department_id),
+      work_area_ref: Map.get(state, :work_area_ref),
+      path: relative_path(tool_execution),
       current_item_id: current_item_id(Map.get(state, :current_item))
     )
 
@@ -55,6 +57,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
       world_id: map_field(Map.get(state, :instance), :world_id),
       city_id: map_field(Map.get(state, :instance), :city_id),
       department_id: Map.get(state, :department_id),
+      work_area_ref: Map.get(state, :work_area_ref),
+      path: relative_path(tool_execution),
       current_item_id: current_item_id(Map.get(state, :current_item))
     )
 
@@ -72,6 +76,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
       world_id: map_field(Map.get(state, :instance), :world_id),
       city_id: map_field(Map.get(state, :instance), :city_id),
       department_id: Map.get(state, :department_id),
+      work_area_ref: Map.get(state, :work_area_ref),
+      path: relative_path(tool_execution),
       current_item_id: current_item_id(Map.get(state, :current_item))
     )
 
@@ -90,7 +96,11 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
         Telemetry.tool_execution_metadata(
           Map.get(state, :instance),
           tool_execution,
-          %{instance_id: Map.get(state, :instance_id)}
+          %{
+            instance_id: Map.get(state, :instance_id),
+            work_area_ref: Map.get(state, :work_area_ref),
+            relative_path: relative_path(tool_execution)
+          }
         )
       )
 
@@ -105,7 +115,11 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
         Telemetry.tool_execution_metadata(
           Map.get(state, :instance),
           tool_execution,
-          %{instance_id: Map.get(state, :instance_id)}
+          %{
+            instance_id: Map.get(state, :instance_id),
+            work_area_ref: Map.get(state, :work_area_ref),
+            relative_path: relative_path(tool_execution)
+          }
         )
       )
 
@@ -122,6 +136,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
           tool_execution,
           %{
             instance_id: Map.get(state, :instance_id),
+            work_area_ref: Map.get(state, :work_area_ref),
+            relative_path: relative_path(tool_execution),
             reason: tool_error_reason(tool_execution.error)
           }
         )
@@ -142,6 +158,8 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
         world_id: map_field(Map.get(state, :instance), :world_id),
         city_id: map_field(Map.get(state, :instance), :city_id),
         department_id: Map.get(state, :department_id),
+        work_area_ref: Map.get(state, :work_area_ref),
+        relative_path: relative_path(tool_execution),
         tool_execution_id: tool_execution.id,
         tool_name: tool_execution.tool_name,
         status: tool_execution.status,
@@ -154,6 +172,12 @@ defmodule LemmingsOs.LemmingInstances.Executor.ToolLifecycle do
   defp tool_error_reason(%{"code" => code}) when is_binary(code), do: code
   defp tool_error_reason(%{code: code}) when is_binary(code), do: code
   defp tool_error_reason(_error), do: nil
+
+  defp relative_path(%{args: %{"path" => path}}) when is_binary(path), do: path
+  defp relative_path(%{args: %{path: path}}) when is_binary(path), do: path
+  defp relative_path(%{result: %{"path" => path}}) when is_binary(path), do: path
+  defp relative_path(%{result: %{path: path}}) when is_binary(path), do: path
+  defp relative_path(_tool_execution), do: nil
 
   defp current_item_id(%{id: id}) when is_binary(id), do: id
   defp current_item_id(_current_item), do: nil

--- a/lib/lemmings_os/tools/adapters/filesystem.ex
+++ b/lib/lemmings_os/tools/adapters/filesystem.ex
@@ -4,6 +4,15 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
   """
 
   alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Tools.WorkArea
+
+  @type runtime_meta :: %{
+          optional(:actor_instance_id) => String.t(),
+          optional(:work_area_ref) => String.t(),
+          optional(:world_id) => String.t(),
+          optional(:city_id) => String.t(),
+          optional(:department_id) => String.t()
+        }
 
   @type success_result :: %{
           summary: String.t(),
@@ -19,37 +28,21 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
 
   @doc """
   Executes the `fs.read_text_file` adapter.
-
-  ## Examples
-
-      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{
-      ...>   department_id: "department-1",
-      ...>   lemming_id: "lemming-1"
-      ...> }
-      iex> LemmingsOs.Tools.Adapters.Filesystem.read_text_file(instance, %{"path" => "notes.txt"})
-      {:error, %{code: "tool.fs.not_found", details: %{path: "notes.txt"}, message: "File not found"}}
   """
-  @spec read_text_file(LemmingInstance.t(), map()) ::
+  @spec read_text_file(LemmingInstance.t(), map(), runtime_meta()) ::
           {:ok, success_result()} | {:error, error_result()}
-  def read_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
+  def read_text_file(%LemmingInstance{} = instance, args, runtime_meta \\ %{})
+      when is_map(args) and is_map(runtime_meta) do
     with {:ok, relative_path} <- validate_read_args(args),
-         {:ok,
-          %{
-            absolute_path: absolute_path,
-            relative_path: normalized_relative_path,
-            root_path: root_path,
-            workspace_path: workspace_path
-          }} <-
-           resolve_workspace_path(instance, relative_path),
-         {:ok, content} <- read_utf8_file(absolute_path) do
+         {:ok, %{absolute_path: absolute_path, relative_path: normalized_relative_path}} <-
+           resolve_workspace_path(instance, relative_path, runtime_meta),
+         {:ok, content} <- read_utf8_file(absolute_path, normalized_relative_path) do
       {:ok,
        %{
          summary: "Read file #{normalized_relative_path}",
          preview: String.slice(content, 0, 280),
          result: %{
            path: normalized_relative_path,
-           root_path: root_path,
-           workspace_path: workspace_path,
            content: content,
            bytes: byte_size(content)
          }
@@ -59,32 +52,14 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
 
   @doc """
   Executes the `fs.write_text_file` adapter.
-
-  ## Examples
-
-      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{
-      ...>   department_id: "department-1",
-      ...>   lemming_id: "lemming-1"
-      ...> }
-      iex> LemmingsOs.Tools.Adapters.Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
-      {:ok,
-      %{result: %{bytes: 5,
-  path: "notes.txt", root_path: "/workspace/department-1/lemming-1",
-  workspace_path: "/workspace/department-1/lemming-1/notes.txt"},
-  summary: "Wrote file notes.txt", preview: "hello"}}
   """
-  @spec write_text_file(LemmingInstance.t(), map()) ::
+  @spec write_text_file(LemmingInstance.t(), map(), runtime_meta()) ::
           {:ok, success_result()} | {:error, error_result()}
-  def write_text_file(%LemmingInstance{} = instance, args) when is_map(args) do
+  def write_text_file(%LemmingInstance{} = instance, args, runtime_meta \\ %{})
+      when is_map(args) and is_map(runtime_meta) do
     with {:ok, {relative_path, content}} <- validate_write_args(args),
-         {:ok,
-          %{
-            absolute_path: absolute_path,
-            relative_path: normalized_relative_path,
-            root_path: root_path,
-            workspace_path: workspace_path
-          }} <-
-           resolve_workspace_path(instance, relative_path),
+         {:ok, %{absolute_path: absolute_path, relative_path: normalized_relative_path}} <-
+           resolve_workspace_path(instance, relative_path, runtime_meta),
          :ok <- ensure_parent_directory(absolute_path),
          :ok <- write_utf8_file(absolute_path, content) do
       {:ok,
@@ -93,8 +68,6 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
          preview: String.slice(content, 0, 280),
          result: %{
            path: normalized_relative_path,
-           root_path: root_path,
-           workspace_path: workspace_path,
            bytes: byte_size(content)
          }
        }}
@@ -130,127 +103,57 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
      }}
   end
 
-  defp resolve_workspace_path(
-         %LemmingInstance{department_id: department_id, lemming_id: lemming_id},
-         relative_path
-       )
-       when is_binary(department_id) and is_binary(lemming_id) and is_binary(relative_path) do
-    with :ok <- validate_relative_path(relative_path) do
-      resolve_valid_workspace_path(department_id, lemming_id, relative_path)
-    end
-  end
+  defp resolve_workspace_path(%LemmingInstance{} = instance, relative_path, runtime_meta) do
+    case work_area_ref(instance, runtime_meta) do
+      work_area_ref when is_binary(work_area_ref) and work_area_ref != "" ->
+        relative_path
+        |> then(&WorkArea.resolve(work_area_ref, &1))
+        |> normalize_resolve_result(relative_path)
 
-  defp resolve_workspace_path(_instance, _relative_path) do
-    {:error,
-     %{
-       code: "tool.fs.invalid_instance_scope",
-       message: "Instance scope is incomplete",
-       details: %{}
-     }}
-  end
-
-  defp validate_relative_path(path) when is_binary(path) do
-    cond do
-      path == "" ->
+      _other ->
         {:error,
          %{
-           code: "tool.validation.invalid_args",
-           message: "Invalid tool arguments",
-           details: %{field: "path"}
+           code: "tool.fs.invalid_instance_scope",
+           message: "Instance scope is incomplete",
+           details: %{}
          }}
-
-      Path.type(path) == :absolute ->
-        {:error,
-         %{
-           code: "tool.fs.path_must_be_relative",
-           message: "Path must be workspace-relative",
-           details: %{path: path}
-         }}
-
-      true ->
-        :ok
     end
   end
 
-  defp resolve_valid_workspace_path(department_id, lemming_id, relative_path) do
-    workspace_root = workspace_root() |> Path.expand()
-    work_area_root = Path.join([workspace_root, department_id, lemming_id])
-    absolute_path = Path.expand(relative_path, work_area_root)
+  defp work_area_ref(_instance, %{work_area_ref: work_area_ref}) when is_binary(work_area_ref),
+    do: work_area_ref
 
-    if path_within_root?(absolute_path, work_area_root) do
-      build_workspace_path_info(work_area_root, absolute_path, department_id, lemming_id)
-    else
-      path_outside_workspace_error(relative_path)
-    end
-  end
+  defp work_area_ref(_instance, %{"work_area_ref" => work_area_ref})
+       when is_binary(work_area_ref),
+       do: work_area_ref
 
-  defp build_workspace_path_info(work_area_root, absolute_path, department_id, lemming_id) do
-    root_path = Path.join(["/workspace", department_id, lemming_id])
-    normalized_relative_path = Path.relative_to(absolute_path, work_area_root)
-    workspace_path = Path.join([root_path, normalized_relative_path])
+  defp work_area_ref(%LemmingInstance{id: instance_id}, _runtime_meta)
+       when is_binary(instance_id),
+       do: instance_id
 
-    with :ok <- validate_no_symlink_components(work_area_root, normalized_relative_path) do
-      {:ok,
-       %{
-         absolute_path: absolute_path,
-         relative_path: normalized_relative_path,
-         root_path: root_path,
-         workspace_path: workspace_path
-       }}
-    end
-  end
+  defp work_area_ref(_instance, _runtime_meta), do: nil
 
-  defp path_outside_workspace_error(relative_path) do
+  defp normalize_resolve_result({:ok, resolved}, _relative_path), do: {:ok, resolved}
+
+  defp normalize_resolve_result({:error, :work_area_unavailable}, relative_path) do
     {:error,
      %{
-       code: "tool.fs.path_outside_workspace",
-       message: "Path escapes workspace boundary",
+       code: "tool.fs.work_area_unavailable",
+       message: "WorkArea is unavailable",
        details: %{path: relative_path}
      }}
   end
 
-  defp path_within_root?(absolute_path, root_path)
-       when is_binary(absolute_path) and is_binary(root_path) do
-    normalized_absolute = Path.expand(absolute_path)
-    normalized_root = Path.expand(root_path)
-
-    normalized_absolute == normalized_root or
-      String.starts_with?(normalized_absolute, normalized_root <> "/")
+  defp normalize_resolve_result({:error, _reason}, relative_path) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_path",
+       message: "Invalid workspace-relative path",
+       details: %{path: relative_path}
+     }}
   end
 
-  defp validate_no_symlink_components(root_path, relative_path)
-       when is_binary(root_path) and is_binary(relative_path) do
-    root_path
-    |> Path.expand()
-    |> validate_no_symlink_components(Path.split(relative_path), relative_path)
-  end
-
-  defp validate_no_symlink_components(_current_path, [], _relative_path), do: :ok
-
-  defp validate_no_symlink_components(current_path, [segment | rest], relative_path) do
-    next_path = Path.join(current_path, segment)
-
-    case File.lstat(next_path) do
-      {:ok, %File.Stat{type: :symlink}} ->
-        {:error,
-         %{
-           code: "tool.fs.path_outside_workspace",
-           message: "Path escapes workspace boundary",
-           details: %{path: relative_path}
-         }}
-
-      {:ok, _stat} ->
-        validate_no_symlink_components(next_path, rest, relative_path)
-
-      {:error, :enoent} ->
-        :ok
-
-      {:error, _reason} ->
-        :ok
-    end
-  end
-
-  defp read_utf8_file(path) when is_binary(path) do
+  defp read_utf8_file(path, relative_path) when is_binary(path) do
     case File.read(path) do
       {:ok, content} when is_binary(content) ->
         {:ok, content}
@@ -260,7 +163,7 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
          %{
            code: "tool.fs.not_found",
            message: "File not found",
-           details: %{path: Path.basename(path)}
+           details: %{path: relative_path}
          }}
 
       {:error, reason} ->
@@ -304,13 +207,5 @@ defmodule LemmingsOs.Tools.Adapters.Filesystem do
            details: %{reason: inspect(reason)}
          }}
     end
-  end
-
-  defp workspace_root do
-    Application.get_env(
-      :lemmings_os,
-      :runtime_workspace_root,
-      Path.expand("../../../priv/runtime/workspace", __DIR__)
-    )
   end
 end

--- a/lib/lemmings_os/tools/runtime.ex
+++ b/lib/lemmings_os/tools/runtime.ex
@@ -43,15 +43,24 @@ defmodule LemmingsOs.Tools.Runtime do
           {:ok, success()} | {:error, error()}
   def execute(world, instance, tool_name, args)
 
+  def execute(world, instance, tool_name, args) do
+    execute(world, instance, tool_name, args, %{})
+  end
+
+  @spec execute(World.t(), LemmingInstance.t(), String.t(), map(), map()) ::
+          {:ok, success()} | {:error, error()}
+  def execute(world, instance, tool_name, args, runtime_meta)
+
   def execute(
         %World{id: world_id},
         %LemmingInstance{world_id: world_id} = instance,
         tool_name,
-        args
+        args,
+        runtime_meta
       )
-      when is_binary(tool_name) and is_map(args) do
+      when is_binary(tool_name) and is_map(args) and is_map(runtime_meta) do
     if Catalog.supported_tool?(tool_name) do
-      dispatch_tool_call(instance, tool_name, args)
+      dispatch_tool_call(instance, tool_name, args, runtime_meta)
     else
       {:error,
        %{
@@ -63,7 +72,8 @@ defmodule LemmingsOs.Tools.Runtime do
     end
   end
 
-  def execute(%World{}, %LemmingInstance{}, tool_name, _args) when is_binary(tool_name) do
+  def execute(%World{}, %LemmingInstance{}, tool_name, _args, _runtime_meta)
+      when is_binary(tool_name) do
     {:error,
      %{
        tool_name: tool_name,
@@ -73,7 +83,7 @@ defmodule LemmingsOs.Tools.Runtime do
      }}
   end
 
-  def execute(%World{}, %LemmingInstance{}, tool_name, _args) do
+  def execute(%World{}, %LemmingInstance{}, tool_name, _args, _runtime_meta) do
     {:error,
      %{
        tool_name: nil,
@@ -83,19 +93,27 @@ defmodule LemmingsOs.Tools.Runtime do
      }}
   end
 
-  defp dispatch_tool_call(instance, "fs.read_text_file", args) do
-    normalize_tool_result("fs.read_text_file", args, Filesystem.read_text_file(instance, args))
+  defp dispatch_tool_call(instance, "fs.read_text_file", args, runtime_meta) do
+    normalize_tool_result(
+      "fs.read_text_file",
+      args,
+      Filesystem.read_text_file(instance, args, runtime_meta)
+    )
   end
 
-  defp dispatch_tool_call(instance, "fs.write_text_file", args) do
-    normalize_tool_result("fs.write_text_file", args, Filesystem.write_text_file(instance, args))
+  defp dispatch_tool_call(instance, "fs.write_text_file", args, runtime_meta) do
+    normalize_tool_result(
+      "fs.write_text_file",
+      args,
+      Filesystem.write_text_file(instance, args, runtime_meta)
+    )
   end
 
-  defp dispatch_tool_call(_instance, "web.search", args) do
+  defp dispatch_tool_call(_instance, "web.search", args, _runtime_meta) do
     normalize_tool_result("web.search", args, Web.search(args))
   end
 
-  defp dispatch_tool_call(_instance, "web.fetch", args) do
+  defp dispatch_tool_call(_instance, "web.fetch", args, _runtime_meta) do
     normalize_tool_result("web.fetch", args, Web.fetch(args))
   end
 

--- a/lib/lemmings_os/tools/work_area.ex
+++ b/lib/lemmings_os/tools/work_area.ex
@@ -1,0 +1,211 @@
+defmodule LemmingsOs.Tools.WorkArea do
+  @moduledoc """
+  Runtime-only shared WorkArea path handling for filesystem tools.
+  """
+
+  require Logger
+
+  @type resolved_path :: %{
+          absolute_path: String.t(),
+          relative_path: String.t(),
+          root_path: String.t()
+        }
+
+  @doc """
+  Best-effort creation of the shared WorkArea directory.
+
+  ## Examples
+
+      iex> old_path = Application.get_env(:lemmings_os, :work_areas_path)
+      iex> path = Path.join(System.tmp_dir!(), "lemmings_work_area_doctest_ensure")
+      iex> Application.put_env(:lemmings_os, :work_areas_path, path)
+      iex> :ok = LemmingsOs.Tools.WorkArea.ensure("instance-1")
+      iex> File.rm_rf!(path)
+      iex> if old_path, do: Application.put_env(:lemmings_os, :work_areas_path, old_path), else: Application.delete_env(:lemmings_os, :work_areas_path)
+      :ok
+  """
+  @spec ensure(String.t()) :: :ok | {:error, term()}
+  def ensure(work_area_ref) when is_binary(work_area_ref) and work_area_ref != "" do
+    root = root_path(work_area_ref)
+
+    File.mkdir_p(root)
+  end
+
+  def ensure(_work_area_ref), do: {:error, :invalid_work_area_ref}
+
+  @doc """
+  Resolves a safe WorkArea-relative path.
+
+  ## Examples
+
+      iex> old_path = Application.get_env(:lemmings_os, :work_areas_path)
+      iex> path = Path.join(System.tmp_dir!(), "lemmings_work_area_doctest_resolve")
+      iex> Application.put_env(:lemmings_os, :work_areas_path, path)
+      iex> :ok = LemmingsOs.Tools.WorkArea.ensure("instance-1")
+      iex> {:ok, resolved} = LemmingsOs.Tools.WorkArea.resolve("instance-1", "scratch/notes.txt")
+      iex> resolved.relative_path
+      "scratch/notes.txt"
+      iex> File.rm_rf!(path)
+      iex> if old_path, do: Application.put_env(:lemmings_os, :work_areas_path, old_path), else: Application.delete_env(:lemmings_os, :work_areas_path)
+      :ok
+
+      iex> LemmingsOs.Tools.WorkArea.resolve("instance-1", "../secret")
+      {:error, :invalid_path}
+  """
+  @spec resolve(String.t(), String.t()) :: {:ok, resolved_path()} | {:error, atom()}
+  def resolve(work_area_ref, relative_path)
+      when is_binary(work_area_ref) and is_binary(relative_path) do
+    with :ok <- validate_relative_path(relative_path),
+         root <- root_path(work_area_ref),
+         :ok <- validate_work_area_available(root),
+         resolved <- Path.expand(relative_path, root),
+         :ok <- validate_within_root(resolved, root),
+         normalized_relative_path <- Path.relative_to(resolved, root),
+         :ok <- validate_no_symlink_components(root, normalized_relative_path) do
+      {:ok,
+       %{
+         absolute_path: resolved,
+         relative_path: normalized_relative_path,
+         root_path: root
+       }}
+    end
+  end
+
+  def resolve(_work_area_ref, _relative_path), do: {:error, :invalid_path}
+
+  @doc """
+  Returns the absolute WorkArea root for internal runtime use.
+
+  ## Examples
+
+      iex> old_path = Application.get_env(:lemmings_os, :work_areas_path)
+      iex> path = Path.join(System.tmp_dir!(), "lemmings_work_area_doctest_root")
+      iex> Application.put_env(:lemmings_os, :work_areas_path, path)
+      iex> LemmingsOs.Tools.WorkArea.root_path("instance-1") == Path.expand(Path.join(path, "instance-1"))
+      true
+      iex> if old_path, do: Application.put_env(:lemmings_os, :work_areas_path, old_path), else: Application.delete_env(:lemmings_os, :work_areas_path)
+      :ok
+  """
+  @spec root_path(String.t()) :: String.t()
+  def root_path(work_area_ref) when is_binary(work_area_ref) do
+    work_areas_path()
+    |> Path.expand()
+    |> Path.join(work_area_ref)
+    |> Path.expand()
+  end
+
+  @spec work_areas_path() :: String.t()
+  @doc """
+  Returns the configured WorkArea storage root.
+
+  ## Examples
+
+      iex> old_path = Application.get_env(:lemmings_os, :work_areas_path)
+      iex> path = Path.join(System.tmp_dir!(), "lemmings_work_area_doctest_config")
+      iex> Application.put_env(:lemmings_os, :work_areas_path, path)
+      iex> LemmingsOs.Tools.WorkArea.work_areas_path()
+      Path.join(System.tmp_dir!(), "lemmings_work_area_doctest_config")
+      iex> if old_path, do: Application.put_env(:lemmings_os, :work_areas_path, old_path), else: Application.delete_env(:lemmings_os, :work_areas_path)
+      :ok
+  """
+  def work_areas_path do
+    Application.get_env(
+      :lemmings_os,
+      :work_areas_path,
+      Path.expand("var/work_areas", File.cwd!())
+    )
+  end
+
+  @spec log_creation_failure(String.t(), term(), map()) :: :ok
+  @doc """
+  Emits a warning for best-effort WorkArea creation failures.
+
+  ## Examples
+
+      iex> ExUnit.CaptureLog.capture_log(fn ->
+      ...>   LemmingsOs.Tools.WorkArea.log_creation_failure("instance-1", :eacces, %{instance_id: "instance-1"})
+      ...> end) =~ "runtime WorkArea could not be created"
+      true
+  """
+  def log_creation_failure(work_area_ref, reason, metadata \\ %{}) do
+    Logger.warning(
+      "runtime WorkArea could not be created",
+      Map.merge(metadata, %{
+        event: "instance.work_area.create_failed",
+        work_area_ref: work_area_ref,
+        reason: inspect(reason)
+      })
+    )
+
+    :ok
+  end
+
+  defp validate_relative_path(path) do
+    cond do
+      path == "" ->
+        {:error, :invalid_path}
+
+      String.contains?(path, <<0>>) ->
+        {:error, :invalid_path}
+
+      String.starts_with?(path, "~") ->
+        {:error, :invalid_path}
+
+      String.contains?(path, "\\") ->
+        {:error, :invalid_path}
+
+      Regex.match?(~r/^[A-Za-z]:/, path) ->
+        {:error, :invalid_path}
+
+      Path.type(path) == :absolute ->
+        {:error, :invalid_path}
+
+      ".." in Path.split(path) ->
+        {:error, :invalid_path}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_work_area_available(root) do
+    case File.stat(root) do
+      {:ok, %File.Stat{type: :directory}} -> :ok
+      {:ok, _stat} -> {:error, :work_area_unavailable}
+      {:error, _reason} -> {:error, :work_area_unavailable}
+    end
+  end
+
+  defp validate_within_root(absolute_path, root_path) do
+    normalized_absolute = Path.expand(absolute_path)
+    normalized_root = Path.expand(root_path)
+
+    if normalized_absolute == normalized_root or
+         String.starts_with?(normalized_absolute, normalized_root <> "/") do
+      :ok
+    else
+      {:error, :invalid_path}
+    end
+  end
+
+  defp validate_no_symlink_components(root_path, relative_path) do
+    validate_no_symlink_components(
+      Path.expand(root_path),
+      Path.split(relative_path),
+      relative_path
+    )
+  end
+
+  defp validate_no_symlink_components(_current_path, [], _relative_path), do: :ok
+
+  defp validate_no_symlink_components(current_path, [segment | rest], relative_path) do
+    next_path = Path.join(current_path, segment)
+
+    case File.lstat(next_path) do
+      {:ok, %File.Stat{type: :symlink}} -> {:error, :invalid_path}
+      {:ok, _stat} -> validate_no_symlink_components(next_path, rest, relative_path)
+      {:error, :enoent} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+end

--- a/lib/lemmings_os_web/live/instance_live.ex
+++ b/lib/lemmings_os_web/live/instance_live.ex
@@ -9,6 +9,7 @@ defmodule LemmingsOsWeb.InstanceLive do
   alias LemmingsOs.LemmingTools
   alias LemmingsOs.Helpers
   alias LemmingsOs.Runtime
+  alias LemmingsOs.Tools.WorkArea
   alias LemmingsOs.Worlds
   alias LemmingsOs.Worlds.World
   alias LemmingsOsWeb.PageData.InstanceDelegationSnapshot
@@ -203,6 +204,28 @@ defmodule LemmingsOsWeb.InstanceLive do
     end
   end
 
+  def handle_event("open_workspace", _params, %{assigns: %{instance: nil}} = socket) do
+    {:noreply,
+     put_flash(socket, :error, dgettext("lemmings", "Workspace is unavailable right now."))}
+  end
+
+  def handle_event("open_workspace", _params, socket) do
+    path = instance_workspace_path(socket.assigns.instance, socket.assigns.runtime_state)
+
+    case open_workspace_path(path) do
+      :ok ->
+        {:noreply, put_flash(socket, :info, dgettext("lemmings", "Workspace open requested."))}
+
+      {:error, _reason} ->
+        {:noreply,
+         put_flash(socket, :error, dgettext("lemmings", "Workspace could not be opened."))}
+    end
+  end
+
+  def handle_event("workspace_path_copied", _params, socket) do
+    {:noreply, put_flash(socket, :info, dgettext("lemmings", "Workspace path copied."))}
+  end
+
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   defp load_instance(socket, id, params) do
@@ -333,6 +356,49 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   defp instance_raw_path(_instance, _world), do: nil
 
+  defp instance_workspace_path(%{id: instance_id}, runtime_state)
+       when is_binary(instance_id) and is_map(runtime_state) do
+    work_area_ref =
+      case Map.get(runtime_state, :work_area_ref) do
+        work_area_ref when is_binary(work_area_ref) and work_area_ref != "" -> work_area_ref
+        _other -> instance_id
+      end
+
+    WorkArea.root_path(work_area_ref)
+  end
+
+  defp instance_workspace_path(_instance, _runtime_state), do: nil
+
+  defp open_workspace_path(path) when is_binary(path) do
+    with :ok <- File.mkdir_p(path),
+         {command, args} <- workspace_open_command(path),
+         {_output, 0} <- System.cmd(command, args, stderr_to_stdout: true) do
+      :ok
+    else
+      {:error, reason} -> {:error, reason}
+      {_output, status} -> {:error, {:exit_status, status}}
+    end
+  rescue
+    exception -> {:error, exception}
+  end
+
+  defp open_workspace_path(_path), do: {:error, :invalid_path}
+
+  defp workspace_open_command(path) do
+    case Application.get_env(:lemmings_os, :workspace_open_command) do
+      {command, args} when is_binary(command) and is_list(args) -> {command, args ++ [path]}
+      command when is_binary(command) -> {command, [path]}
+      _other -> default_workspace_open_command(path)
+    end
+  end
+
+  defp default_workspace_open_command(path) do
+    case :os.type() do
+      {:unix, :darwin} -> {"open", [path]}
+      _other -> {"xdg-open", [path]}
+    end
+  end
+
   defp parent_lemming_name(%{lemming: %{name: name}}) when is_binary(name) and name != "",
     do: name
 
@@ -351,6 +417,7 @@ defmodule LemmingsOsWeb.InstanceLive do
           retry_count: Map.get(state, :retry_count, 0),
           max_retries: Map.get(state, :max_retries, 3),
           queue_depth: Map.get(state, :queue_depth, 0),
+          work_area_ref: Map.get(state, :work_area_ref),
           current_item: Map.get(state, :current_item),
           last_error: Map.get(state, :last_error),
           status: Map.get(state, :status),
@@ -377,6 +444,7 @@ defmodule LemmingsOsWeb.InstanceLive do
       retry_count: 0,
       max_retries: 3,
       queue_depth: 0,
+      work_area_ref: nil,
       current_item: nil,
       last_error: nil,
       status: status,

--- a/lib/lemmings_os_web/live/instance_live.html.heex
+++ b/lib/lemmings_os_web/live/instance_live.html.heex
@@ -80,7 +80,9 @@
                 :if={@parent_lemming_path}
                 id="instance-parent-lemming-link"
                 navigate={@parent_lemming_path}
-                class="inline-flex min-h-11 items-center gap-2 border border-sky-400/40 bg-sky-400/10 px-4 py-2 text-xs font-medium uppercase tracking-widest text-sky-300 transition duration-150 ease-out hover:-translate-y-px hover:border-sky-300 hover:text-sky-200"
+                class="inline-flex min-h-11 items-center gap-2 border border-sky-400/40 bg-sky-400/10 px-4 py-2 text-xs
+		  font-medium uppercase tracking-widest text-sky-300 transition duration-150 ease-out
+		  hover:-translate-y-px hover:border-sky-300 hover:text-sky-200"
               >
                 <.icon name="hero-arrow-left" class="size-4" />
                 {dgettext("lemmings", "Back to parent lemming")}
@@ -90,11 +92,30 @@
                 :if={instance_raw_path(@instance, @world)}
                 id="instance-raw-context-link"
                 navigate={instance_raw_path(@instance, @world)}
-                class="inline-flex min-h-11 items-center gap-2 border border-zinc-700 bg-zinc-950/70 px-4 py-2 text-xs font-medium uppercase tracking-widest text-zinc-300 transition duration-150 ease-out hover:-translate-y-px hover:border-zinc-500 hover:text-zinc-100"
+                class="inline-flex min-h-11 items-center gap-2 border border-zinc-700 bg-zinc-950/70 px-4 py-2 text-xs
+		  font-medium uppercase tracking-widest text-zinc-300 transition duration-150 ease-out
+		  hover:-translate-y-px hover:border-zinc-500 hover:text-zinc-100"
               >
                 <.icon name="hero-code-bracket-square" class="size-4" />
                 {dgettext("lemmings", "Raw context")}
               </.link>
+
+              <button
+                :if={instance_workspace_path(@instance, @runtime_state)}
+                id="instance-workspace-copy-button"
+                type="button"
+                title={instance_workspace_path(@instance, @runtime_state)}
+                data-workspace-path={instance_workspace_path(@instance, @runtime_state)}
+                onclick="navigator.clipboard.writeText(this.dataset.workspacePath)"
+                phx-click="workspace_path_copied"
+                class="inline-flex min-h-11 items-center gap-2 border border-emerald-400/40
+		  bg-emerald-400/10 px-4 py-2 text-xs font-medium uppercase tracking-widest
+		  text-emerald-300 transition duration-150 ease-out hover:-translate-y-px
+		  hover:border-emerald-300 hover:text-emerald-200"
+              >
+                <.icon name="hero-clipboard-document" class="size-4" />
+                {dgettext("lemmings", "Copy workspace path")}
+              </button>
             </div>
           </div>
 
@@ -111,7 +132,10 @@
                   type="button"
                   phx-click="retry_instance"
                   phx-disable-with={dgettext("lemmings", "Retrying...")}
-                  class="inline-flex min-h-11 items-center justify-center gap-2 border border-red-400/40 bg-red-400/10 px-4 py-2 text-sm font-medium uppercase tracking-widest text-red-300 transition duration-150 ease-out hover:-translate-y-px hover:border-red-300 hover:text-red-200"
+                  class="inline-flex min-h-11 items-center justify-center gap-2 border
+		    border-red-400/40 bg-red-400/10 px-4 py-2 text-sm font-medium uppercase
+		    tracking-widest text-red-300 transition duration-150 ease-out
+		    hover:-translate-y-px hover:border-red-300 hover:text-red-200"
                 >
                   <.icon name="hero-arrow-path" class="size-4" />
                   {dgettext("lemmings", "Retry")}

--- a/test/lemmings_os/lemming_calls_runtime_test.exs
+++ b/test/lemmings_os/lemming_calls_runtime_test.exs
@@ -18,7 +18,7 @@ defmodule LemmingsOs.LemmingCallsRuntimeTest do
   defmodule CapturingRuntime do
     def spawn_session(lemming, request_text, opts) do
       if test_pid = Keyword.get(opts, :test_pid) do
-        send(test_pid, {:spawned_child_request, request_text})
+        send(test_pid, {:spawned_child_request, request_text, opts})
       end
 
       LemmingInstances.spawn_instance(lemming, request_text)
@@ -234,6 +234,7 @@ defmodule LemmingsOs.LemmingCallsRuntimeTest do
     {:ok, %{absolute_path: absolute_path}} =
       LemmingInstances.artifact_absolute_path(manager_instance, "proposal.md")
 
+    File.mkdir_p!(Path.dirname(absolute_path))
     File.write!(absolute_path, "# Existing Proposal\n\nOriginal body.\n")
 
     assert {:ok, _call} =
@@ -244,7 +245,7 @@ defmodule LemmingsOs.LemmingCallsRuntimeTest do
                runtime_opts: [test_pid: self()]
              )
 
-    assert_receive {:spawned_child_request, child_request}
+    assert_receive {:spawned_child_request, child_request, _opts}
     assert child_request =~ "Improve proposal.md for enterprise buyers"
     assert child_request =~ "Delegation Artifact Context:"
     assert child_request =~ "Artifact: proposal.md"
@@ -252,6 +253,21 @@ defmodule LemmingsOs.LemmingCallsRuntimeTest do
 
     assert child_request =~
              "Do not call fs.read_text_file for these paths unless runtime later provides them inside your own workspace."
+  end
+
+  test "S02c: request_call passes runtime opts to spawned child", %{
+    manager_instance: manager_instance
+  } do
+    assert {:ok, _call} =
+             LemmingCalls.request_call(
+               manager_instance,
+               %{target: "ops-worker", request: "Draft shared notes"},
+               runtime_mod: CapturingRuntime,
+               runtime_opts: [test_pid: self(), executor_opts: [work_area_ref: "root-instance-1"]]
+             )
+
+    assert_receive {:spawned_child_request, "Draft shared notes", opts}
+    assert opts[:executor_opts][:work_area_ref] == "root-instance-1"
   end
 
   test "S03: workers cannot request lemming calls", %{worker_instance: worker_instance} do

--- a/test/lemmings_os/lemming_instances/executor/communication_runtime_test.exs
+++ b/test/lemmings_os/lemming_instances/executor/communication_runtime_test.exs
@@ -29,6 +29,13 @@ defmodule LemmingsOs.LemmingInstances.Executor.CommunicationRuntimeTest do
       do: {:ok, %{id: "call-1", request_text: attrs.request}}
   end
 
+  defmodule CapturingRequestCalls do
+    def request_call(instance, attrs, opts) do
+      send(instance.config_snapshot.test_pid, {:request_call_opts, opts})
+      {:ok, %{id: "call-1", request_text: attrs.request}}
+    end
+  end
+
   defmodule RejectingCalls do
     def request_call(_instance, _attrs, _opts), do: {:error, :not_allowed}
   end
@@ -104,6 +111,37 @@ defmodule LemmingsOs.LemmingInstances.Executor.CommunicationRuntimeTest do
              List.last(rejected_state.context_messages).content,
              "Assistant requested lemming_call"
            )
+  end
+
+  test "execute_lemming_call/2 passes parent work_area_ref as hidden runtime opts" do
+    response =
+      LemmingsOs.ModelRuntime.Response.new(
+        action: :lemming_call,
+        lemming_target: "ops-worker",
+        lemming_request: "Draft child notes",
+        continue_call_id: nil,
+        provider: "fake",
+        model: "fake-model",
+        raw: %{}
+      )
+
+    state = %{
+      instance: %{id: "instance-1", config_snapshot: %{}},
+      config_snapshot: %{test_pid: self()},
+      context_messages: [],
+      lemming_calls_mod: CapturingRequestCalls,
+      work_area_ref: "root-instance-1"
+    }
+
+    assert {:ok, _next_state, %{id: "call-1"}} =
+             CommunicationRuntime.execute_lemming_call(state, response)
+
+    assert_receive {:request_call_opts,
+                    [
+                      runtime_opts: [
+                        executor_opts: [work_area_ref: "root-instance-1"]
+                      ]
+                    ]}
   end
 
   test "resume_after_lemming_call/3 resumes processing when state is eligible" do

--- a/test/lemmings_os/lemming_instances/executor_test.exs
+++ b/test/lemmings_os/lemming_instances/executor_test.exs
@@ -570,6 +570,25 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     end
   end
 
+  defmodule MetadataToolRuntime do
+    def execute(_world, _instance, tool_name, _args, runtime_meta) do
+      send(Application.fetch_env!(:lemmings_os, __MODULE__)[:test_pid], {
+        :tool_runtime_meta,
+        tool_name,
+        runtime_meta
+      })
+
+      {:ok,
+       %{
+         tool_name: tool_name,
+         args: %{},
+         summary: "metadata captured",
+         preview: nil,
+         result: %{path: "metadata.txt"}
+       }}
+    end
+  end
+
   defmodule RejectingMessagePersistor do
     def insert(_attrs), do: {:error, :forced_persist_failure}
   end
@@ -632,6 +651,50 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     spec = Executor.child_spec(instance: instance, name: nil)
     assert spec.id == {Executor, instance.id}
     assert spec.start == {Executor, :start_link, [[instance: instance, name: nil]]}
+  end
+
+  test "S01a: root executor derives work_area_ref from instance id and creates WorkArea", %{
+    instance: instance
+  } do
+    work_areas_path = isolated_work_areas_path()
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        context_mod: nil,
+        model_mod: nil,
+        pubsub_mod: nil,
+        dets_mod: nil,
+        ets_mod: nil,
+        name: nil
+      )
+
+    snapshot = Executor.snapshot(pid)
+
+    assert snapshot.work_area_ref == instance.id
+    assert File.dir?(Path.join(work_areas_path, instance.id))
+
+    GenServer.stop(pid)
+  end
+
+  test "S01c: WorkArea creation failure does not fail executor startup", %{instance: instance} do
+    work_areas_path = isolated_work_areas_path()
+    File.write!(work_areas_path, "not a directory")
+
+    assert {:ok, pid} =
+             Executor.start_link(
+               instance: instance,
+               context_mod: nil,
+               model_mod: nil,
+               pubsub_mod: nil,
+               dets_mod: nil,
+               ets_mod: nil,
+               name: nil
+             )
+
+    assert Executor.snapshot(pid).work_area_ref == instance.id
+
+    GenServer.stop(pid)
   end
 
   test "S01b: enqueue_work/2 returns executor_unavailable when the target process is gone" do
@@ -1702,6 +1765,57 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     GenServer.stop(pid)
   end
 
+  test "S07a: executor sends hidden WorkArea metadata to tool runtime", %{instance: instance} do
+    resource_key = "ollama:tool-loop-model"
+    work_area_ref = Ecto.UUID.generate()
+    previous_env = Application.get_env(:lemmings_os, MetadataToolRuntime)
+    Application.put_env(:lemmings_os, MetadataToolRuntime, test_pid: self())
+
+    on_exit(fn ->
+      if previous_env do
+        Application.put_env(:lemmings_os, MetadataToolRuntime, previous_env)
+      else
+        Application.delete_env(:lemmings_os, MetadataToolRuntime)
+      end
+    end)
+
+    {:ok, pid} =
+      Executor.start_link(
+        instance: instance,
+        work_area_ref: work_area_ref,
+        config_snapshot: %{
+          model: "tool-loop-model",
+          observer_pid: self(),
+          models_config: %{profiles: %{default: %{provider: "ollama", model: "tool-loop-model"}}}
+        },
+        context_mod: LemmingInstances,
+        model_mod: ToolLoopModelRuntime,
+        tool_runtime_mod: MetadataToolRuntime,
+        pool_mod: ResourcePool,
+        pubsub_mod: Phoenix.PubSub,
+        dets_mod: nil,
+        ets_mod: LemmingsOs.LemmingInstances.EtsStore,
+        name: nil
+      )
+
+    {:ok, _pool_pid} =
+      start_supervised({ResourcePool, resource_key: resource_key, gate: :open, pubsub_mod: nil})
+
+    assert :ok = ResourcePool.checkout(resource_key, holder: pid)
+    assert :ok = Executor.enqueue_work(pid, "Use a tool")
+
+    send(pid, {:scheduler_admit, %{instance_id: instance.id, resource_key: resource_key}})
+
+    assert_receive {:tool_runtime_meta, "web.fetch", runtime_meta}
+    assert runtime_meta.actor_instance_id == instance.id
+    assert runtime_meta.work_area_ref == work_area_ref
+    assert runtime_meta.world_id == instance.world_id
+    assert runtime_meta.city_id == instance.city_id
+    assert runtime_meta.department_id == instance.department_id
+
+    GenServer.stop(pid)
+  end
+
   test "S08: tool_call loop executes tool runtime and continues until final reply", %{
     instance: instance
   } do
@@ -2535,5 +2649,29 @@ defmodule LemmingsOs.LemmingInstances.ExecutorTest do
     after
       Logger.configure(level: previous_level)
     end
+  end
+
+  defp isolated_work_areas_path do
+    old_work_areas_path = Application.get_env(:lemmings_os, :work_areas_path)
+
+    work_areas_path =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_executor_work_area_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :work_areas_path, work_areas_path)
+
+    on_exit(fn ->
+      if old_work_areas_path do
+        Application.put_env(:lemmings_os, :work_areas_path, old_work_areas_path)
+      else
+        Application.delete_env(:lemmings_os, :work_areas_path)
+      end
+
+      File.rm_rf(work_areas_path)
+    end)
+
+    work_areas_path
   end
 end

--- a/test/lemmings_os/lemming_instances_test.exs
+++ b/test/lemmings_os/lemming_instances_test.exs
@@ -165,7 +165,7 @@ defmodule LemmingsOs.LemmingInstancesTest do
     refute Map.has_key?(instance.config_snapshot, "__meta__")
   end
 
-  test "S03b: spawn_instance creates the lemming work area under the runtime workspace root" do
+  test "S03b: spawn_instance does not create the runtime WorkArea before an executor starts" do
     world = insert(:world, name: "Ops World", slug: "ops-world")
     city = insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")
     department = insert(:department, world: world, city: city, name: "Support", slug: "support")
@@ -188,10 +188,10 @@ defmodule LemmingsOs.LemmingInstancesTest do
 
     work_area_root =
       :lemmings_os
-      |> Application.fetch_env!(:runtime_workspace_root)
+      |> Application.fetch_env!(:work_areas_path)
       |> Path.expand()
 
-    assert File.dir?(Path.join(work_area_root, Path.join([department.id, lemming.id])))
+    refute File.dir?(Path.join(work_area_root, instance.id))
   end
 
   test "S04: get_runtime_state/1 normalizes persisted runtime state from DETS" do
@@ -225,6 +225,7 @@ defmodule LemmingsOs.LemmingInstancesTest do
              LemmingInstances.get_runtime_state(instance.id, world_id: instance.world_id)
 
     assert runtime_state == %{
+             work_area_ref: nil,
              retry_count: 1,
              max_retries: 3,
              queue_depth: 1,

--- a/test/lemmings_os/runtime_test.exs
+++ b/test/lemmings_os/runtime_test.exs
@@ -62,10 +62,10 @@ defmodule LemmingsOs.RuntimeTest do
 
     work_area_root =
       :lemmings_os
-      |> Application.fetch_env!(:runtime_workspace_root)
+      |> Application.fetch_env!(:work_areas_path)
       |> Path.expand()
 
-    assert File.dir?(Path.join(work_area_root, Path.join([department.id, lemming.id])))
+    assert File.dir?(Path.join(work_area_root, instance.id))
 
     assert eventually_status(instance.id) == "queued"
 

--- a/test/lemmings_os/tools/adapters/filesystem_test.exs
+++ b/test/lemmings_os/tools/adapters/filesystem_test.exs
@@ -3,18 +3,18 @@ defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
 
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.Tools.Adapters.Filesystem
+  alias LemmingsOs.Tools.WorkArea
 
   setup do
-    old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+    old_work_areas_path = Application.get_env(:lemmings_os, :work_areas_path)
 
-    workspace_root =
+    work_areas_path =
       Path.join(
         System.tmp_dir!(),
         "lemmings_tools_filesystem_test_#{System.unique_integer([:positive])}"
       )
 
-    Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
-    File.mkdir_p!(workspace_root)
+    Application.put_env(:lemmings_os, :work_areas_path, work_areas_path)
 
     instance = %LemmingInstance{
       id: Ecto.UUID.generate(),
@@ -23,143 +23,183 @@ defmodule LemmingsOs.Tools.Adapters.FilesystemTest do
       lemming_id: Ecto.UUID.generate()
     }
 
-    work_area = Path.join([workspace_root, instance.department_id, instance.lemming_id])
-    File.mkdir_p!(work_area)
+    work_area_ref = Ecto.UUID.generate()
+    :ok = WorkArea.ensure(work_area_ref)
+    work_area = WorkArea.root_path(work_area_ref)
+    runtime_meta = %{actor_instance_id: instance.id, work_area_ref: work_area_ref}
 
     on_exit(fn ->
-      if old_workspace_root do
-        Application.put_env(:lemmings_os, :runtime_workspace_root, old_workspace_root)
+      if old_work_areas_path do
+        Application.put_env(:lemmings_os, :work_areas_path, old_work_areas_path)
       else
-        Application.delete_env(:lemmings_os, :runtime_workspace_root)
+        Application.delete_env(:lemmings_os, :work_areas_path)
       end
 
-      File.rm_rf(workspace_root)
+      File.rm_rf(work_areas_path)
     end)
 
-    {:ok, instance: instance, work_area: work_area}
+    {:ok, instance: instance, runtime_meta: runtime_meta, work_area: work_area}
   end
 
-  test "S01: write_text_file writes content inside work area with normalized result", %{
-    instance: instance
+  test "S01: write_text_file writes content inside shared WorkArea", %{
+    instance: instance,
+    runtime_meta: runtime_meta,
+    work_area: work_area
   } do
     assert {:ok, result} =
-             Filesystem.write_text_file(instance, %{
-               "path" => "reports/out.txt",
-               "content" => "hello filesystem"
-             })
+             Filesystem.write_text_file(
+               instance,
+               %{"path" => "reports/out.txt", "content" => "hello filesystem"},
+               runtime_meta
+             )
 
     assert result.summary == "Wrote file reports/out.txt"
     assert result.result.path == "reports/out.txt"
-
-    assert result.result.root_path ==
-             "/workspace/#{instance.department_id}/#{instance.lemming_id}"
-
-    assert result.result.workspace_path ==
-             "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/out.txt"
-
     assert result.result.bytes == byte_size("hello filesystem")
     assert result.preview == "hello filesystem"
+    refute Map.has_key?(result.result, :root_path)
+    refute Map.has_key?(result.result, :workspace_path)
+    assert File.read!(Path.join(work_area, "reports/out.txt")) == "hello filesystem"
   end
 
-  test "S02: read_text_file returns normalized content from work area", %{instance: instance} do
+  test "S02: read_text_file returns normalized content from shared WorkArea", %{
+    instance: instance,
+    runtime_meta: runtime_meta
+  } do
     assert {:ok, _write_result} =
-             Filesystem.write_text_file(instance, %{"path" => "notes.txt", "content" => "hello"})
+             Filesystem.write_text_file(
+               instance,
+               %{"path" => "notes.txt", "content" => "hello"},
+               runtime_meta
+             )
 
-    assert {:ok, result} = Filesystem.read_text_file(instance, %{"path" => "notes.txt"})
+    assert {:ok, result} =
+             Filesystem.read_text_file(instance, %{"path" => "notes.txt"}, runtime_meta)
+
     assert result.summary == "Read file notes.txt"
     assert result.result.path == "notes.txt"
-
-    assert result.result.root_path ==
-             "/workspace/#{instance.department_id}/#{instance.lemming_id}"
-
-    assert result.result.workspace_path ==
-             "/workspace/#{instance.department_id}/#{instance.lemming_id}/notes.txt"
-
     assert result.result.content == "hello"
     assert result.result.bytes == 5
     assert result.preview == "hello"
   end
 
-  test "S03: read_text_file validates required args", %{instance: instance} do
-    assert {:error, %{code: "tool.validation.invalid_args", details: %{required: ["path"]}}} =
-             Filesystem.read_text_file(instance, %{})
-  end
-
-  test "S04: write_text_file rejects absolute paths", %{instance: instance} do
-    assert {:error, %{code: "tool.fs.path_must_be_relative"}} =
-             Filesystem.write_text_file(instance, %{
-               "path" => "/etc/passwd",
-               "content" => "blocked"
-             })
-  end
-
-  test "S05: write_text_file rejects traversal outside workspace", %{
+  test "S03: multiple instances can use the same WorkArea", %{
     instance: instance,
-    work_area: work_area
+    runtime_meta: runtime_meta
   } do
-    escaped_path = Path.expand("../outside.txt", work_area)
+    child_instance = %{instance | id: Ecto.UUID.generate()}
+    child_meta = %{runtime_meta | actor_instance_id: child_instance.id}
 
-    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
-             Filesystem.write_text_file(instance, %{
-               "path" => "../outside.txt",
-               "content" => "blocked"
-             })
+    assert {:ok, _write_result} =
+             Filesystem.write_text_file(
+               instance,
+               %{"path" => "scratch/shared.txt", "content" => "shared"},
+               runtime_meta
+             )
 
-    refute File.exists?(escaped_path)
+    assert {:ok, result} =
+             Filesystem.read_text_file(
+               child_instance,
+               %{"path" => "scratch/shared.txt"},
+               child_meta
+             )
+
+    assert result.result.content == "shared"
   end
 
-  test "S06: read_text_file returns not_found error for missing file", %{instance: instance} do
+  test "S04: read_text_file validates required args", %{
+    instance: instance,
+    runtime_meta: runtime_meta
+  } do
+    assert {:error, %{code: "tool.validation.invalid_args", details: %{required: ["path"]}}} =
+             Filesystem.read_text_file(instance, %{}, runtime_meta)
+  end
+
+  test "S05: filesystem adapters reject unsafe paths", %{
+    instance: instance,
+    runtime_meta: runtime_meta
+  } do
+    for path <- [
+          "../secret",
+          "scratch/../../secret",
+          "/tmp/file",
+          "C:\\tmp\\file",
+          "scratch\\file",
+          "~/file"
+        ] do
+      assert {:error, %{code: "tool.validation.invalid_path"}} =
+               Filesystem.write_text_file(
+                 instance,
+                 %{"path" => path, "content" => "blocked"},
+                 runtime_meta
+               )
+    end
+  end
+
+  test "S06: read_text_file returns not_found error for missing file", %{
+    instance: instance,
+    runtime_meta: runtime_meta
+  } do
     assert {:error, %{code: "tool.fs.not_found", details: %{path: "missing.txt"}}} =
-             Filesystem.read_text_file(instance, %{"path" => "missing.txt"})
+             Filesystem.read_text_file(instance, %{"path" => "missing.txt"}, runtime_meta)
   end
 
-  test "S07: filesystem adapters reject incomplete instance scope" do
-    assert {:error, %{code: "tool.fs.invalid_instance_scope"}} =
-             Filesystem.read_text_file(%LemmingInstance{}, %{"path" => "notes.txt"})
+  test "S07: file tool returns structured error when WorkArea is unavailable", %{
+    instance: instance
+  } do
+    assert {:error, %{code: "tool.fs.work_area_unavailable"}} =
+             Filesystem.read_text_file(instance, %{"path" => "notes.txt"}, %{
+               work_area_ref: Ecto.UUID.generate()
+             })
   end
 
   test "S08: read_text_file rejects symlink targets outside workspace", %{
     instance: instance,
+    runtime_meta: runtime_meta,
     work_area: work_area
   } do
     outside_path = Path.join(Path.dirname(work_area), "outside-secret.txt")
     File.write!(outside_path, "do not read")
     assert :ok = File.ln_s(outside_path, Path.join(work_area, "secret-link.txt"))
 
-    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
-             Filesystem.read_text_file(instance, %{"path" => "secret-link.txt"})
+    assert {:error, %{code: "tool.validation.invalid_path"}} =
+             Filesystem.read_text_file(instance, %{"path" => "secret-link.txt"}, runtime_meta)
   end
 
   test "S09: write_text_file rejects existing symlink file targets outside workspace", %{
     instance: instance,
+    runtime_meta: runtime_meta,
     work_area: work_area
   } do
     outside_path = Path.join(Path.dirname(work_area), "outside-write.txt")
     File.write!(outside_path, "unchanged")
     assert :ok = File.ln_s(outside_path, Path.join(work_area, "write-link.txt"))
 
-    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
-             Filesystem.write_text_file(instance, %{
-               "path" => "write-link.txt",
-               "content" => "mutated"
-             })
+    assert {:error, %{code: "tool.validation.invalid_path"}} =
+             Filesystem.write_text_file(
+               instance,
+               %{"path" => "write-link.txt", "content" => "mutated"},
+               runtime_meta
+             )
 
     assert File.read!(outside_path) == "unchanged"
   end
 
   test "S10: write_text_file rejects symlink parent directories outside workspace", %{
     instance: instance,
+    runtime_meta: runtime_meta,
     work_area: work_area
   } do
     outside_dir = Path.join(Path.dirname(work_area), "outside-dir")
     File.mkdir_p!(outside_dir)
     assert :ok = File.ln_s(outside_dir, Path.join(work_area, "linked-dir"))
 
-    assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
-             Filesystem.write_text_file(instance, %{
-               "path" => "linked-dir/output.txt",
-               "content" => "escaped"
-             })
+    assert {:error, %{code: "tool.validation.invalid_path"}} =
+             Filesystem.write_text_file(
+               instance,
+               %{"path" => "linked-dir/output.txt", "content" => "escaped"},
+               runtime_meta
+             )
 
     refute File.exists?(Path.join(outside_dir, "output.txt"))
   end

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -6,29 +6,29 @@ defmodule LemmingsOs.Tools.RuntimeTest do
   alias LemmingsOs.Worlds.World
 
   setup do
-    old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+    old_work_areas_path = Application.get_env(:lemmings_os, :work_areas_path)
     old_allow_private_hosts = Application.fetch_env(:lemmings_os, :tools_web_allow_private_hosts)
 
-    workspace_root =
+    work_areas_path =
       Path.join(
         System.tmp_dir!(),
         "lemmings_tools_runtime_test_#{System.unique_integer([:positive])}"
       )
 
-    Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
+    Application.put_env(:lemmings_os, :work_areas_path, work_areas_path)
     Application.put_env(:lemmings_os, :tools_web_allow_private_hosts, true)
-    File.mkdir_p!(workspace_root)
+    File.mkdir_p!(work_areas_path)
 
     on_exit(fn ->
-      if old_workspace_root do
-        Application.put_env(:lemmings_os, :runtime_workspace_root, old_workspace_root)
+      if old_work_areas_path do
+        Application.put_env(:lemmings_os, :work_areas_path, old_work_areas_path)
       else
-        Application.delete_env(:lemmings_os, :runtime_workspace_root)
+        Application.delete_env(:lemmings_os, :work_areas_path)
       end
 
       restore_env(:tools_web_allow_private_hosts, old_allow_private_hosts)
 
-      File.rm_rf(workspace_root)
+      File.rm_rf(work_areas_path)
     end)
 
     world = %World{id: Ecto.UUID.generate()}
@@ -40,7 +40,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
       lemming_id: Ecto.UUID.generate()
     }
 
-    File.mkdir_p!(Path.join([workspace_root, instance.department_id, instance.lemming_id]))
+    File.mkdir_p!(Path.join(work_areas_path, instance.id))
 
     {:ok, world: world, instance: instance}
   end
@@ -60,8 +60,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
       assert write_result.summary == "Wrote file reports/result.md"
       assert write_result.result.path == "reports/result.md"
 
-      assert write_result.result.workspace_path ==
-               "/workspace/#{instance.department_id}/#{instance.lemming_id}/reports/result.md"
+      refute Map.has_key?(write_result.result, :workspace_path)
 
       assert {:ok, read_result} =
                Runtime.execute(world, instance, "fs.read_text_file", %{
@@ -75,13 +74,13 @@ defmodule LemmingsOs.Tools.RuntimeTest do
     end
 
     test "rejects absolute and escaping paths", %{world: world, instance: instance} do
-      assert {:error, %{code: "tool.fs.path_must_be_relative"}} =
+      assert {:error, %{code: "tool.validation.invalid_path"}} =
                Runtime.execute(world, instance, "fs.write_text_file", %{
                  "path" => "/etc/passwd",
                  "content" => "nope"
                })
 
-      assert {:error, %{code: "tool.fs.path_outside_workspace"}} =
+      assert {:error, %{code: "tool.validation.invalid_path"}} =
                Runtime.execute(world, instance, "fs.read_text_file", %{"path" => "../secret.txt"})
     end
   end

--- a/test/lemmings_os/tools/work_area_test.exs
+++ b/test/lemmings_os/tools/work_area_test.exs
@@ -1,0 +1,70 @@
+defmodule LemmingsOs.Tools.WorkAreaTest do
+  use ExUnit.Case, async: false
+
+  alias LemmingsOs.Tools.WorkArea
+
+  doctest WorkArea
+
+  setup do
+    old_work_areas_path = Application.get_env(:lemmings_os, :work_areas_path)
+
+    work_areas_path =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_work_area_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :work_areas_path, work_areas_path)
+
+    on_exit(fn ->
+      if old_work_areas_path do
+        Application.put_env(:lemmings_os, :work_areas_path, old_work_areas_path)
+      else
+        Application.delete_env(:lemmings_os, :work_areas_path)
+      end
+
+      File.rm_rf(work_areas_path)
+    end)
+
+    {:ok, work_areas_path: work_areas_path, work_area_ref: Ecto.UUID.generate()}
+  end
+
+  test "ensure/1 creates the WorkArea root and default subfolders", %{
+    work_area_ref: work_area_ref
+  } do
+    assert :ok = WorkArea.ensure(work_area_ref)
+
+    root = WorkArea.root_path(work_area_ref)
+    assert File.dir?(root)
+  end
+
+  test "resolve/2 returns an absolute path inside the WorkArea", %{work_area_ref: work_area_ref} do
+    assert :ok = WorkArea.ensure(work_area_ref)
+
+    assert {:ok, resolved} = WorkArea.resolve(work_area_ref, "scratch/notes.txt")
+    assert resolved.relative_path == "scratch/notes.txt"
+    assert resolved.root_path == WorkArea.root_path(work_area_ref)
+    assert String.starts_with?(resolved.absolute_path, resolved.root_path <> "/")
+  end
+
+  test "resolve/2 rejects unsafe paths", %{work_area_ref: work_area_ref} do
+    assert :ok = WorkArea.ensure(work_area_ref)
+
+    for path <- [
+          "../secret",
+          "scratch/../../secret",
+          "/tmp/file",
+          "C:\\tmp\\file",
+          "scratch\\file",
+          "~/file"
+        ] do
+      assert {:error, :invalid_path} = WorkArea.resolve(work_area_ref, path)
+    end
+  end
+
+  test "resolve/2 returns work_area_unavailable when the root is missing", %{
+    work_area_ref: work_area_ref
+  } do
+    assert {:error, :work_area_unavailable} = WorkArea.resolve(work_area_ref, "scratch/notes.txt")
+  end
+end

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -740,18 +740,39 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
     assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
   end
 
-  test "S08h: html and svg artifacts download without inline rendering", %{conn: conn} do
+  test "S08j: workspace action copies the workspace path", %{conn: conn} do
     %{world: world, instance: instance} = spawn_runtime_session()
 
-    assert_artifact_download_headers(
-      conn,
-      world,
-      instance,
-      "report.html",
-      "<script>alert(1)</script>"
-    )
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
 
-    assert_artifact_download_headers(conn, world, instance, "diagram.svg", "<svg></svg>")
+    html =
+      view
+      |> element("#instance-workspace-copy-button")
+      |> render()
+
+    assert html =~ ~s(type="button")
+    assert html =~ ~s(data-workspace-path=)
+    assert html =~ "Copy workspace path"
+    assert html =~ "navigator.clipboard.writeText(this.dataset.workspacePath)"
+
+    refute html =~ ~s(target="_blank")
+    refute html =~ ~s(href=)
+    refute html =~ "Open workspace"
+  end
+
+  test "S08k: clicking copy workspace path shows a copied flash", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    html =
+      view
+      |> element("#instance-workspace-copy-button")
+      |> render_click()
+
+    assert html =~ "Workspace path copied."
   end
 
   test "S08g: artifact download rejects symlink targets outside workspace", %{conn: conn} do
@@ -1685,27 +1706,5 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
       {position, _length} -> position
       :nomatch -> nil
     end
-  end
-
-  defp assert_artifact_download_headers(conn, world, instance, path, content) do
-    {:ok, %{absolute_path: absolute_path}} =
-      LemmingInstances.artifact_absolute_path(instance, path)
-
-    File.mkdir_p!(Path.dirname(absolute_path))
-    File.write!(absolute_path, content)
-
-    response =
-      conn
-      |> get(~p"/lemmings/instances/#{instance.id}/artifacts/#{[path]}?#{%{world: world.id}}")
-
-    assert response.status == 200
-    assert response.resp_body == content
-    assert get_resp_header(response, "content-type") == ["application/octet-stream"]
-
-    assert get_resp_header(response, "content-disposition") == [
-             ~s(attachment; filename="#{path}")
-           ]
-
-    assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
   end
 end


### PR DESCRIPTION
## Summary

Adds shared WorkArea support for multi-lemming calls.

Previously, filesystem tools resolved paths from the callee instance scope, so a child Lemming could not reliably read or update files created by the root instance or a sibling child. This PR changes the runtime so a root Executor derives a shared `work_area_ref`, child Executors inherit it through delegation, and filesystem tools resolve relative paths against that shared WorkArea.

This keeps each LemmingInstance independent for execution, status, messages, and trace, while allowing delegated workers to collaborate over the same task files.

## Scope

- [ ] Bug fix
- [x] Feature
- [x] Refactor
- [ ] Docs
- [x] Chore

## Linked Issues

Closes #21

## Technical Notes

- Key implementation details:
  - Adds `LemmingsOs.Tools.WorkArea` as the runtime-only path resolver and WorkArea directory helper.
  - Root Executors derive `work_area_ref` from their own instance id.
  - Delegated child Executors inherit the parent `work_area_ref` through runtime options.
  - `Tools.Runtime.execute/5` now supports hidden runtime metadata while preserving the existing `execute/4` API.
  - Filesystem tools now resolve `fs.read_text_file` and `fs.write_text_file` through `work_area_ref` instead of per-callee instance identity.
  - Tool lifecycle telemetry/events include `work_area_ref` and relative path metadata where available.
  - Instance LiveView exposes a copyable WorkArea path for operator convenience.

- Data model / migration impact:
  - No database migration.
  - No `work_areas` table.
  - No `work_area_id`, `parent_instance_id`, or `root_instance_id` column added.
  - WorkArea identity is a derived runtime concept for this MVP.

- Config/env var changes:
  - Adds `:work_areas_path` application config.
  - Uses `LEMMINGS_WORK_AREAS_PATH` for runtime WorkArea root configuration.
  - Keeps the path configurable so Docker/self-hosted deployments can mount external writable storage later.

- Security/privacy considerations:
  - LLM-visible tool arguments remain relative-path only.
  - Host absolute paths and `work_area_ref` are not exposed to the model.
  - Filesystem tool results no longer expose workspace/root absolute paths.
  - WorkArea path resolution rejects unsafe relative paths such as traversal attempts, absolute paths, Windows-style paths, backslashes, and `~`.
  - Final path resolution remains bounded inside the configured WorkArea root.
  - WorkArea creation is best-effort; Executor startup does not fail if the directory cannot be created. File tools return structured errors when invoked and the WorkArea is unavailable.

## Validation

- [ ] `mix format`
- [ ] `mix test`
- [ ] `mix precommit`
- [ ] Manual validation completed

### Manual validation notes

Recommended validation:

1. Start a root LemmingInstance.
2. Confirm the Executor snapshot/runtime state includes `work_area_ref`.
3. Trigger a delegated child Lemming call.
4. Confirm the child Executor inherits the same `work_area_ref`.
5. Use one Lemming to write a file through `fs.write_text_file`.
6. Use another delegated Lemming to read/update the same relative file path through `fs.read_text_file` / `fs.write_text_file`.
7. Confirm invalid paths are rejected:
   - `../secret`
   - `scratch/../../secret`
   - `/tmp/file`
   - `C:\tmp\file`
   - `scratch\file`
   - `~/file`
8. Confirm startup continues if WorkArea directory creation fails, and only file tools fail when they need the unavailable WorkArea.

## Screenshots / Recordings (if UI changes)

 
<img width="919" height="278" alt="image" src="https://github.com/user-attachments/assets/a9a08f61-db65-4dc8-ad68-be7fd89401a5" />


## Rollout / Rollback

- Rollout notes:
  - Configure `LEMMINGS_WORK_AREAS_PATH` in deployments that need WorkArea files outside the release/app directory.
  - Existing filesystem tool schemas remain compatible.
  - No database migration is required.

- Rollback notes:
  - Revert this PR to return filesystem path resolution to the previous per-instance workspace behavior.
  - Any files created under the new WorkArea root are runtime artifacts and are not tied to database state.

## Checklist

- [x] Tests added/updated for changed behavior
- [ ] Docs updated (README/docs/ADR/runbook) when needed
- [x] No secrets or sensitive data committed
- [x] Backward compatibility considered