### PR TITLE
Add Artifact domain model with manual workspace file promotion

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,5 +7,6 @@ export PORT="${PORT:-${MIX_PORT}}"
 export OLLAMA_BASE_URL=http://localhost:11434
 
 export LEMMINGS_WORK_AREAS_PATH="~/.lemmings/workspace"
+export LEMMINGS_ARTIFACT_STORAGE_PATH="~/.lemmings/storage"
 
 [ -f .envrc.custom ] && source .envrc.custom

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ _build
 /erl_crash.dump
 /.codex
 /nvim.log
+/priv/runtime/storage/

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ See [docs/architecture.md](docs/architecture.md) for details.
 
 Feature documentation:
 
+- [Artifacts](docs/features/artifacts.md) — promoted durable file references,
+  managed local storage, lifecycle/state model, and safe download/promotion flows.
 - [Secret Bank](docs/features/secret_bank.md) — encrypted local runtime secrets,
   hierarchy resolution, env fallback, write-only operator flows, and safe audit
   events.

--- a/config/config.exs
+++ b/config/config.exs
@@ -15,6 +15,10 @@ config :lemmings_os, :runtime_city_heartbeat,
   interval_ms: 30_000,
   freshness_threshold_seconds: 90
 
+config :lemmings_os, :artifact_storage,
+  backend: :local,
+  root_path: Path.expand("../storage/artifacts", __DIR__)
+
 config :lemmings_os, :runtime_dets, directory: Path.expand("../priv/runtime/dets", __DIR__)
 config :lemmings_os, :runtime_engine_on_startup, true
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,7 @@ config :lemmings_os, :runtime_city_heartbeat,
 
 config :lemmings_os, :artifact_storage,
   backend: :local,
-  root_path: Path.expand("../storage/artifacts", __DIR__)
+  root_path: Path.expand("../priv/runtime/storage", __DIR__)
 
 config :lemmings_os, :runtime_dets, directory: Path.expand("../priv/runtime/dets", __DIR__)
 config :lemmings_os, :runtime_engine_on_startup, true

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -20,7 +20,7 @@ artifact_storage = Application.get_env(:lemmings_os, :artifact_storage, [])
 
 artifact_storage_root_path =
   System.get_env("LEMMINGS_ARTIFACT_STORAGE_PATH") ||
-    Keyword.get(artifact_storage, :root_path, Path.expand("../storage/artifacts", __DIR__))
+    Keyword.get(artifact_storage, :root_path, Path.expand("../priv/runtime/storage", __DIR__))
 
 runtime_city_node_name = System.get_env("LEMMINGS_CITY_NODE_NAME") || Atom.to_string(node())
 runtime_city_heartbeat = Application.get_env(:lemmings_os, :runtime_city_heartbeat, [])

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -16,10 +16,17 @@ work_areas_path =
       Path.expand("../priv/runtime/workspace", __DIR__)
     )
 
+artifact_storage = Application.get_env(:lemmings_os, :artifact_storage, [])
+
+artifact_storage_root_path =
+  System.get_env("LEMMINGS_ARTIFACT_STORAGE_PATH") ||
+    Keyword.get(artifact_storage, :root_path, Path.expand("../storage/artifacts", __DIR__))
+
 runtime_city_node_name = System.get_env("LEMMINGS_CITY_NODE_NAME") || Atom.to_string(node())
 runtime_city_heartbeat = Application.get_env(:lemmings_os, :runtime_city_heartbeat, [])
 
 config :lemmings_os, :work_areas_path, work_areas_path
+config :lemmings_os, :artifact_storage, backend: :local, root_path: artifact_storage_root_path
 
 config :lemmings_os, :runtime_city,
   node_name: runtime_city_node_name,

--- a/config/test.exs
+++ b/config/test.exs
@@ -31,6 +31,10 @@ config :lemmings_os, :runtime_dets, directory: Path.expand("../tmp/runtime/dets"
 config :lemmings_os, :runtime_workspace_root, Path.expand("../tmp/runtime/workspace", __DIR__)
 config :lemmings_os, :work_areas_path, Path.expand("../tmp/runtime/work_areas", __DIR__)
 
+config :lemmings_os, :artifact_storage,
+  backend: :local,
+  root_path: Path.expand("../tmp/runtime/storage", __DIR__)
+
 config :lemmings_os, :model_runtime,
   provider_module: LemmingsOs.ModelRuntime.Providers.Ollama,
   default_model: "llama3.2",

--- a/docs/adr/0008-lemming-persistence-model.md
+++ b/docs/adr/0008-lemming-persistence-model.md
@@ -153,6 +153,23 @@ Durable state includes:
 - case status
 - metadata required to resume the conversation
 
+## 5.1 Artifact persistence boundary (implemented)
+
+The Artifact domain model uses a split persistence contract:
+
+- Postgres stores Artifact metadata rows (scope, provenance, lifecycle fields,
+  `storage_ref`, checksum, size, and related metadata).
+- Artifact file bytes are stored outside Postgres in managed local file storage
+  addressed by opaque `local://artifacts/...` references.
+
+Artifact bytes must never be embedded into:
+
+- Postgres transcript/context rows
+- ETS runtime state
+- DETS idle snapshots
+- logs or telemetry payloads
+- automatic LLM context assembly
+
 Durable state **must respect the effective token budget** derived from:
 
 - model context window
@@ -171,7 +188,7 @@ Postgres **must never store**:
 - raw runtime secret values in transcripts, snapshots, tool results, prompts, or
   context
 
-## 5.1 Secret Bank Encrypted Storage Note
+## 5.2 Secret Bank Encrypted Storage Note
 
 The "Postgres must never store secrets" rule above applies to conversational
 state, runtime snapshots, prompts, tool results, and Lemming context.

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -1,11 +1,150 @@
 # Artifacts
 
+## Purpose
+
+Artifacts are durable references to promoted runtime output files.
+
+- `File`: bytes in a runtime workspace.
+- `Artifact`: a promoted file with durable metadata, scope ownership, lifecycle status, and provenance.
+
+A workspace file does not become an Artifact automatically.
+
+## Implemented creation model
+
+Current implementation supports manual promotion only.
+
+- Promotion entry point: instance timeline UI for eligible `fs.write_text_file` tool executions.
+- Backend API: `LemmingsOs.Artifacts.promote_workspace_file/2`.
+- Automatic promotion by model/tool behavior: not implemented.
+
+## Scope and provenance model
+
+Artifact rows are persisted in the `artifacts` table with explicit world hierarchy scope.
+
+Required durable scope/data fields:
+- `world_id`
+- `filename`
+- `type`
+- `content_type`
+- `storage_ref`
+- `size_bytes`
+- `checksum`
+- `status`
+- `metadata`
+
+Optional scope/provenance fields:
+- `city_id`
+- `department_id`
+- `lemming_id`
+- `lemming_instance_id`
+- `created_by_tool_execution_id`
+- `notes`
+
+Allowed values:
+- `type`: `markdown | pdf | json | csv | email | html | image | text | other`
+- `status`: `ready | archived | deleted | error`
+
+Provenance deletion behavior:
+- deleting a creator instance nilifies `lemming_instance_id`
+- deleting a creator tool execution nilifies `created_by_tool_execution_id`
+- Artifact rows survive those deletes
+
+## Storage model
+
+Artifact bytes are stored in managed local filesystem storage.
+
+- Config key: `:lemmings_os, :artifact_storage`
+- Backend: `:local` only
+- Runtime env override: `LEMMINGS_ARTIFACT_STORAGE_PATH`
+- Default root path: `priv/runtime/storage`
+- Physical layout: `<artifact_storage_root>/<world_id>/<artifact_id>/<filename>`
+- Durable reference format: `local://artifacts/<world_id>/<artifact_id>/<filename>`
+
+Promotion copies the source workspace file into managed storage (source file is not moved).
+
+## Collision and update behavior
+
+Same-scope filename collisions are explicit.
+
+- No existing same-scope filename: create a new `ready` Artifact row.
+- Existing same-scope filename + no mode: returns `:mode_required`.
+- `mode: :update_existing`: overwrite managed file and keep same Artifact row id.
+- `mode: :promote_as_new`: create a second Artifact row for the same filename.
+
+UI behavior mirrors this:
+- `Promote to Artifact` shown when no promoted match exists.
+- `Update Artifact` + `Promote as New Artifact` shown when a same-filename Artifact exists and workspace file fingerprint changed.
+
+## Timeline rendering behavior
+
+Instance timeline renders promoted Artifact references with safe summary fields.
+
+Rendered summary fields:
+- `filename`
+- `status`
+- `type`
+- `size_bytes` label
+- created timestamp label
+
+Notes rendering:
+- notes are shown behind a `<details>` disclosure
+- notes are not included in the compact summary line
+
+The rendered reference intentionally omits `storage_ref`, managed path, and raw file content.
+
+## Download and open behavior
+
+Two routes exist:
+
+1. Durable Artifact download route:
+- `GET /lemmings/instances/:instance_id/artifacts/:artifact_id/download`
+- world + instance + artifact scope is validated before storage ref resolution
+- only `ready` Artifacts are downloadable by default
+- response includes safe headers:
+  - `x-content-type-options: nosniff`
+  - `content-disposition: attachment; filename="..."`
+
+2. Workspace compatibility route (legacy path-based open/download):
+- `GET /lemmings/instances/:instance_id/artifacts/*path`
+- serves workspace file bytes when path resolves safely inside workspace
+
+Failure behavior on both routes is a safe `404` without leaking storage refs or filesystem paths.
+
+## Security and privacy boundaries
+
+Artifact file contents are not persisted in:
+- Postgres rows
+- ETS runtime state
+- DETS snapshots
+- logs
+- LLM context (automatic injection)
+
+Additional safeguards:
+- public Artifact descriptors omit `storage_ref` and filesystem paths
+- storage ref parsing/resolution rejects traversal and symlink escape patterns
+- malformed or out-of-scope download attempts return safe not-found responses
+
 ## Observability scope
 
-- Artifact lifecycle operations do not write durable audit rows to the `events` table.
-- Artifact code does not rely on `LemmingsOs.Events` for lifecycle audit semantics.
-- Any Artifact observability in this slice is limited to lightweight logging/telemetry only, with allowlisted safe fields.
+In this implementation slice:
+
+- Artifact lifecycle operations do not write durable audit/event rows to `events`
+- Artifact code does not rely on `LemmingsOs.Events` for lifecycle audit semantics
+- observability is limited to lightweight non-durable logging/telemetry
+
+## Out of scope
+
+Not implemented:
+- S3/MinIO/external Artifact storage backends
+- automatic model/tool promotion
+- Artifact version graph/workflows
+- durable Artifact read/download audit taxonomy
+- Artifact content ingestion/RAG workflows
 
 ## Future work
 
-Platform audit/event model should be designed separately. That future design should define durable vs transient events, actor attribution, retention, immutability, event taxonomy, read/download audit, filtering/export, and whether the current `events` table is the audit log or a domain activity log.
+Platform audit/event design should separately define:
+- durable vs transient event boundaries
+- actor attribution and immutability requirements
+- read/download audit policy
+- retention/filter/export behavior

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -1,0 +1,11 @@
+# Artifacts
+
+## Observability scope
+
+- Artifact lifecycle operations do not write durable audit rows to the `events` table.
+- Artifact code does not rely on `LemmingsOs.Events` for lifecycle audit semantics.
+- Any Artifact observability in this slice is limited to lightweight logging/telemetry only, with allowlisted safe fields.
+
+## Future work
+
+Platform audit/event model should be designed separately. That future design should define durable vs transient events, actor attribution, retention, immutability, event taxonomy, read/download audit, filtering/export, and whether the current `events` table is the audit log or a domain activity log.

--- a/lib/lemmings_os/artifacts.ex
+++ b/lib/lemmings_os/artifacts.ex
@@ -329,6 +329,37 @@ defmodule LemmingsOs.Artifacts do
     Map.take(artifact, @descriptor_fields)
   end
 
+  @doc """
+  Decorates artifact descriptors with scope slugs for UI display.
+
+  Adds `:city_slug`, `:department_slug`, and `:lemming_slug` keys when the
+  corresponding scope ids are present and resolvable.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.decorate_scope_slugs([])
+      []
+  """
+  @spec decorate_scope_slugs([artifact_descriptor()]) :: [map()]
+  def decorate_scope_slugs(rows) when is_list(rows) do
+    city_slug_by_id = slug_map_for(City, rows, :city_id)
+    department_slug_by_id = slug_map_for(Department, rows, :department_id)
+    lemming_slug_by_id = slug_map_for(Lemming, rows, :lemming_id)
+
+    Enum.map(rows, fn row ->
+      city_id = map_field(row, :city_id)
+      department_id = map_field(row, :department_id)
+      lemming_id = map_field(row, :lemming_id)
+
+      row
+      |> Map.put(:city_slug, Map.get(city_slug_by_id, city_id))
+      |> Map.put(:department_slug, Map.get(department_slug_by_id, department_id))
+      |> Map.put(:lemming_slug, Map.get(lemming_slug_by_id, lemming_id))
+    end)
+  end
+
+  def decorate_scope_slugs(_rows), do: []
+
   defp get_artifact_record(scope_data, artifact_id) do
     Artifact
     |> filter_query(scope_filters(scope_data))
@@ -411,6 +442,29 @@ defmodule LemmingsOs.Artifacts do
         value -> [{field, value} | acc]
       end
     end)
+  end
+
+  defp slug_map_for(schema, rows, field) do
+    ids = collect_scope_ids(rows, field)
+
+    case ids do
+      [] ->
+        %{}
+
+      _ids ->
+        schema
+        |> where([entity], entity.id in ^ids)
+        |> select([entity], {entity.id, entity.slug})
+        |> Repo.all()
+        |> Map.new()
+    end
+  end
+
+  defp collect_scope_ids(rows, field) do
+    rows
+    |> Enum.map(&map_field(&1, field))
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
   end
 
   defp scope_data(%World{id: world_id}) when is_binary(world_id) do

--- a/lib/lemmings_os/artifacts.ex
+++ b/lib/lemmings_os/artifacts.ex
@@ -73,6 +73,13 @@ defmodule LemmingsOs.Artifacts do
           updated_at: DateTime.t()
         }
 
+  @type download_artifact :: %{
+          id: Ecto.UUID.t(),
+          filename: String.t(),
+          content_type: String.t(),
+          storage_ref: String.t()
+        }
+
   @doc """
   Creates an Artifact row from trusted metadata inside an explicit scope.
 
@@ -169,6 +176,32 @@ defmodule LemmingsOs.Artifacts do
   end
 
   def get_artifact(_scope, _artifact_id, _opts), do: {:error, :invalid_scope}
+
+  @doc """
+  Retrieves one download-ready Artifact with internal storage metadata.
+
+  This API is for trusted runtime/controller boundaries that must resolve and
+  stream Artifact files. It only returns `ready` artifacts and is scoped
+  explicitly to the given world hierarchy.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.get_artifact_download(%{city_id: Ecto.UUID.generate()}, Ecto.UUID.generate())
+      {:error, :invalid_scope}
+  """
+  @spec get_artifact_download(scope(), Ecto.UUID.t()) ::
+          {:ok, download_artifact()} | {:error, :invalid_scope | :not_found}
+  def get_artifact_download(scope, artifact_id) when is_binary(artifact_id) do
+    with {:ok, scope_data} <- scope_data(scope) do
+      Artifact
+      |> filter_query(scope_filters(scope_data))
+      |> filter_query(id: artifact_id, status: @ready_status)
+      |> Repo.one()
+      |> normalize_download_result()
+    end
+  end
+
+  def get_artifact_download(_scope, _artifact_id), do: {:error, :invalid_scope}
 
   @doc """
   Lists `ready` artifacts in an explicit scope.
@@ -306,6 +339,18 @@ defmodule LemmingsOs.Artifacts do
 
   defp normalize_read_result(nil), do: {:error, :not_found}
   defp normalize_read_result(%Artifact{} = artifact), do: {:ok, artifact_descriptor(artifact)}
+
+  defp normalize_download_result(nil), do: {:error, :not_found}
+
+  defp normalize_download_result(%Artifact{} = artifact) do
+    {:ok,
+     %{
+       id: artifact.id,
+       filename: artifact.filename,
+       content_type: artifact.content_type,
+       storage_ref: artifact.storage_ref
+     }}
+  end
 
   defp normalize_write_result({:ok, %Artifact{} = artifact}),
     do: {:ok, artifact_descriptor(artifact)}

--- a/lib/lemmings_os/artifacts.ex
+++ b/lib/lemmings_os/artifacts.ex
@@ -1,0 +1,561 @@
+defmodule LemmingsOs.Artifacts do
+  @moduledoc """
+  World-scoped persistence boundary for Artifact metadata and lifecycle state.
+
+  This context exposes explicit-scope APIs for creating, retrieving, listing,
+  and status updates while keeping storage internals private. Public read models
+  use `artifact_descriptor/1`, which omits `storage_ref` and any filesystem path.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.Promotion
+  alias LemmingsOs.Cities.City
+  alias LemmingsOs.Departments.Department
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Lemmings.Lemming
+  alias LemmingsOs.Repo
+  alias LemmingsOs.Worlds.World
+
+  @ready_status "ready"
+  @artifact_statuses Artifact.statuses()
+  @status_fields ~w(status statuses include_non_ready)a
+  @scope_fields ~w(world_id city_id department_id lemming_id lemming_instance_id)a
+  @descriptor_fields ~w(
+    id
+    world_id
+    city_id
+    department_id
+    lemming_id
+    lemming_instance_id
+    created_by_tool_execution_id
+    type
+    filename
+    content_type
+    size_bytes
+    checksum
+    status
+    notes
+    metadata
+    inserted_at
+    updated_at
+  )a
+
+  @type scope_data :: %{
+          required(:world_id) => Ecto.UUID.t(),
+          required(:city_id) => Ecto.UUID.t() | nil,
+          required(:department_id) => Ecto.UUID.t() | nil,
+          required(:lemming_id) => Ecto.UUID.t() | nil,
+          required(:lemming_instance_id) => Ecto.UUID.t() | nil
+        }
+
+  @type scope ::
+          World.t() | City.t() | Department.t() | Lemming.t() | LemmingInstance.t() | map()
+
+  @type artifact_descriptor :: %{
+          id: Ecto.UUID.t(),
+          world_id: Ecto.UUID.t(),
+          city_id: Ecto.UUID.t() | nil,
+          department_id: Ecto.UUID.t() | nil,
+          lemming_id: Ecto.UUID.t() | nil,
+          lemming_instance_id: Ecto.UUID.t() | nil,
+          created_by_tool_execution_id: Ecto.UUID.t() | nil,
+          type: String.t(),
+          filename: String.t(),
+          content_type: String.t(),
+          size_bytes: non_neg_integer(),
+          checksum: String.t(),
+          status: String.t(),
+          notes: String.t() | nil,
+          metadata: map(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  @doc """
+  Creates an Artifact row from trusted metadata inside an explicit scope.
+
+  Scope ids are context-controlled. Conflicting scope fields in `attrs` are
+  rejected with `{:error, :scope_mismatch}`.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.create_artifact(%{city_id: Ecto.UUID.generate()}, %{})
+      {:error, :invalid_scope}
+  """
+  @spec create_artifact(scope(), map()) ::
+          {:ok, artifact_descriptor()}
+          | {:error, :invalid_scope | :scope_mismatch | Ecto.Changeset.t()}
+  def create_artifact(scope, attrs) when is_map(attrs) do
+    with {:ok, scope_data} <- scope_data(scope),
+         :ok <- ensure_scope_attr_consistency(scope_data, attrs) do
+      attrs =
+        attrs
+        |> Map.new()
+        |> Map.merge(scope_attrs(scope_data))
+
+      %Artifact{}
+      |> Artifact.changeset(attrs)
+      |> Repo.insert()
+      |> normalize_write_result()
+    end
+  end
+
+  def create_artifact(_scope, _attrs), do: {:error, :invalid_scope}
+
+  @doc """
+  Promotes one trusted workspace file into managed Artifact storage.
+
+  Promotion always computes and persists `storage_ref`, `size_bytes`, and
+  `checksum`, and sets Artifact status to `ready`.
+
+  Collision behavior for existing `(world_id, city_id, department_id, lemming_id, filename)`:
+  - `mode: :update_existing` overwrites the existing managed file and keeps the same row.
+  - `mode: :promote_as_new` creates a new Artifact row with a new id.
+  - missing/invalid mode when a collision exists returns a safe error.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.promote_workspace_file(%{city_id: Ecto.UUID.generate()}, %{})
+      {:error, :invalid_scope}
+  """
+  @spec promote_workspace_file(scope(), map()) ::
+          {:ok, artifact_descriptor()}
+          | {:error, atom() | Ecto.Changeset.t() | {atom(), term()}}
+  def promote_workspace_file(scope, attrs) when is_map(attrs) do
+    with {:ok, scope_data} <- scope_data(scope) do
+      Promotion.promote_workspace_file(scope_data, attrs)
+    end
+  end
+
+  def promote_workspace_file(_scope, _attrs), do: {:error, :invalid_scope}
+
+  @doc """
+  Retrieves one `ready` Artifact by id within an explicit scope.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.get_artifact(%{city_id: Ecto.UUID.generate()}, Ecto.UUID.generate())
+      {:error, :invalid_scope}
+  """
+  @spec get_artifact(scope(), Ecto.UUID.t()) ::
+          {:ok, artifact_descriptor()} | {:error, :invalid_scope | :not_found}
+  def get_artifact(scope, artifact_id), do: get_artifact(scope, artifact_id, [])
+
+  @doc """
+  Retrieves one Artifact by id within an explicit scope.
+
+  By default, only `ready` artifacts are returned. Pass `include_non_ready: true`
+  or explicit `:status`/`:statuses` filters to include other lifecycle states.
+
+  ## Examples
+
+      iex> scope = %{world_id: Ecto.UUID.generate()}
+      iex> LemmingsOs.Artifacts.get_artifact(scope, Ecto.UUID.generate(), include_non_ready: true)
+      {:error, :not_found}
+  """
+  @spec get_artifact(scope(), Ecto.UUID.t(), keyword()) ::
+          {:ok, artifact_descriptor()} | {:error, :invalid_scope | :not_found}
+  def get_artifact(scope, artifact_id, opts)
+      when is_binary(artifact_id) and is_list(opts) do
+    with {:ok, scope_data} <- scope_data(scope) do
+      Artifact
+      |> filter_query(scope_filters(scope_data))
+      |> filter_query([{:id, artifact_id} | normalize_status_filters(opts)])
+      |> Repo.one()
+      |> normalize_read_result()
+    end
+  end
+
+  def get_artifact(_scope, _artifact_id, _opts), do: {:error, :invalid_scope}
+
+  @doc """
+  Lists `ready` artifacts in an explicit scope.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.list_artifacts_for_scope(%{city_id: Ecto.UUID.generate()})
+      {:error, :invalid_scope}
+  """
+  @spec list_artifacts_for_scope(scope(), keyword()) ::
+          {:ok, [artifact_descriptor()]} | {:error, :invalid_scope}
+  def list_artifacts_for_scope(scope, opts \\ []) when is_list(opts) do
+    with {:ok, scope_data} <- scope_data(scope) do
+      artifacts =
+        Artifact
+        |> filter_query(scope_filters(scope_data))
+        |> filter_query(normalize_status_filters(opts))
+        |> order_by([artifact], desc: artifact.inserted_at, desc: artifact.id)
+        |> Repo.all()
+        |> Enum.map(&artifact_descriptor/1)
+
+      {:ok, artifacts}
+    end
+  end
+
+  @doc """
+  Lists `ready` artifacts for a runtime instance id within an explicit scope.
+
+  ## Examples
+
+      iex> scope = %{world_id: Ecto.UUID.generate()}
+      iex> LemmingsOs.Artifacts.list_artifacts_for_instance(scope, Ecto.UUID.generate())
+      {:ok, []}
+  """
+  @spec list_artifacts_for_instance(scope(), Ecto.UUID.t()) ::
+          {:ok, [artifact_descriptor()]} | {:error, :invalid_scope}
+  def list_artifacts_for_instance(scope, lemming_instance_id),
+    do: list_artifacts_for_instance(scope, lemming_instance_id, [])
+
+  @doc """
+  Lists artifacts for a runtime instance id within an explicit scope.
+
+  By default, only `ready` artifacts are returned. Pass `include_non_ready: true`
+  or explicit `:status`/`:statuses` filters to include other lifecycle states.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.list_artifacts_for_instance(%{city_id: Ecto.UUID.generate()}, Ecto.UUID.generate())
+      {:error, :invalid_scope}
+  """
+  @spec list_artifacts_for_instance(scope(), Ecto.UUID.t(), keyword()) ::
+          {:ok, [artifact_descriptor()]} | {:error, :invalid_scope}
+  def list_artifacts_for_instance(scope, lemming_instance_id, opts)
+      when is_binary(lemming_instance_id) and is_list(opts) do
+    with {:ok, scope_data} <- scope_data(scope),
+         :ok <- ensure_scope_instance_consistency(scope_data, lemming_instance_id) do
+      artifacts =
+        Artifact
+        |> filter_query(scope_filters(scope_data))
+        |> filter_query([
+          {:lemming_instance_id, lemming_instance_id} | normalize_status_filters(opts)
+        ])
+        |> order_by([artifact], desc: artifact.inserted_at, desc: artifact.id)
+        |> Repo.all()
+        |> Enum.map(&artifact_descriptor/1)
+
+      {:ok, artifacts}
+    end
+  end
+
+  def list_artifacts_for_instance(_scope, _lemming_instance_id, _opts),
+    do: {:error, :invalid_scope}
+
+  @doc """
+  Updates Artifact lifecycle status in explicit scope.
+
+  ## Examples
+
+      iex> scope = %{world_id: Ecto.UUID.generate()}
+      iex> LemmingsOs.Artifacts.update_artifact_status(scope, Ecto.UUID.generate(), "pending")
+      {:error, :invalid_status}
+  """
+  @spec update_artifact_status(scope(), Ecto.UUID.t(), String.t()) ::
+          {:ok, artifact_descriptor()}
+          | {:error, :invalid_scope | :not_found | :invalid_status | Ecto.Changeset.t()}
+  def update_artifact_status(scope, artifact_id, status)
+      when is_binary(artifact_id) and is_binary(status) do
+    with {:ok, scope_data} <- scope_data(scope),
+         :ok <- validate_status(status),
+         {:ok, artifact} <- get_artifact_record(scope_data, artifact_id) do
+      artifact
+      |> Artifact.changeset(%{status: status})
+      |> Repo.update()
+      |> normalize_write_result()
+    end
+  end
+
+  def update_artifact_status(_scope, _artifact_id, _status), do: {:error, :invalid_scope}
+
+  @doc """
+  Returns a safe public descriptor for an Artifact.
+
+  The descriptor intentionally excludes `storage_ref` and any filesystem paths.
+
+  ## Examples
+
+      iex> artifact = %LemmingsOs.Artifacts.Artifact{
+      ...>   id: Ecto.UUID.generate(),
+      ...>   world_id: Ecto.UUID.generate(),
+      ...>   filename: "summary.md",
+      ...>   type: "markdown",
+      ...>   content_type: "text/markdown",
+      ...>   storage_ref: "local://artifacts/world/artifact/summary.md",
+      ...>   size_bytes: 7,
+      ...>   checksum: String.duplicate("a", 64),
+      ...>   status: "ready",
+      ...>   metadata: %{}
+      ...> }
+      iex> descriptor = LemmingsOs.Artifacts.artifact_descriptor(artifact)
+      iex> Map.has_key?(descriptor, :storage_ref)
+      false
+  """
+  @spec artifact_descriptor(Artifact.t()) :: artifact_descriptor()
+  def artifact_descriptor(%Artifact{} = artifact) do
+    Map.take(artifact, @descriptor_fields)
+  end
+
+  defp get_artifact_record(scope_data, artifact_id) do
+    Artifact
+    |> filter_query(scope_filters(scope_data))
+    |> filter_query(id: artifact_id)
+    |> Repo.one()
+    |> normalize_artifact_result()
+  end
+
+  defp normalize_read_result(nil), do: {:error, :not_found}
+  defp normalize_read_result(%Artifact{} = artifact), do: {:ok, artifact_descriptor(artifact)}
+
+  defp normalize_write_result({:ok, %Artifact{} = artifact}),
+    do: {:ok, artifact_descriptor(artifact)}
+
+  defp normalize_write_result({:error, %Ecto.Changeset{} = changeset}), do: {:error, changeset}
+
+  defp normalize_artifact_result(nil), do: {:error, :not_found}
+  defp normalize_artifact_result(%Artifact{} = artifact), do: {:ok, artifact}
+
+  defp validate_status(status) when status in @artifact_statuses, do: :ok
+  defp validate_status(_status), do: {:error, :invalid_status}
+
+  defp normalize_status_filters(opts) do
+    cond do
+      Keyword.has_key?(opts, :status) ->
+        Keyword.drop(opts, [:include_non_ready])
+
+      Keyword.has_key?(opts, :statuses) ->
+        Keyword.drop(opts, [:include_non_ready])
+
+      Keyword.get(opts, :include_non_ready, false) ->
+        Keyword.drop(opts, [:include_non_ready])
+
+      true ->
+        [{:status, @ready_status} | Keyword.drop(opts, [:include_non_ready])]
+    end
+  end
+
+  defp ensure_scope_instance_consistency(%{lemming_instance_id: nil}, _instance_id), do: :ok
+
+  defp ensure_scope_instance_consistency(%{lemming_instance_id: lemming_instance_id}, instance_id)
+       when lemming_instance_id == instance_id,
+       do: :ok
+
+  defp ensure_scope_instance_consistency(_scope_data, _instance_id), do: {:error, :invalid_scope}
+
+  defp ensure_scope_attr_consistency(scope_data, attrs) do
+    Enum.reduce_while(@scope_fields, :ok, fn field, :ok ->
+      expected = Map.get(scope_data, field)
+      actual = map_field(attrs, field)
+
+      if is_nil(actual) or actual == expected do
+        {:cont, :ok}
+      else
+        {:halt, {:error, :scope_mismatch}}
+      end
+    end)
+  end
+
+  defp scope_attrs(%{} = scope_data) do
+    Map.take(scope_data, @scope_fields)
+  end
+
+  defp scope_filters(scope_data) do
+    Enum.reduce(@scope_fields, [], fn field, acc ->
+      case Map.get(scope_data, field) do
+        nil -> acc
+        value -> [{field, value} | acc]
+      end
+    end)
+  end
+
+  defp scope_data(%World{id: world_id}) when is_binary(world_id) do
+    {:ok,
+     %{
+       world_id: world_id,
+       city_id: nil,
+       department_id: nil,
+       lemming_id: nil,
+       lemming_instance_id: nil
+     }}
+  end
+
+  defp scope_data(%City{id: city_id, world_id: world_id})
+       when is_binary(world_id) and is_binary(city_id) do
+    {:ok,
+     %{
+       world_id: world_id,
+       city_id: city_id,
+       department_id: nil,
+       lemming_id: nil,
+       lemming_instance_id: nil
+     }}
+  end
+
+  defp scope_data(%Department{id: department_id, city_id: city_id, world_id: world_id})
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) do
+    {:ok,
+     %{
+       world_id: world_id,
+       city_id: city_id,
+       department_id: department_id,
+       lemming_id: nil,
+       lemming_instance_id: nil
+     }}
+  end
+
+  defp scope_data(%Lemming{
+         id: lemming_id,
+         department_id: department_id,
+         city_id: city_id,
+         world_id: world_id
+       })
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) and
+              is_binary(lemming_id) do
+    {:ok,
+     %{
+       world_id: world_id,
+       city_id: city_id,
+       department_id: department_id,
+       lemming_id: lemming_id,
+       lemming_instance_id: nil
+     }}
+  end
+
+  defp scope_data(%LemmingInstance{
+         id: lemming_instance_id,
+         lemming_id: lemming_id,
+         department_id: department_id,
+         city_id: city_id,
+         world_id: world_id
+       })
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) and
+              is_binary(lemming_id) and is_binary(lemming_instance_id) do
+    {:ok,
+     %{
+       world_id: world_id,
+       city_id: city_id,
+       department_id: department_id,
+       lemming_id: lemming_id,
+       lemming_instance_id: lemming_instance_id
+     }}
+  end
+
+  defp scope_data(%{} = scope) do
+    world_id = map_field(scope, :world_id)
+    city_id = map_field(scope, :city_id)
+    department_id = map_field(scope, :department_id)
+    lemming_id = map_field(scope, :lemming_id)
+    lemming_instance_id = map_field(scope, :lemming_instance_id)
+
+    with :ok <-
+           validate_scope_shape(world_id, city_id, department_id, lemming_id, lemming_instance_id),
+         :ok <-
+           validate_scope_uuids(world_id, city_id, department_id, lemming_id, lemming_instance_id) do
+      {:ok,
+       %{
+         world_id: world_id,
+         city_id: city_id,
+         department_id: department_id,
+         lemming_id: lemming_id,
+         lemming_instance_id: lemming_instance_id
+       }}
+    end
+  end
+
+  defp scope_data(_scope), do: {:error, :invalid_scope}
+
+  defp validate_scope_shape(world_id, nil, nil, nil, nil) when is_binary(world_id), do: :ok
+
+  defp validate_scope_shape(world_id, city_id, nil, nil, nil)
+       when is_binary(world_id) and is_binary(city_id),
+       do: :ok
+
+  defp validate_scope_shape(world_id, city_id, department_id, nil, nil)
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id),
+       do: :ok
+
+  defp validate_scope_shape(world_id, city_id, department_id, lemming_id, nil)
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) and
+              is_binary(lemming_id),
+       do: :ok
+
+  defp validate_scope_shape(world_id, city_id, department_id, lemming_id, lemming_instance_id)
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) and
+              is_binary(lemming_id) and is_binary(lemming_instance_id),
+       do: :ok
+
+  defp validate_scope_shape(_world_id, _city_id, _department_id, _lemming_id, _instance_id),
+    do: {:error, :invalid_scope}
+
+  defp validate_scope_uuids(world_id, city_id, department_id, lemming_id, lemming_instance_id) do
+    [world_id, city_id, department_id, lemming_id, lemming_instance_id]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce_while(:ok, fn value, :ok ->
+      case Ecto.UUID.cast(value) do
+        {:ok, _uuid} -> {:cont, :ok}
+        :error -> {:halt, {:error, :invalid_scope}}
+      end
+    end)
+  end
+
+  defp map_field(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp filter_query(query, [{:id, id} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.id == ^id), rest)
+
+  defp filter_query(query, [{:ids, ids} | rest]) when is_list(ids),
+    do: filter_query(from(artifact in query, where: artifact.id in ^ids), rest)
+
+  defp filter_query(query, [{:world_id, world_id} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.world_id == ^world_id), rest)
+
+  defp filter_query(query, [{:city_id, city_id} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.city_id == ^city_id), rest)
+
+  defp filter_query(query, [{:department_id, department_id} | rest]),
+    do:
+      filter_query(from(artifact in query, where: artifact.department_id == ^department_id), rest)
+
+  defp filter_query(query, [{:lemming_id, lemming_id} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.lemming_id == ^lemming_id), rest)
+
+  defp filter_query(query, [{:lemming_instance_id, lemming_instance_id} | rest]),
+    do:
+      filter_query(
+        from(artifact in query, where: artifact.lemming_instance_id == ^lemming_instance_id),
+        rest
+      )
+
+  defp filter_query(query, [{:created_by_tool_execution_id, created_by_tool_execution_id} | rest]),
+    do:
+      filter_query(
+        from(
+          artifact in query,
+          where: artifact.created_by_tool_execution_id == ^created_by_tool_execution_id
+        ),
+        rest
+      )
+
+  defp filter_query(query, [{:filename, filename} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.filename == ^filename), rest)
+
+  defp filter_query(query, [{:type, type} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.type == ^type), rest)
+
+  defp filter_query(query, [{:status, status} | rest]),
+    do: filter_query(from(artifact in query, where: artifact.status == ^status), rest)
+
+  defp filter_query(query, [{:statuses, statuses} | rest]) when is_list(statuses),
+    do: filter_query(from(artifact in query, where: artifact.status in ^statuses), rest)
+
+  defp filter_query(query, [{:preload, preloads} | rest]),
+    do: filter_query(preload(query, ^preloads), rest)
+
+  defp filter_query(query, [{key, _value} | rest]) when key in @status_fields,
+    do: filter_query(query, rest)
+
+  defp filter_query(query, [_unknown | rest]), do: filter_query(query, rest)
+  defp filter_query(query, []), do: query
+end

--- a/lib/lemmings_os/artifacts/artifact.ex
+++ b/lib/lemmings_os/artifacts/artifact.ex
@@ -1,0 +1,214 @@
+defmodule LemmingsOs.Artifacts.Artifact do
+  @moduledoc """
+  Persisted Artifact domain record promoted from runtime outputs.
+
+  A simple file only represents bytes on disk. An Artifact represents those
+  bytes plus durable domain semantics: scope ownership (`world/city/department/
+  lemming`), optional provenance, lifecycle status, metadata contract, and a
+  storage reference that points to managed storage.
+  """
+
+  use Ecto.Schema
+  use Gettext, backend: LemmingsOs.Gettext
+
+  import Ecto.Changeset
+
+  alias LemmingsOs.Cities.City
+  alias LemmingsOs.Departments.Department
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.LemmingInstances.ToolExecution
+  alias LemmingsOs.Lemmings.Lemming
+  alias LemmingsOs.Worlds.World
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  @types ~w(markdown pdf json csv email html image text other)
+  @statuses ~w(ready archived deleted error)
+  @required ~w(world_id filename type content_type storage_ref size_bytes checksum status metadata)a
+  @optional ~w(city_id department_id lemming_id lemming_instance_id created_by_tool_execution_id notes)a
+  @allowed_metadata_sources ~w(manual_promotion)
+
+  @type t :: %__MODULE__{
+          id: Ecto.UUID.t() | nil,
+          world_id: Ecto.UUID.t() | nil,
+          world: World.t() | Ecto.Association.NotLoaded.t() | nil,
+          city_id: Ecto.UUID.t() | nil,
+          city: City.t() | Ecto.Association.NotLoaded.t() | nil,
+          department_id: Ecto.UUID.t() | nil,
+          department: Department.t() | Ecto.Association.NotLoaded.t() | nil,
+          lemming_id: Ecto.UUID.t() | nil,
+          lemming: Lemming.t() | Ecto.Association.NotLoaded.t() | nil,
+          lemming_instance_id: Ecto.UUID.t() | nil,
+          lemming_instance: LemmingInstance.t() | Ecto.Association.NotLoaded.t() | nil,
+          created_by_tool_execution_id: Ecto.UUID.t() | nil,
+          created_by_tool_execution: ToolExecution.t() | Ecto.Association.NotLoaded.t() | nil,
+          type: String.t() | nil,
+          filename: String.t() | nil,
+          content_type: String.t() | nil,
+          storage_ref: String.t() | nil,
+          size_bytes: integer() | nil,
+          checksum: String.t() | nil,
+          status: String.t() | nil,
+          notes: String.t() | nil,
+          metadata: map(),
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  schema "artifacts" do
+    field :type, :string
+    field :filename, :string
+    field :content_type, :string
+    field :storage_ref, :string
+    field :size_bytes, :integer
+    field :checksum, :string
+    field :status, :string
+    field :notes, :string
+    field :metadata, :map, default: %{}
+
+    belongs_to :world, World
+    belongs_to :city, City
+    belongs_to :department, Department
+    belongs_to :lemming, Lemming
+    belongs_to :lemming_instance, LemmingInstance
+    belongs_to :created_by_tool_execution, ToolExecution
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Builds the changeset for a persisted artifact.
+
+  ## Examples
+
+      iex> attrs = %{
+      ...>   world_id: Ecto.UUID.generate(),
+      ...>   filename: "artifact.md",
+      ...>   type: "markdown",
+      ...>   content_type: "text/markdown",
+      ...>   storage_ref: "local://artifacts/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/artifact.md",
+      ...>   size_bytes: 12,
+      ...>   checksum: String.duplicate("a", 64),
+      ...>   status: "ready",
+      ...>   metadata: %{"source" => "manual_promotion"}
+      ...> }
+      iex> changeset = LemmingsOs.Artifacts.Artifact.changeset(%LemmingsOs.Artifacts.Artifact{}, attrs)
+      iex> changeset.valid?
+      true
+  """
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(artifact, attrs) do
+    artifact
+    |> cast(attrs, @required ++ @optional)
+    |> validate_required(@required, message: dgettext("errors", ".required"))
+    |> validate_inclusion(:type, @types, message: dgettext("errors", ".invalid_choice"))
+    |> validate_inclusion(:status, @statuses, message: dgettext("errors", ".invalid_choice"))
+    |> validate_number(:size_bytes,
+      greater_than_or_equal_to: 0,
+      message: dgettext("errors", ".invalid_value")
+    )
+    |> validate_scope_shape()
+    |> validate_metadata_contract()
+    |> assoc_constraint(:world)
+    |> assoc_constraint(:city)
+    |> assoc_constraint(:department)
+    |> assoc_constraint(:lemming)
+    |> assoc_constraint(:lemming_instance)
+    |> assoc_constraint(:created_by_tool_execution)
+  end
+
+  @doc """
+  Canonical persisted artifact type values.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.Artifact.types()
+      ["markdown", "pdf", "json", "csv", "email", "html", "image", "text", "other"]
+  """
+  @spec types() :: [String.t()]
+  def types, do: @types
+
+  @doc """
+  Canonical persisted artifact status values.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.Artifact.statuses()
+      ["ready", "archived", "deleted", "error"]
+  """
+  @spec statuses() :: [String.t()]
+  def statuses, do: @statuses
+
+  defp validate_scope_shape(changeset) do
+    city_id = get_field(changeset, :city_id)
+    department_id = get_field(changeset, :department_id)
+    lemming_id = get_field(changeset, :lemming_id)
+
+    if valid_scope_shape?(city_id, department_id, lemming_id) do
+      changeset
+    else
+      add_error(changeset, :city_id, dgettext("errors", ".invalid_value"))
+    end
+  end
+
+  defp valid_scope_shape?(nil, nil, nil), do: true
+  defp valid_scope_shape?(city_id, nil, nil) when is_binary(city_id), do: true
+
+  defp valid_scope_shape?(city_id, department_id, nil)
+       when is_binary(city_id) and is_binary(department_id),
+       do: true
+
+  defp valid_scope_shape?(city_id, department_id, lemming_id)
+       when is_binary(city_id) and is_binary(department_id) and is_binary(lemming_id),
+       do: true
+
+  defp valid_scope_shape?(_city_id, _department_id, _lemming_id), do: false
+
+  defp validate_metadata_contract(changeset) do
+    validate_change(changeset, :metadata, &metadata_errors/2)
+  end
+
+  defp metadata_errors(:metadata, metadata) when is_map(metadata) do
+    metadata
+    |> normalize_metadata_keys()
+    |> metadata_contract_errors()
+  end
+
+  defp metadata_errors(:metadata, _metadata) do
+    [metadata: dgettext("errors", ".invalid_value_type")]
+  end
+
+  defp normalize_metadata_keys(metadata) do
+    Enum.reduce(metadata, %{}, fn
+      {key, value}, acc when is_binary(key) -> Map.put(acc, key, value)
+      {key, value}, acc when is_atom(key) -> Map.put(acc, Atom.to_string(key), value)
+      {_key, _value}, acc -> acc
+    end)
+  end
+
+  defp metadata_contract_errors(%{} = metadata) do
+    with :ok <- validate_metadata_keys(metadata),
+         :ok <- validate_metadata_source(metadata) do
+      []
+    else
+      {:error, reason} -> [metadata: reason]
+    end
+  end
+
+  defp validate_metadata_keys(metadata) do
+    case Map.keys(metadata) do
+      [] -> :ok
+      ["source"] -> :ok
+      _keys -> {:error, dgettext("errors", ".invalid_value")}
+    end
+  end
+
+  defp validate_metadata_source(%{"source" => source}) when source in @allowed_metadata_sources,
+    do: :ok
+
+  defp validate_metadata_source(%{"source" => _source}),
+    do: {:error, dgettext("errors", ".invalid_choice")}
+
+  defp validate_metadata_source(%{}), do: :ok
+end

--- a/lib/lemmings_os/artifacts/local_storage.ex
+++ b/lib/lemmings_os/artifacts/local_storage.ex
@@ -157,7 +157,7 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
   def root_path do
     :lemmings_os
     |> Application.get_env(:artifact_storage, [])
-    |> Keyword.get(:root_path, Path.expand("storage/artifacts", File.cwd!()))
+    |> Keyword.get(:root_path, Path.expand("priv/runtime/storage", File.cwd!()))
     |> Path.expand()
   end
 

--- a/lib/lemmings_os/artifacts/local_storage.ex
+++ b/lib/lemmings_os/artifacts/local_storage.ex
@@ -220,6 +220,7 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
   defp validate_filename_bytes(filename) do
     cond do
       String.contains?(filename, <<0>>) -> {:error, :invalid_filename}
+      filename =~ ~r/[\x00-\x1F\x7F]/ -> {:error, :invalid_filename}
       String.starts_with?(filename, "~") -> {:error, :invalid_filename}
       String.contains?(filename, "\\") -> {:error, :invalid_filename}
       true -> :ok

--- a/lib/lemmings_os/artifacts/local_storage.ex
+++ b/lib/lemmings_os/artifacts/local_storage.ex
@@ -1,0 +1,361 @@
+defmodule LemmingsOs.Artifacts.LocalStorage do
+  @moduledoc """
+  Local managed storage boundary for promoted Artifact files.
+
+  An Artifact is not just a plain file path in a workspace. It is a promoted
+  runtime output that must be stored under an app-managed root with a stable,
+  opaque storage reference (`local://artifacts/...`), plus integrity metadata.
+
+  This module is responsible for the filesystem side of that contract:
+  safe reference generation, trusted resolution, root-bound copying, and
+  checksum/size calculation.
+  """
+
+  @storage_scheme "local"
+  @storage_host "artifacts"
+
+  @typedoc """
+  Metadata returned after storing a file in managed artifact storage.
+  """
+  @type stored_file :: %{
+          storage_ref: String.t(),
+          checksum: String.t(),
+          size_bytes: non_neg_integer()
+        }
+
+  @doc """
+  Copies a trusted source file into managed storage.
+
+  Returns an opaque `storage_ref` suitable for persistence plus checksum and size.
+
+  ## Examples
+
+      iex> old_storage = Application.get_env(:lemmings_os, :artifact_storage)
+      iex> root = Path.join(System.tmp_dir!(), "lemmings_local_storage_doctest_store_copy")
+      iex> world_id = "11111111-1111-4111-8111-111111111111"
+      iex> artifact_id = "22222222-2222-4222-8222-222222222222"
+      iex> source_path = Path.join(root, "source.txt")
+      iex> File.rm_rf!(root)
+      iex> File.mkdir_p!(root)
+      iex> Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: root)
+      iex> :ok = File.write(source_path, "hello\\n")
+      iex> {:ok, stored} =
+      ...>   LemmingsOs.Artifacts.LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+      iex> stored.storage_ref
+      "local://artifacts/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/artifact.txt"
+      iex> stored.size_bytes
+      6
+      iex> expected_checksum = :sha256 |> :crypto.hash("hello\\n") |> Base.encode16(case: :lower)
+      iex> stored.checksum == expected_checksum
+      true
+      iex> File.rm_rf!(root)
+      iex> if old_storage, do: Application.put_env(:lemmings_os, :artifact_storage, old_storage), else: Application.delete_env(:lemmings_os, :artifact_storage)
+      :ok
+  """
+  @spec store_copy(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t()) ::
+          {:ok, stored_file()} | {:error, atom() | {atom(), term()}}
+  def store_copy(world_id, artifact_id, source_path, filename)
+      when is_binary(world_id) and is_binary(artifact_id) and is_binary(source_path) and
+             is_binary(filename) do
+    with :ok <- validate_world_id(world_id),
+         :ok <- validate_artifact_id(artifact_id),
+         :ok <- validate_filename(filename),
+         {:ok, source_absolute_path} <- validate_source_path(source_path),
+         {:ok, storage_ref} <- build_storage_ref(world_id, artifact_id, filename),
+         :ok <- ensure_storage_root(root_path()),
+         {:ok, destination_path} <- resolve_storage_ref(storage_ref),
+         :ok <- File.mkdir_p(Path.dirname(destination_path)),
+         :ok <- copy_file(source_absolute_path, destination_path),
+         {:ok, size_bytes} <- size_bytes(destination_path),
+         {:ok, checksum} <- checksum(destination_path) do
+      {:ok,
+       %{
+         storage_ref: storage_ref,
+         checksum: checksum,
+         size_bytes: size_bytes
+       }}
+    end
+  end
+
+  def store_copy(_world_id, _artifact_id, _source_path, _filename), do: {:error, :invalid_input}
+
+  @doc """
+  Builds an opaque local artifact storage reference.
+
+  ## Examples
+
+      iex> world_id = "11111111-1111-4111-8111-111111111111"
+      iex> artifact_id = "22222222-2222-4222-8222-222222222222"
+      iex> {:ok, ref} = LemmingsOs.Artifacts.LocalStorage.build_storage_ref(world_id, artifact_id, "summary.md")
+      iex> ref
+      "local://artifacts/11111111-1111-4111-8111-111111111111/22222222-2222-4222-8222-222222222222/summary.md"
+  """
+  @spec build_storage_ref(Ecto.UUID.t(), Ecto.UUID.t(), String.t()) ::
+          {:ok, String.t()} | {:error, atom()}
+  def build_storage_ref(world_id, artifact_id, filename)
+      when is_binary(world_id) and is_binary(artifact_id) and is_binary(filename) do
+    with :ok <- validate_world_id(world_id),
+         :ok <- validate_artifact_id(artifact_id),
+         :ok <- validate_filename(filename) do
+      {:ok, "#{@storage_scheme}://#{@storage_host}/#{world_id}/#{artifact_id}/#{filename}"}
+    end
+  end
+
+  def build_storage_ref(_world_id, _artifact_id, _filename), do: {:error, :invalid_storage_ref}
+
+  @doc """
+  Resolves a trusted storage reference into an absolute filesystem path.
+
+  This function is for internal runtime use only.
+
+  ## Examples
+
+      iex> old_storage = Application.get_env(:lemmings_os, :artifact_storage)
+      iex> root = Path.join(System.tmp_dir!(), "lemmings_local_storage_doctest_resolve")
+      iex> world_id = "11111111-1111-4111-8111-111111111111"
+      iex> artifact_id = "22222222-2222-4222-8222-222222222222"
+      iex> File.rm_rf!(root)
+      iex> File.mkdir_p!(Path.join([root, world_id, artifact_id]))
+      iex> Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: root)
+      iex> ref = "local://artifacts/\#{world_id}/\#{artifact_id}/summary.md"
+      iex> {:ok, path} = LemmingsOs.Artifacts.LocalStorage.resolve_storage_ref(ref)
+      iex> path == Path.join([Path.expand(root), world_id, artifact_id, "summary.md"])
+      true
+      iex> File.rm_rf!(root)
+      iex> if old_storage, do: Application.put_env(:lemmings_os, :artifact_storage, old_storage), else: Application.delete_env(:lemmings_os, :artifact_storage)
+      :ok
+  """
+  @spec resolve_storage_ref(String.t()) :: {:ok, String.t()} | {:error, atom()}
+  def resolve_storage_ref(storage_ref) when is_binary(storage_ref) do
+    with {:ok, world_id, artifact_id, filename} <- parse_storage_ref(storage_ref),
+         root <- root_path(),
+         :ok <- validate_storage_root_available(root),
+         relative_path <- Path.join([world_id, artifact_id, filename]),
+         absolute_path <- Path.expand(relative_path, root),
+         :ok <- validate_within_root(absolute_path, root),
+         :ok <- validate_no_symlink_components(root, relative_path) do
+      {:ok, absolute_path}
+    end
+  end
+
+  def resolve_storage_ref(_storage_ref), do: {:error, :invalid_storage_ref}
+
+  @doc """
+  Returns the configured artifact storage root path.
+
+  ## Examples
+
+      iex> old_storage = Application.get_env(:lemmings_os, :artifact_storage)
+      iex> root = Path.join(System.tmp_dir!(), "lemmings_local_storage_doctest_root")
+      iex> Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: root)
+      iex> LemmingsOs.Artifacts.LocalStorage.root_path()
+      Path.expand(root)
+      iex> if old_storage, do: Application.put_env(:lemmings_os, :artifact_storage, old_storage), else: Application.delete_env(:lemmings_os, :artifact_storage)
+      :ok
+  """
+  @spec root_path() :: String.t()
+  def root_path do
+    :lemmings_os
+    |> Application.get_env(:artifact_storage, [])
+    |> Keyword.get(:root_path, Path.expand("storage/artifacts", File.cwd!()))
+    |> Path.expand()
+  end
+
+  defp parse_storage_ref(storage_ref) do
+    uri = URI.parse(storage_ref)
+
+    with :ok <- validate_uri_shape(uri),
+         [world_id, artifact_id, filename] <- path_segments(uri.path),
+         :ok <- validate_world_id(world_id),
+         :ok <- validate_artifact_id(artifact_id),
+         :ok <- validate_filename(filename) do
+      {:ok, world_id, artifact_id, filename}
+    else
+      _error -> {:error, :invalid_storage_ref}
+    end
+  end
+
+  defp path_segments(nil), do: []
+
+  defp path_segments(path) do
+    path
+    |> String.trim_leading("/")
+    |> Path.split()
+  end
+
+  defp validate_uri_shape(%URI{
+         scheme: @storage_scheme,
+         host: @storage_host,
+         query: nil,
+         fragment: nil
+       }),
+       do: :ok
+
+  defp validate_uri_shape(_uri), do: {:error, :invalid_storage_ref}
+
+  defp validate_world_id(world_id) do
+    case Ecto.UUID.cast(world_id) do
+      {:ok, _uuid} -> :ok
+      :error -> {:error, :invalid_world_id}
+    end
+  end
+
+  defp validate_artifact_id(artifact_id) do
+    case Ecto.UUID.cast(artifact_id) do
+      {:ok, _uuid} -> :ok
+      :error -> {:error, :invalid_artifact_id}
+    end
+  end
+
+  defp validate_filename(""), do: {:error, :invalid_filename}
+  defp validate_filename("."), do: {:error, :invalid_filename}
+  defp validate_filename(".."), do: {:error, :invalid_filename}
+
+  defp validate_filename(filename) do
+    with :ok <- validate_filename_bytes(filename) do
+      validate_filename_shape(filename)
+    end
+  end
+
+  defp validate_filename_bytes(filename) do
+    cond do
+      String.contains?(filename, <<0>>) -> {:error, :invalid_filename}
+      String.starts_with?(filename, "~") -> {:error, :invalid_filename}
+      String.contains?(filename, "\\") -> {:error, :invalid_filename}
+      true -> :ok
+    end
+  end
+
+  defp validate_filename_shape(filename) do
+    cond do
+      Regex.match?(~r/^[A-Za-z]:/, filename) -> {:error, :invalid_filename}
+      Path.type(filename) == :absolute -> {:error, :invalid_filename}
+      Path.basename(filename) != filename -> {:error, :invalid_filename}
+      ".." in Path.split(filename) -> {:error, :invalid_filename}
+      true -> :ok
+    end
+  end
+
+  defp validate_source_path(source_path) do
+    cond do
+      source_path == "" ->
+        {:error, :invalid_source_path}
+
+      String.contains?(source_path, <<0>>) ->
+        {:error, :invalid_source_path}
+
+      String.contains?(source_path, "\\") ->
+        {:error, :invalid_source_path}
+
+      Regex.match?(~r/^[A-Za-z]:/, source_path) ->
+        {:error, :invalid_source_path}
+
+      Path.type(source_path) != :absolute ->
+        {:error, :invalid_source_path}
+
+      true ->
+        source_path
+        |> Path.expand()
+        |> validate_source_file()
+    end
+  end
+
+  defp validate_source_file(source_path) do
+    case File.lstat(source_path) do
+      {:ok, %File.Stat{type: :regular}} -> {:ok, source_path}
+      {:ok, %File.Stat{type: :symlink}} -> {:error, :invalid_source_path}
+      {:ok, _stat} -> {:error, :source_not_regular_file}
+      {:error, :enoent} -> {:error, :source_not_found}
+      {:error, _reason} -> {:error, :invalid_source_path}
+    end
+  end
+
+  defp ensure_storage_root(root_path) do
+    case File.stat(root_path) do
+      {:ok, %File.Stat{type: :directory}} -> :ok
+      {:ok, _stat} -> {:error, :storage_unavailable}
+      {:error, :enoent} -> File.mkdir_p(root_path)
+      {:error, _reason} -> {:error, :storage_unavailable}
+    end
+  end
+
+  defp validate_storage_root_available(root_path) do
+    case File.stat(root_path) do
+      {:ok, %File.Stat{type: :directory}} -> :ok
+      {:ok, _stat} -> {:error, :storage_unavailable}
+      {:error, _reason} -> {:error, :storage_unavailable}
+    end
+  end
+
+  defp validate_within_root(absolute_path, root_path) do
+    normalized_absolute = Path.expand(absolute_path)
+    normalized_root = Path.expand(root_path)
+
+    if normalized_absolute == normalized_root or
+         String.starts_with?(normalized_absolute, normalized_root <> "/") do
+      :ok
+    else
+      {:error, :invalid_storage_ref}
+    end
+  end
+
+  defp validate_no_symlink_components(root_path, relative_path) do
+    walk_symlink_components(
+      Path.expand(root_path),
+      Path.split(relative_path)
+    )
+  end
+
+  defp walk_symlink_components(_current_path, []), do: :ok
+
+  defp walk_symlink_components(current_path, [segment | rest]) do
+    next_path = Path.join(current_path, segment)
+
+    case File.lstat(next_path) do
+      {:ok, %File.Stat{type: :symlink}} ->
+        {:error, :invalid_storage_ref}
+
+      {:ok, _stat} ->
+        walk_symlink_components(next_path, rest)
+
+      {:error, :enoent} ->
+        :ok
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp copy_file(source, destination) do
+    case File.cp(source, destination) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:copy_failed, reason}}
+    end
+  end
+
+  defp size_bytes(path) do
+    case File.stat(path) do
+      {:ok, %File.Stat{size: size}} when is_integer(size) and size >= 0 -> {:ok, size}
+      {:ok, _stat} -> {:error, :invalid_file_size}
+      {:error, reason} -> {:error, {:size_failed, reason}}
+    end
+  end
+
+  defp checksum(path) do
+    case File.open(path, [:read, :binary]) do
+      {:ok, device} ->
+        digest =
+          Enum.reduce(IO.binstream(device, 65_536), :crypto.hash_init(:sha256), fn chunk, acc ->
+            :crypto.hash_update(acc, chunk)
+          end)
+          |> :crypto.hash_final()
+          |> Base.encode16(case: :lower)
+
+        :ok = File.close(device)
+        {:ok, digest}
+
+      {:error, reason} ->
+        {:error, {:checksum_failed, reason}}
+    end
+  end
+end

--- a/lib/lemmings_os/artifacts/promotion.ex
+++ b/lib/lemmings_os/artifacts/promotion.ex
@@ -12,6 +12,7 @@ defmodule LemmingsOs.Artifacts.Promotion do
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.Repo
+  alias LemmingsOs.Tools.WorkArea
 
   @ready_status "ready"
   @promote_modes ~w(update_existing promote_as_new)a
@@ -59,7 +60,7 @@ defmodule LemmingsOs.Artifacts.Promotion do
              LemmingInstances.get_instance(instance_id, world_id: scope_data.world_id),
            {:ok, promotion_scope} <- enrich_scope_with_instance(scope_data, instance),
            {:ok, resolved_source} <-
-             LemmingInstances.artifact_absolute_path(instance, relative_path),
+             resolve_workspace_source_path(promotion_scope, instance, relative_path),
            filename <- resolve_filename(attrs, resolved_source.relative_path),
            :ok <- ensure_filename_safe(filename),
            promotion_attrs <- build_promotion_attrs(attrs, promotion_scope, instance, filename) do
@@ -251,6 +252,44 @@ defmodule LemmingsOs.Artifacts.Promotion do
 
   defp resolve_filename(attrs, resolved_relative_path) do
     map_field(attrs, :filename) || Path.basename(resolved_relative_path)
+  end
+
+  defp resolve_workspace_source_path(scope_data, %LemmingInstance{} = instance, relative_path) do
+    work_area_ref = runtime_work_area_ref(scope_data, instance)
+
+    case WorkArea.resolve(work_area_ref, relative_path) do
+      {:ok, %{absolute_path: absolute_path} = resolved} ->
+        if File.regular?(absolute_path) do
+          {:ok, resolved}
+        else
+          resolve_workspace_source_path_legacy(instance, relative_path)
+        end
+
+      {:error, :work_area_unavailable} ->
+        resolve_workspace_source_path_legacy(instance, relative_path)
+
+      {:error, :invalid_path} ->
+        {:error, :path_outside_workspace}
+    end
+  end
+
+  defp resolve_workspace_source_path_legacy(%LemmingInstance{} = instance, relative_path) do
+    case LemmingInstances.artifact_absolute_path(instance, relative_path) do
+      {:ok, resolved_source} -> {:ok, resolved_source}
+      {:error, :invalid_path} -> {:error, :path_outside_workspace}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp runtime_work_area_ref(scope_data, %LemmingInstance{} = instance) do
+    case LemmingInstances.get_runtime_state(instance.id, world_id: scope_data.world_id) do
+      {:ok, %{work_area_ref: work_area_ref}}
+      when is_binary(work_area_ref) and work_area_ref != "" ->
+        work_area_ref
+
+      _other ->
+        instance.id
+    end
   end
 
   defp resolve_instance_id(scope_data, attrs) do

--- a/lib/lemmings_os/artifacts/promotion.ex
+++ b/lib/lemmings_os/artifacts/promotion.ex
@@ -51,27 +51,30 @@ defmodule LemmingsOs.Artifacts.Promotion do
           {:ok, Artifacts.artifact_descriptor()}
           | {:error, atom() | Ecto.Changeset.t() | {atom(), term()}}
   def promote_workspace_file(scope_data, attrs) when is_map(scope_data) and is_map(attrs) do
-    with {:ok, relative_path} <- fetch_non_empty_string(attrs, :relative_path),
-         {:ok, mode} <- normalize_mode(map_field(attrs, :mode)),
-         {:ok, instance_id} <- resolve_instance_id(scope_data, attrs),
-         {:ok, instance} <-
-           LemmingInstances.get_instance(instance_id, world_id: scope_data.world_id),
-         {:ok, promotion_scope} <- enrich_scope_with_instance(scope_data, instance),
-         {:ok, resolved_source} <-
-           LemmingInstances.artifact_absolute_path(instance, relative_path),
-         filename <- resolve_filename(attrs, resolved_source.relative_path),
-         :ok <- ensure_filename_safe(filename),
-         promotion_attrs <- build_promotion_attrs(attrs, promotion_scope, instance, filename) do
-      promote_with_mode(
-        promotion_scope,
-        promotion_attrs,
-        resolved_source.absolute_path,
-        mode
-      )
-    else
-      {:error, :not_found} -> {:error, :instance_not_found}
-      {:error, reason} -> {:error, reason}
-    end
+    result =
+      with {:ok, relative_path} <- fetch_non_empty_string(attrs, :relative_path),
+           {:ok, mode} <- normalize_mode(map_field(attrs, :mode)),
+           {:ok, instance_id} <- resolve_instance_id(scope_data, attrs),
+           {:ok, instance} <-
+             LemmingInstances.get_instance(instance_id, world_id: scope_data.world_id),
+           {:ok, promotion_scope} <- enrich_scope_with_instance(scope_data, instance),
+           {:ok, resolved_source} <-
+             LemmingInstances.artifact_absolute_path(instance, relative_path),
+           filename <- resolve_filename(attrs, resolved_source.relative_path),
+           :ok <- ensure_filename_safe(filename),
+           promotion_attrs <- build_promotion_attrs(attrs, promotion_scope, instance, filename) do
+        promote_with_mode(
+          promotion_scope,
+          promotion_attrs,
+          resolved_source.absolute_path,
+          mode
+        )
+      else
+        {:error, :not_found} -> {:error, :instance_not_found}
+        {:error, reason} -> {:error, reason}
+      end
+
+    result
   end
 
   defp promote_with_mode(scope_data, promotion_attrs, source_absolute_path, mode) do
@@ -133,6 +136,7 @@ defmodule LemmingsOs.Artifacts.Promotion do
       %Artifact{id: artifact_id}
       |> Artifact.changeset(Map.merge(promotion_attrs, stored))
       |> repo.insert()
+      |> lifecycle_result(:promoted)
     end
   end
 
@@ -159,6 +163,7 @@ defmodule LemmingsOs.Artifacts.Promotion do
       existing_artifact
       |> Artifact.changeset(attrs)
       |> repo.update()
+      |> lifecycle_result(:updated)
     end
   end
 
@@ -182,6 +187,7 @@ defmodule LemmingsOs.Artifacts.Promotion do
       %Artifact{id: artifact_id}
       |> Artifact.changeset(Map.merge(promotion_attrs, stored))
       |> repo.insert()
+      |> lifecycle_result(:promoted)
     end
   end
 
@@ -205,14 +211,20 @@ defmodule LemmingsOs.Artifacts.Promotion do
        ),
        do: {:error, :invalid_mode}
 
-  defp normalize_promotion_result({:ok, %{artifact: %Artifact{} = artifact}}),
-    do: {:ok, Artifacts.artifact_descriptor(artifact)}
+  defp normalize_promotion_result(
+         {:ok, %{artifact: %{artifact: %Artifact{} = artifact, lifecycle: _lifecycle}}}
+       ) do
+    {:ok, Artifacts.artifact_descriptor(artifact)}
+  end
 
   defp normalize_promotion_result({:error, :artifact, %Ecto.Changeset{} = changeset, _changes}),
     do: {:error, changeset}
 
-  defp normalize_promotion_result({:error, :artifact, reason, _changes}), do: {:error, reason}
-  defp normalize_promotion_result({:error, _step, reason, _changes}), do: {:error, reason}
+  defp normalize_promotion_result({:error, :artifact, reason, _changes}),
+    do: {:error, reason}
+
+  defp normalize_promotion_result({:error, _step, reason, _changes}),
+    do: {:error, reason}
 
   defp build_promotion_attrs(attrs, scope_data, instance, filename) do
     type = map_field(attrs, :type) || infer_type(filename)
@@ -324,6 +336,11 @@ defmodule LemmingsOs.Artifacts.Promotion do
     |> String.downcase()
     |> then(&Map.get(@extension_types, &1, "other"))
   end
+
+  defp lifecycle_result({:ok, %Artifact{} = artifact}, lifecycle),
+    do: {:ok, %{artifact: artifact, lifecycle: lifecycle}}
+
+  defp lifecycle_result({:error, reason}, _lifecycle), do: {:error, reason}
 
   defp map_field(map, key) do
     Map.get(map, key) || Map.get(map, Atom.to_string(key))

--- a/lib/lemmings_os/artifacts/promotion.ex
+++ b/lib/lemmings_os/artifacts/promotion.ex
@@ -111,7 +111,9 @@ defmodule LemmingsOs.Artifacts.Promotion do
     repo.one(query)
   end
 
-  defp maybe_scope_match(query, _field, nil), do: query
+  defp maybe_scope_match(query, field, nil) do
+    from(artifact in query, where: is_nil(field(artifact, ^field)))
+  end
 
   defp maybe_scope_match(query, field, value) do
     from(artifact in query, where: field(artifact, ^field) == ^value)

--- a/lib/lemmings_os/artifacts/promotion.ex
+++ b/lib/lemmings_os/artifacts/promotion.ex
@@ -1,0 +1,331 @@
+defmodule LemmingsOs.Artifacts.Promotion do
+  @moduledoc """
+  Promotion workflow for copying trusted workspace files into managed Artifact storage.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Ecto.Multi
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.LocalStorage
+  alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Repo
+
+  @ready_status "ready"
+  @promote_modes ~w(update_existing promote_as_new)a
+  @extension_types %{
+    ".md" => "markdown",
+    ".markdown" => "markdown",
+    ".pdf" => "pdf",
+    ".json" => "json",
+    ".csv" => "csv",
+    ".eml" => "email",
+    ".html" => "html",
+    ".htm" => "html",
+    ".png" => "image",
+    ".jpg" => "image",
+    ".jpeg" => "image",
+    ".gif" => "image",
+    ".webp" => "image",
+    ".txt" => "text"
+  }
+
+  @doc """
+  Promotes one trusted workspace file into managed Artifact storage for a validated scope.
+
+  ## Examples
+
+      iex> scope = %{
+      ...>   world_id: Ecto.UUID.generate(),
+      ...>   city_id: nil,
+      ...>   department_id: nil,
+      ...>   lemming_id: nil,
+      ...>   lemming_instance_id: nil
+      ...> }
+      iex> LemmingsOs.Artifacts.Promotion.promote_workspace_file(scope, %{})
+      {:error, :invalid_attrs}
+  """
+  @spec promote_workspace_file(Artifacts.scope_data(), map()) ::
+          {:ok, Artifacts.artifact_descriptor()}
+          | {:error, atom() | Ecto.Changeset.t() | {atom(), term()}}
+  def promote_workspace_file(scope_data, attrs) when is_map(scope_data) and is_map(attrs) do
+    with {:ok, relative_path} <- fetch_non_empty_string(attrs, :relative_path),
+         {:ok, mode} <- normalize_mode(map_field(attrs, :mode)),
+         {:ok, instance_id} <- resolve_instance_id(scope_data, attrs),
+         {:ok, instance} <-
+           LemmingInstances.get_instance(instance_id, world_id: scope_data.world_id),
+         {:ok, promotion_scope} <- enrich_scope_with_instance(scope_data, instance),
+         {:ok, resolved_source} <-
+           LemmingInstances.artifact_absolute_path(instance, relative_path),
+         filename <- resolve_filename(attrs, resolved_source.relative_path),
+         :ok <- ensure_filename_safe(filename),
+         promotion_attrs <- build_promotion_attrs(attrs, promotion_scope, instance, filename) do
+      promote_with_mode(
+        promotion_scope,
+        promotion_attrs,
+        resolved_source.absolute_path,
+        mode
+      )
+    else
+      {:error, :not_found} -> {:error, :instance_not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp promote_with_mode(scope_data, promotion_attrs, source_absolute_path, mode) do
+    Multi.new()
+    |> Multi.run(:existing_artifact, fn repo, _changes ->
+      {:ok, find_existing_artifact(repo, scope_data, promotion_attrs.filename)}
+    end)
+    |> Multi.run(:artifact, fn repo, %{existing_artifact: existing_artifact} ->
+      upsert_promoted_artifact(
+        repo,
+        existing_artifact,
+        scope_data,
+        promotion_attrs,
+        source_absolute_path,
+        mode
+      )
+    end)
+    |> Repo.transaction()
+    |> normalize_promotion_result()
+  end
+
+  defp find_existing_artifact(repo, scope_data, filename) do
+    query =
+      Artifact
+      |> where([artifact], artifact.world_id == ^scope_data.world_id)
+      |> maybe_scope_match(:city_id, scope_data.city_id)
+      |> maybe_scope_match(:department_id, scope_data.department_id)
+      |> maybe_scope_match(:lemming_id, scope_data.lemming_id)
+      |> where([artifact], artifact.filename == ^filename)
+      |> order_by([artifact], desc: artifact.inserted_at, desc: artifact.id)
+      |> limit(1)
+
+    repo.one(query)
+  end
+
+  defp maybe_scope_match(query, _field, nil), do: query
+
+  defp maybe_scope_match(query, field, value) do
+    from(artifact in query, where: field(artifact, ^field) == ^value)
+  end
+
+  defp upsert_promoted_artifact(
+         repo,
+         nil,
+         scope_data,
+         promotion_attrs,
+         source_absolute_path,
+         _mode
+       ) do
+    artifact_id = Ecto.UUID.generate()
+
+    with {:ok, stored} <-
+           LocalStorage.store_copy(
+             scope_data.world_id,
+             artifact_id,
+             source_absolute_path,
+             promotion_attrs.filename
+           ) do
+      %Artifact{id: artifact_id}
+      |> Artifact.changeset(Map.merge(promotion_attrs, stored))
+      |> repo.insert()
+    end
+  end
+
+  defp upsert_promoted_artifact(
+         repo,
+         %Artifact{} = existing_artifact,
+         scope_data,
+         promotion_attrs,
+         source_absolute_path,
+         :update_existing
+       ) do
+    with {:ok, stored} <-
+           LocalStorage.store_copy(
+             scope_data.world_id,
+             existing_artifact.id,
+             source_absolute_path,
+             existing_artifact.filename
+           ) do
+      attrs =
+        promotion_attrs
+        |> Map.put(:filename, existing_artifact.filename)
+        |> Map.merge(stored)
+
+      existing_artifact
+      |> Artifact.changeset(attrs)
+      |> repo.update()
+    end
+  end
+
+  defp upsert_promoted_artifact(
+         repo,
+         %Artifact{},
+         scope_data,
+         promotion_attrs,
+         source_absolute_path,
+         :promote_as_new
+       ) do
+    artifact_id = Ecto.UUID.generate()
+
+    with {:ok, stored} <-
+           LocalStorage.store_copy(
+             scope_data.world_id,
+             artifact_id,
+             source_absolute_path,
+             promotion_attrs.filename
+           ) do
+      %Artifact{id: artifact_id}
+      |> Artifact.changeset(Map.merge(promotion_attrs, stored))
+      |> repo.insert()
+    end
+  end
+
+  defp upsert_promoted_artifact(
+         _repo,
+         %Artifact{},
+         _scope_data,
+         _attrs,
+         _source_absolute_path,
+         nil
+       ),
+       do: {:error, :mode_required}
+
+  defp upsert_promoted_artifact(
+         _repo,
+         %Artifact{},
+         _scope_data,
+         _attrs,
+         _source_absolute_path,
+         _other_mode
+       ),
+       do: {:error, :invalid_mode}
+
+  defp normalize_promotion_result({:ok, %{artifact: %Artifact{} = artifact}}),
+    do: {:ok, Artifacts.artifact_descriptor(artifact)}
+
+  defp normalize_promotion_result({:error, :artifact, %Ecto.Changeset{} = changeset, _changes}),
+    do: {:error, changeset}
+
+  defp normalize_promotion_result({:error, :artifact, reason, _changes}), do: {:error, reason}
+  defp normalize_promotion_result({:error, _step, reason, _changes}), do: {:error, reason}
+
+  defp build_promotion_attrs(attrs, scope_data, instance, filename) do
+    type = map_field(attrs, :type) || infer_type(filename)
+    content_type = map_field(attrs, :content_type) || infer_content_type(filename)
+    notes = map_field(attrs, :notes)
+    created_by_tool_execution_id = map_field(attrs, :created_by_tool_execution_id)
+    metadata = map_field(attrs, :metadata) || %{"source" => "manual_promotion"}
+
+    %{
+      world_id: scope_data.world_id,
+      city_id: scope_data.city_id,
+      department_id: scope_data.department_id,
+      lemming_id: scope_data.lemming_id,
+      lemming_instance_id: instance.id,
+      created_by_tool_execution_id: created_by_tool_execution_id,
+      filename: filename,
+      type: type,
+      content_type: content_type,
+      status: @ready_status,
+      notes: notes,
+      metadata: metadata
+    }
+  end
+
+  defp resolve_filename(attrs, resolved_relative_path) do
+    map_field(attrs, :filename) || Path.basename(resolved_relative_path)
+  end
+
+  defp resolve_instance_id(scope_data, attrs) do
+    attrs_instance_id = map_field(attrs, :lemming_instance_id)
+
+    cond do
+      is_binary(scope_data.lemming_instance_id) and is_binary(attrs_instance_id) and
+          scope_data.lemming_instance_id != attrs_instance_id ->
+        {:error, :invalid_scope}
+
+      is_binary(scope_data.lemming_instance_id) ->
+        {:ok, scope_data.lemming_instance_id}
+
+      is_binary(attrs_instance_id) ->
+        {:ok, attrs_instance_id}
+
+      true ->
+        {:error, :missing_instance_id}
+    end
+  end
+
+  defp enrich_scope_with_instance(scope_data, %LemmingInstance{} = instance) do
+    merged_scope = %{
+      world_id: scope_data.world_id,
+      city_id: scope_data.city_id || instance.city_id,
+      department_id: scope_data.department_id || instance.department_id,
+      lemming_id: scope_data.lemming_id || instance.lemming_id,
+      lemming_instance_id: scope_data.lemming_instance_id || instance.id
+    }
+
+    if instance_matches_scope?(merged_scope, instance) do
+      {:ok, merged_scope}
+    else
+      {:error, :invalid_scope}
+    end
+  end
+
+  defp instance_matches_scope?(scope_data, instance) do
+    scope_data.world_id == instance.world_id and
+      scope_data.city_id == instance.city_id and
+      scope_data.department_id == instance.department_id and
+      scope_data.lemming_id == instance.lemming_id and
+      scope_data.lemming_instance_id == instance.id
+  end
+
+  defp fetch_non_empty_string(attrs, field) do
+    case map_field(attrs, field) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _value -> {:error, :invalid_attrs}
+    end
+  end
+
+  defp normalize_mode(nil), do: {:ok, nil}
+  defp normalize_mode(mode) when mode in @promote_modes, do: {:ok, mode}
+
+  defp normalize_mode(mode) when is_binary(mode) do
+    case mode do
+      "update_existing" -> {:ok, :update_existing}
+      "promote_as_new" -> {:ok, :promote_as_new}
+      _other -> {:error, :invalid_mode}
+    end
+  end
+
+  defp normalize_mode(_mode), do: {:error, :invalid_mode}
+
+  defp ensure_filename_safe(filename) when is_binary(filename) do
+    case LocalStorage.build_storage_ref(Ecto.UUID.generate(), Ecto.UUID.generate(), filename) do
+      {:ok, _storage_ref} -> :ok
+      {:error, _reason} -> {:error, :invalid_filename}
+    end
+  end
+
+  defp infer_content_type(filename) do
+    case MIME.from_path(filename) do
+      "" -> "application/octet-stream"
+      content_type -> content_type
+    end
+  end
+
+  defp infer_type(filename) do
+    filename
+    |> Path.extname()
+    |> String.downcase()
+    |> then(&Map.get(@extension_types, &1, "other"))
+  end
+
+  defp map_field(map, key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+end

--- a/lib/lemmings_os_web.ex
+++ b/lib/lemmings_os_web.ex
@@ -91,6 +91,7 @@ defmodule LemmingsOsWeb do
       alias Phoenix.LiveView.JS
 
       alias LemmingsOsWeb.{
+        ArtifactsComponents,
         CityMapComponents,
         ConnectionsComponents,
         HomeComponents,

--- a/lib/lemmings_os_web/components/artifacts_components.ex
+++ b/lib/lemmings_os_web/components/artifacts_components.ex
@@ -1,0 +1,146 @@
+defmodule LemmingsOsWeb.ArtifactsComponents do
+  @moduledoc """
+  Shared read-only Artifacts UI surface for world/city/department/lemming pages.
+  """
+
+  use LemmingsOsWeb, :html
+
+  alias LemmingsOs.Helpers
+
+  attr :id_prefix, :string, required: true
+  attr :rows, :list, default: []
+  attr :title, :string, default: nil
+  attr :subtitle, :string, default: nil
+
+  def artifact_surface(assigns) do
+    assigns =
+      assigns
+      |> assign(:title, assigns[:title] || dgettext("layout", "Artifacts"))
+      |> assign(
+        :subtitle,
+        assigns[:subtitle] || dgettext("layout", "Artifacts available at this scope.")
+      )
+
+    ~H"""
+    <.panel id={"#{@id_prefix}-artifacts-panel"} tone="info">
+      <:title>{@title}</:title>
+      <:subtitle>{@subtitle}</:subtitle>
+
+      <div :if={@rows == []} id={"#{@id_prefix}-artifacts-empty"} class="text-sm text-zinc-400">
+        {dgettext("layout", "No artifacts available for this scope.")}
+      </div>
+
+      <div :if={@rows != []} id={"#{@id_prefix}-artifacts-table-wrap"} class="overflow-x-auto">
+        <table class="min-w-full border-separate border-spacing-y-2 text-sm">
+          <caption class="sr-only">{dgettext("layout", "Artifacts")}</caption>
+          <thead class="text-left text-xs uppercase tracking-wider text-zinc-400">
+            <tr>
+              <th class="px-2 py-1">{dgettext("layout", "Filename")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Scope")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Type")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Status")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Size")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Created")}</th>
+              <th class="px-2 py-1">{dgettext("layout", "Actions")}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              :for={row <- @rows}
+              id={"#{@id_prefix}-artifacts-row-#{row.id}"}
+              class="bg-zinc-950/70 align-top"
+            >
+              <td
+                id={"#{@id_prefix}-artifacts-filename-#{row.id}"}
+                class="px-2 py-2 font-medium text-zinc-100"
+              >
+                {Helpers.display_value(row.filename)}
+              </td>
+              <td id={"#{@id_prefix}-artifacts-scope-#{row.id}"} class="px-2 py-2">
+                <div class="flex flex-wrap gap-1.5">
+                  <.badge
+                    :if={present_text?(row.city_slug)}
+                    id={"#{@id_prefix}-artifacts-context-city-#{row.id}"}
+                    tone="info"
+                  >
+                    {dgettext("layout", "city")}:{row.city_slug}
+                  </.badge>
+                  <.badge
+                    :if={present_text?(row.department_slug)}
+                    id={"#{@id_prefix}-artifacts-context-department-#{row.id}"}
+                    tone="warning"
+                  >
+                    {dgettext("layout", "dept")}:{row.department_slug}
+                  </.badge>
+                  <.badge
+                    :if={present_text?(row.lemming_slug)}
+                    id={"#{@id_prefix}-artifacts-context-lemming-#{row.id}"}
+                    tone="success"
+                  >
+                    {dgettext("layout", "lemming")}:{row.lemming_slug}
+                  </.badge>
+                  <.badge
+                    :if={
+                      !present_text?(row.city_slug) and !present_text?(row.department_slug) and
+                        !present_text?(row.lemming_slug)
+                    }
+                    id={"#{@id_prefix}-artifacts-context-world-#{row.id}"}
+                    tone="default"
+                  >
+                    {dgettext("layout", "world")}
+                  </.badge>
+                </div>
+              </td>
+              <td id={"#{@id_prefix}-artifacts-type-#{row.id}"} class="px-2 py-2 text-zinc-300">
+                {Helpers.display_value(row.type)}
+              </td>
+              <td id={"#{@id_prefix}-artifacts-status-#{row.id}"} class="px-2 py-2 text-zinc-300">
+                {Helpers.display_value(row.status)}
+              </td>
+              <td id={"#{@id_prefix}-artifacts-size-#{row.id}"} class="px-2 py-2 text-zinc-300">
+                {size_label(row.size_bytes)}
+              </td>
+              <td id={"#{@id_prefix}-artifacts-created-#{row.id}"} class="px-2 py-2 text-zinc-300">
+                {Helpers.format_datetime(row.inserted_at)}
+              </td>
+              <td id={"#{@id_prefix}-artifacts-actions-#{row.id}"} class="px-2 py-2 text-zinc-300">
+                <.link
+                  :if={download_href(row)}
+                  id={"#{@id_prefix}-artifacts-download-#{row.id}"}
+                  href={download_href(row)}
+                  class="inline-flex h-9 items-center justify-center gap-2 border-2 border-emerald-400/50 bg-emerald-400/10 px-3 text-xs font-medium text-emerald-300 shadow-lg transition duration-200 ease-out hover:-translate-y-px hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+                  aria-label={
+                    dgettext("layout", "Download Artifact %{filename}", filename: row.filename)
+                  }
+                >
+                  {dgettext("layout", "Download")}
+                </.link>
+                <span :if={!download_href(row)} class="text-zinc-500">-</span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </.panel>
+    """
+  end
+
+  defp size_label(size_bytes) when is_integer(size_bytes) and size_bytes >= 0,
+    do: "#{size_bytes} B"
+
+  defp size_label(_size_bytes), do: "-"
+
+  defp present_text?(value), do: is_binary(value) and String.trim(value) != ""
+
+  defp download_href(%{
+         id: artifact_id,
+         lemming_instance_id: instance_id,
+         world_id: world_id,
+         status: "ready"
+       })
+       when is_binary(artifact_id) and is_binary(instance_id) and is_binary(world_id) do
+    ~p"/lemmings/instances/#{instance_id}/artifacts/#{artifact_id}/download?#{%{world: world_id}}"
+  end
+
+  defp download_href(_row), do: nil
+end

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -221,10 +221,24 @@ defmodule LemmingsOsWeb.InstanceComponents do
       |> assign(:artifact_link, tool_artifact_link(assigns.tool_execution, assigns.world_id))
       |> assign(:promotion_form_id, "artifact-promotion-form-#{assigns.tool_execution.id}")
       |> assign(:promotion_status_id, "artifact-promotion-status-#{assigns.tool_execution.id}")
+      |> assign(:promotion_heading_id, "artifact-promotion-heading-#{assigns.tool_execution.id}")
+      |> assign(:promotion_help_id, "artifact-promotion-help-#{assigns.tool_execution.id}")
+      |> assign(
+        :promotion_help_summary_id,
+        "artifact-promotion-help-summary-#{assigns.tool_execution.id}"
+      )
+      |> assign(
+        :promotion_help_text_id,
+        "artifact-promotion-help-text-#{assigns.tool_execution.id}"
+      )
       |> assign(:artifact_reference_id, "artifact-reference-#{assigns.tool_execution.id}")
       |> assign(
         :artifact_notes_toggle_id,
         "artifact-reference-notes-toggle-#{assigns.tool_execution.id}"
+      )
+      |> assign(
+        :artifact_notes_summary_id,
+        "artifact-reference-notes-summary-#{assigns.tool_execution.id}"
       )
       |> assign(:artifact_notes_id, "artifact-reference-notes-#{assigns.tool_execution.id}")
 
@@ -262,7 +276,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 id={"tool-execution-summary-#{@tool_execution.id}"}
                 class="text-sm leading-6 text-zinc-200"
               >
-                <%= if @artifact_link do %>
+                <span :if={@artifact_link}>
                   {tool_summary_prefix(@tool_execution)}
                   <.link
                     href={@artifact_link.href}
@@ -272,9 +286,10 @@ defmodule LemmingsOsWeb.InstanceComponents do
                   >
                     {@artifact_link.label}
                   </.link>
-                <% else %>
+                </span>
+                <span :if={!@artifact_link}>
                   {tool_summary(@tool_execution)}
-                <% end %>
+                </span>
               </p>
             </div>
 
@@ -299,32 +314,39 @@ defmodule LemmingsOsWeb.InstanceComponents do
           <div
             :if={@promotion_candidate}
             class="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3"
+            role="region"
+            aria-labelledby={@promotion_heading_id}
           >
             <div class="flex flex-wrap items-start justify-between gap-3">
               <div class="space-y-1">
                 <div class="flex items-center gap-4">
-                  <p class="text-xs uppercase tracking-widest text-zinc-500">
+                  <p
+                    id={@promotion_heading_id}
+                    class="text-xs uppercase tracking-widest text-zinc-500"
+                  >
                     {dgettext("lemmings", "Artifact promotion")}
                   </p>
-                  <button
-                    id={"artifact-promotion-help-#{@tool_execution.id}"}
-                    type="button"
-                    title={
-                      dgettext(
+                  <details id={@promotion_help_id} class="relative">
+                    <summary
+                      id={@promotion_help_summary_id}
+                      aria-controls={@promotion_help_text_id}
+                      class="inline-flex size-6 cursor-pointer list-none items-center justify-center rounded-full border border-zinc-700 bg-zinc-900/70 text-xs font-semibold text-zinc-300 hover:border-zinc-500 hover:text-zinc-100"
+                    >
+                      <span aria-hidden="true">i</span>
+                      <span class="sr-only">
+                        {dgettext("lemmings", "Show Artifact help")}
+                      </span>
+                    </summary>
+                    <p
+                      id={@promotion_help_text_id}
+                      class="mt-2 max-w-sm rounded-lg border border-zinc-700 bg-zinc-950 px-2 py-1 text-xs leading-6 text-zinc-300"
+                    >
+                      {dgettext(
                         "lemmings",
                         "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
-                      )
-                    }
-                    aria-label={
-                      dgettext(
-                        "lemmings",
-                        "Artifact help: promoted durable file reference with metadata and lifecycle"
-                      )
-                    }
-                    class="inline-flex size-6 items-center justify-center rounded-full border border-zinc-700 bg-zinc-900/70 text-xs font-semibold text-zinc-300 hover:border-zinc-500 hover:text-zinc-100"
-                  >
-                    i
-                  </button>
+                      )}
+                    </p>
+                  </details>
                 </div>
                 <p
                   id={"artifact-promotion-source-#{@tool_execution.id}"}
@@ -343,6 +365,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
               id={@promotion_form_id}
               class="mt-3 flex flex-wrap gap-2"
               phx-submit="promote_workspace_artifact"
+              aria-describedby={"artifact-promotion-source-#{@tool_execution.id} #{@promotion_help_text_id} #{@promotion_status_id}"}
             >
               <input
                 id={"artifact-promotion-tool-execution-id-#{@tool_execution.id}"}
@@ -361,7 +384,9 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 :if={@promotion_action == :promote}
                 id={"artifact-promote-button-#{@tool_execution.id}"}
                 type="submit"
+                phx-disable-with={dgettext("lemmings", "Promoting...")}
                 aria-label={dgettext("lemmings", "Promote workspace file to Artifact")}
+                aria-describedby={@promotion_status_id}
                 class="inline-flex min-h-10 items-center gap-2 border border-emerald-400/40 bg-emerald-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-emerald-300 transition duration-150 ease-out hover:-translate-y-px hover:border-emerald-300 hover:text-emerald-200"
               >
                 <.icon name="hero-arrow-up-tray" class="size-4" />
@@ -374,7 +399,9 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 type="submit"
                 name="artifact_promotion[mode]"
                 value="update_existing"
+                phx-disable-with={dgettext("lemmings", "Updating...")}
                 aria-label={dgettext("lemmings", "Update existing Artifact from workspace file")}
+                aria-describedby={@promotion_status_id}
                 class="inline-flex min-h-10 items-center gap-2 border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-amber-200 transition duration-150 ease-out hover:-translate-y-px hover:border-amber-300 hover:text-amber-100"
               >
                 <.icon name="hero-arrow-path" class="size-4" />
@@ -387,7 +414,9 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 type="submit"
                 name="artifact_promotion[mode]"
                 value="promote_as_new"
+                phx-disable-with={dgettext("lemmings", "Promoting...")}
                 aria-label={dgettext("lemmings", "Promote as new Artifact from workspace file")}
+                aria-describedby={@promotion_status_id}
                 class="inline-flex min-h-10 items-center gap-2 border border-sky-400/40 bg-sky-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-sky-200 transition duration-150 ease-out hover:-translate-y-px hover:border-sky-300 hover:text-sky-100"
               >
                 <.icon name="hero-document-duplicate" class="size-4" />
@@ -403,6 +432,10 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 if(@promotion_message.kind == :error, do: "text-red-300", else: "text-emerald-300")
               ]}
               role={if(@promotion_message.kind == :error, do: "alert", else: "status")}
+              aria-live={if(@promotion_message.kind == :error, do: "assertive", else: "polite")}
+              aria-atomic="true"
+              tabindex="-1"
+              phx-mounted={Phoenix.LiveView.JS.focus(to: "##{@promotion_status_id}")}
             >
               {@promotion_message.text}
             </p>
@@ -434,6 +467,11 @@ defmodule LemmingsOsWeb.InstanceComponents do
                   :if={artifact_download_link(@tool_execution, @promoted_artifact, @world_id)}
                   id={"artifact-reference-download-#{@tool_execution.id}"}
                   href={artifact_download_link(@tool_execution, @promoted_artifact, @world_id)}
+                  aria-label={
+                    dgettext("lemmings", "Download Artifact %{filename}",
+                      filename: @promoted_artifact.filename
+                    )
+                  }
                   class="text-xs uppercase tracking-widest text-sky-300 underline decoration-sky-400/40 underline-offset-4 hover:text-sky-200"
                 >
                   {dgettext("lemmings", "Download")}
@@ -445,7 +483,11 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 id={@artifact_notes_toggle_id}
                 class="mt-3 border-t border-emerald-400/20 pt-3"
               >
-                <summary class="cursor-pointer text-xs uppercase tracking-widest text-zinc-400">
+                <summary
+                  id={@artifact_notes_summary_id}
+                  aria-controls={@artifact_notes_id}
+                  class="cursor-pointer text-xs uppercase tracking-widest text-zinc-400"
+                >
                   {dgettext("lemmings", "Notes")}
                 </summary>
                 <p
@@ -471,8 +513,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 <pre
                   id={"tool-execution-args-#{@tool_execution.id}"}
                   class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
-                  phx-no-curly-interpolation
-                ><%= @args_payload %></pre>
+                >{@args_payload}</pre>
               </div>
 
               <div :if={@tool_execution.result}>
@@ -482,8 +523,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 <pre
                   id={"tool-execution-result-#{@tool_execution.id}"}
                   class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
-                  phx-no-curly-interpolation
-                ><%= @result_payload %></pre>
+                >{@result_payload}</pre>
               </div>
 
               <div :if={@tool_execution.error}>
@@ -493,8 +533,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 <pre
                   id={"tool-execution-error-#{@tool_execution.id}"}
                   class="mt-2 overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/80 p-3 text-xs leading-6 text-zinc-300"
-                  phx-no-curly-interpolation
-                ><%= @error_payload %></pre>
+                >{@error_payload}</pre>
               </div>
             </div>
           </details>

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -201,6 +201,10 @@ defmodule LemmingsOsWeb.InstanceComponents do
   attr :id, :string, required: true
   attr :tool_execution, :map, required: true
   attr :world_id, :string, default: nil
+  attr :promotion_candidate, :map, default: nil
+  attr :promoted_artifact, :map, default: nil
+  attr :promotion_action, :atom, default: :none
+  attr :promotion_message, :map, default: nil
   attr :display_now, :any, default: nil
   attr :class, :string, default: nil
 
@@ -215,6 +219,14 @@ defmodule LemmingsOsWeb.InstanceComponents do
       |> assign(:result_payload, tool_payload_json(assigns.tool_execution.result))
       |> assign(:error_payload, tool_payload_json(assigns.tool_execution.error))
       |> assign(:artifact_link, tool_artifact_link(assigns.tool_execution, assigns.world_id))
+      |> assign(:promotion_form_id, "artifact-promotion-form-#{assigns.tool_execution.id}")
+      |> assign(:promotion_status_id, "artifact-promotion-status-#{assigns.tool_execution.id}")
+      |> assign(:artifact_reference_id, "artifact-reference-#{assigns.tool_execution.id}")
+      |> assign(
+        :artifact_notes_toggle_id,
+        "artifact-reference-notes-toggle-#{assigns.tool_execution.id}"
+      )
+      |> assign(:artifact_notes_id, "artifact-reference-notes-#{assigns.tool_execution.id}")
 
     ~H"""
     <article
@@ -283,6 +295,155 @@ defmodule LemmingsOsWeb.InstanceComponents do
           >
             {tool_preview(@tool_execution)}
           </p>
+
+          <div
+            :if={@promotion_candidate}
+            class="mt-3 rounded-xl border border-zinc-800 bg-zinc-950/70 p-3"
+          >
+            <div class="flex flex-wrap items-start justify-between gap-3">
+              <div class="space-y-1">
+                <div class="flex items-center gap-4">
+                  <p class="text-xs uppercase tracking-widest text-zinc-500">
+                    {dgettext("lemmings", "Artifact promotion")}
+                  </p>
+                  <button
+                    id={"artifact-promotion-help-#{@tool_execution.id}"}
+                    type="button"
+                    title={
+                      dgettext(
+                        "lemmings",
+                        "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
+                      )
+                    }
+                    aria-label={
+                      dgettext(
+                        "lemmings",
+                        "Artifact help: promoted durable file reference with metadata and lifecycle"
+                      )
+                    }
+                    class="inline-flex size-6 items-center justify-center rounded-full border border-zinc-700 bg-zinc-900/70 text-xs font-semibold text-zinc-300 hover:border-zinc-500 hover:text-zinc-100"
+                  >
+                    i
+                  </button>
+                </div>
+                <p
+                  id={"artifact-promotion-source-#{@tool_execution.id}"}
+                  class="break-words font-mono text-xs leading-6 text-zinc-400"
+                >
+                  {@promotion_candidate.relative_path}
+                </p>
+              </div>
+              <.badge :if={@promoted_artifact} tone="success">
+                {dgettext("lemmings", "Promoted")}
+              </.badge>
+            </div>
+
+            <form
+              :if={@promotion_action in [:promote, :update_existing]}
+              id={@promotion_form_id}
+              class="mt-3 flex flex-wrap gap-2"
+              phx-submit="promote_workspace_artifact"
+            >
+              <input
+                id={"artifact-promotion-tool-execution-id-#{@tool_execution.id}"}
+                type="hidden"
+                name="artifact_promotion[tool_execution_id]"
+                value={@tool_execution.id}
+              />
+              <input
+                id={"artifact-promotion-relative-path-#{@tool_execution.id}"}
+                type="hidden"
+                name="artifact_promotion[relative_path]"
+                value={@promotion_candidate.relative_path}
+              />
+
+              <button
+                :if={@promotion_action == :promote}
+                id={"artifact-promote-button-#{@tool_execution.id}"}
+                type="submit"
+                aria-label={dgettext("lemmings", "Promote workspace file to Artifact")}
+                class="inline-flex min-h-10 items-center gap-2 border border-emerald-400/40 bg-emerald-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-emerald-300 transition duration-150 ease-out hover:-translate-y-px hover:border-emerald-300 hover:text-emerald-200"
+              >
+                <.icon name="hero-arrow-up-tray" class="size-4" />
+                {dgettext("lemmings", "Promote to Artifact")}
+              </button>
+
+              <button
+                :if={@promotion_action == :update_existing}
+                id={"artifact-update-button-#{@tool_execution.id}"}
+                type="submit"
+                name="artifact_promotion[mode]"
+                value="update_existing"
+                aria-label={dgettext("lemmings", "Update existing Artifact from workspace file")}
+                class="inline-flex min-h-10 items-center gap-2 border border-amber-400/40 bg-amber-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-amber-200 transition duration-150 ease-out hover:-translate-y-px hover:border-amber-300 hover:text-amber-100"
+              >
+                <.icon name="hero-arrow-path" class="size-4" />
+                {dgettext("lemmings", "Update Artifact")}
+              </button>
+            </form>
+
+            <p
+              :if={@promotion_message}
+              id={@promotion_status_id}
+              class={[
+                "mt-3 text-sm",
+                if(@promotion_message.kind == :error, do: "text-red-300", else: "text-emerald-300")
+              ]}
+              role={if(@promotion_message.kind == :error, do: "alert", else: "status")}
+            >
+              {@promotion_message.text}
+            </p>
+            <section
+              :if={@promoted_artifact}
+              id={@artifact_reference_id}
+              class="mt-3 rounded-xl border border-emerald-400/20 bg-emerald-950/20 p-3"
+            >
+              <div class="flex flex-wrap items-center justify-between gap-3 text-xs">
+                <p
+                  id={"artifact-reference-summary-#{@tool_execution.id}"}
+                  class="flex flex-wrap items-center gap-x-1.5 gap-y-1 text-zinc-200"
+                >
+                  <span class="font-mono text-emerald-200">{@promoted_artifact.filename}</span>
+                  <span class="text-zinc-500">({@promoted_artifact.status})</span>
+                  <span class="text-zinc-300">{@promoted_artifact.type}</span>
+                  <span class="text-zinc-500">-</span>
+                  <span class="text-zinc-300">
+                    {artifact_size_label(@promoted_artifact.size_bytes)}
+                  </span>
+                  <span class="text-zinc-500">.</span>
+                  <span class="text-zinc-400">
+                    {dgettext("lemmings", "Created")} {artifact_created_at_label(
+                      @promoted_artifact.inserted_at
+                    )}
+                  </span>
+                </p>
+                <.link
+                  :if={artifact_download_link(@tool_execution, @promoted_artifact, @world_id)}
+                  id={"artifact-reference-download-#{@tool_execution.id}"}
+                  href={artifact_download_link(@tool_execution, @promoted_artifact, @world_id)}
+                  class="text-xs uppercase tracking-widest text-sky-300 underline decoration-sky-400/40 underline-offset-4 hover:text-sky-200"
+                >
+                  {dgettext("lemmings", "Download")}
+                </.link>
+              </div>
+
+              <details
+                :if={present_text?(@promoted_artifact.notes)}
+                id={@artifact_notes_toggle_id}
+                class="mt-3 border-t border-emerald-400/20 pt-3"
+              >
+                <summary class="cursor-pointer text-xs uppercase tracking-widest text-zinc-400">
+                  {dgettext("lemmings", "Notes")}
+                </summary>
+                <p
+                  id={@artifact_notes_id}
+                  class="mt-2 whitespace-pre-wrap break-words text-sm text-zinc-200"
+                >
+                  {@promoted_artifact.notes}
+                </p>
+              </details>
+            </section>
+          </div>
 
           <details id={@tool_details_id} class="mt-3 border-t border-zinc-800 pt-3">
             <summary class="cursor-pointer text-xs uppercase tracking-widest text-zinc-500">
@@ -878,6 +1039,31 @@ defmodule LemmingsOsWeb.InstanceComponents do
 
   defp tool_artifact_label(%{result: %{path: path}}) when is_binary(path) and path != "", do: path
   defp tool_artifact_label(_tool_execution), do: nil
+
+  defp artifact_download_link(
+         %{lemming_instance_id: instance_id},
+         %{id: artifact_id, status: "ready"},
+         world_id
+       )
+       when is_binary(instance_id) and is_binary(artifact_id) and is_binary(world_id) and
+              world_id != "" do
+    ~p"/lemmings/instances/#{instance_id}/artifacts/#{artifact_id}/download?#{%{world: world_id}}"
+  end
+
+  defp artifact_download_link(_tool_execution, _artifact, _world_id), do: nil
+
+  defp artifact_size_label(size_bytes) when is_integer(size_bytes) and size_bytes >= 0,
+    do: dgettext("lemmings", "%{count} bytes", count: size_bytes)
+
+  defp artifact_size_label(_size_bytes), do: dgettext("lemmings", "Unknown size")
+
+  defp artifact_created_at_label(%DateTime{} = inserted_at),
+    do: Calendar.strftime(inserted_at, "%Y-%m-%d %H:%M UTC")
+
+  defp artifact_created_at_label(_inserted_at), do: dgettext("lemmings", "Unknown time")
+
+  defp present_text?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present_text?(_value), do: false
 
   defp ensure_trailing_space(value) when is_binary(value) and value != "" do
     if String.ends_with?(value, " "), do: value, else: value <> " "

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -380,6 +380,19 @@ defmodule LemmingsOsWeb.InstanceComponents do
                 <.icon name="hero-arrow-path" class="size-4" />
                 {dgettext("lemmings", "Update Artifact")}
               </button>
+
+              <button
+                :if={@promotion_action == :update_existing}
+                id={"artifact-promote-as-new-button-#{@tool_execution.id}"}
+                type="submit"
+                name="artifact_promotion[mode]"
+                value="promote_as_new"
+                aria-label={dgettext("lemmings", "Promote as new Artifact from workspace file")}
+                class="inline-flex min-h-10 items-center gap-2 border border-sky-400/40 bg-sky-400/10 px-3 py-2 text-xs font-medium uppercase tracking-widest text-sky-200 transition duration-150 ease-out hover:-translate-y-px hover:border-sky-300 hover:text-sky-100"
+              >
+                <.icon name="hero-document-duplicate" class="size-4" />
+                {dgettext("lemmings", "Promote as New Artifact")}
+              </button>
             </form>
 
             <p

--- a/lib/lemmings_os_web/components/lemming_components.ex
+++ b/lib/lemmings_os_web/components/lemming_components.ex
@@ -159,6 +159,8 @@ defmodule LemmingsOsWeb.LemmingComponents do
   attr :overview_path, :string, default: nil
   attr :edit_path, :string, default: nil
   attr :secrets_path, :string, default: nil
+  attr :artifacts_path, :string, default: nil
+  attr :artifact_rows, :list, default: []
   attr :secret_form, :any, default: nil
   attr :secret_metadata, :list, default: []
   attr :secret_activity, :list, default: []
@@ -292,6 +294,8 @@ defmodule LemmingsOsWeb.LemmingComponents do
           overview_path={@overview_path}
           edit_path={@edit_path}
           secrets_path={@secrets_path}
+          artifacts_path={@artifacts_path}
+          artifact_rows={@artifact_rows}
           secret_form={@secret_form}
           secret_metadata={@secret_metadata}
           secret_activity={@secret_activity}
@@ -320,6 +324,8 @@ defmodule LemmingsOsWeb.LemmingComponents do
   attr :overview_path, :string, default: nil
   attr :edit_path, :string, default: nil
   attr :secrets_path, :string, default: nil
+  attr :artifacts_path, :string, default: nil
+  attr :artifact_rows, :list, default: []
   attr :secret_form, :any, default: nil
   attr :secret_metadata, :list, default: []
   attr :secret_activity, :list, default: []
@@ -369,6 +375,14 @@ defmodule LemmingsOsWeb.LemmingComponents do
           class={detail_tab_class(@active_tab == "secrets")}
         >
           {dgettext("world", ".tab_secrets")}
+        </.link>
+        <.link
+          id="lemming-tab-artifacts"
+          patch={@artifacts_path}
+          aria-current={if @active_tab == "artifacts", do: "page"}
+          class={detail_tab_class(@active_tab == "artifacts")}
+        >
+          {dgettext("layout", "Artifacts")}
         </.link>
       </div>
 
@@ -563,6 +577,12 @@ defmodule LemmingsOsWeb.LemmingComponents do
         edit_event="edit_lemming_secret"
         delete_event="delete_lemming_secret"
         subtitle={dgettext("world", ".secret_lemming_subtitle")}
+      />
+
+      <ArtifactsComponents.artifact_surface
+        :if={@active_tab == "artifacts"}
+        id_prefix="lemming"
+        rows={@artifact_rows}
       />
     </.panel>
     """
@@ -1049,6 +1069,7 @@ defmodule LemmingsOsWeb.LemmingComponents do
 
   defp detail_mode_label("edit"), do: dgettext("lemmings", ".tab_edit")
   defp detail_mode_label("secrets"), do: dgettext("world", ".tab_secrets")
+  defp detail_mode_label("artifacts"), do: dgettext("layout", "Artifacts")
   defp detail_mode_label(_tab), do: dgettext("lemmings", ".tab_overview")
 
   defp detail_tab_class(true),

--- a/lib/lemmings_os_web/components/world_components.ex
+++ b/lib/lemmings_os_web/components/world_components.ex
@@ -22,6 +22,7 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, default: []
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :artifact_rows, :list, default: []
 
   def world_page(assigns) do
     assigns =
@@ -61,6 +62,7 @@ defmodule LemmingsOsWeb.WorldComponents do
         connection_rows={@connection_rows}
         connection_editing_id={@connection_editing_id}
         connection_edit_form={@connection_edit_form}
+        artifact_rows={@artifact_rows}
       />
     </.content_container>
     """
@@ -87,6 +89,7 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, required: true
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :artifact_rows, :list, default: []
 
   defp world_snapshot(assigns) do
     ~H"""
@@ -232,6 +235,15 @@ defmodule LemmingsOsWeb.WorldComponents do
         variant={tab_button_variant(@active_tab, "connections")}
       >
         {dgettext("layout", ".nav_connections")}
+      </.button>
+      <.button
+        id="world-tab-artifacts"
+        phx-click="select_tab"
+        phx-value-tab="artifacts"
+        aria_pressed={pressed_attr(@active_tab == "artifacts")}
+        variant={tab_button_variant(@active_tab, "artifacts")}
+      >
+        {dgettext("layout", "Artifacts")}
       </.button>
     </div>
 
@@ -517,6 +529,12 @@ defmodule LemmingsOsWeb.WorldComponents do
       lifecycle_event="world_connection_lifecycle"
       test_event="test_world_connection"
     />
+
+    <ArtifactsComponents.artifact_surface
+      :if={@active_tab == "artifacts"}
+      id_prefix="world"
+      rows={@artifact_rows}
+    />
     """
   end
 
@@ -755,6 +773,7 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, default: []
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :artifact_rows, :list, default: []
 
   def department_detail_page(assigns) do
     ~H"""
@@ -820,6 +839,16 @@ defmodule LemmingsOsWeb.WorldComponents do
           class={department_tab_class(@active_tab == "connections")}
         >
           {dgettext("layout", ".nav_connections")}
+        </.link>
+        <.link
+          id="department-tab-artifacts"
+          patch={
+            ~p"/departments?#{department_tab_params(@selected_city.id, @department.id, "artifacts")}"
+          }
+          aria-current={if @active_tab == "artifacts", do: "page"}
+          class={department_tab_class(@active_tab == "artifacts")}
+        >
+          {dgettext("layout", "Artifacts")}
         </.link>
       </div>
 
@@ -1216,6 +1245,12 @@ defmodule LemmingsOsWeb.WorldComponents do
         delete_event="delete_department_connection"
         lifecycle_event="department_connection_lifecycle"
         test_event="test_department_connection"
+      />
+
+      <ArtifactsComponents.artifact_surface
+        :if={@active_tab == "artifacts"}
+        id_prefix="department"
+        rows={@artifact_rows}
       />
     </.panel>
     """

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -1,4 +1,15 @@
 defmodule LemmingsOsWeb.InstanceArtifactController do
+  @moduledoc """
+  Serves workspace file downloads for a lemming instance.
+
+  This controller handles path-based workspace artifacts from
+  `/lemmings/instances/:id/artifacts/*path`, resolving the path through
+  `LemmingInstances.artifact_absolute_path/2` to enforce world scoping and
+  workspace path safety.
+
+  It is intentionally separate from durable Artifact-record downloads; it
+  streams files that exist in the runtime workspace.
+  """
   use LemmingsOsWeb, :controller
 
   alias LemmingsOs.LemmingInstances

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -1,24 +1,51 @@
 defmodule LemmingsOsWeb.InstanceArtifactController do
   @moduledoc """
-  Serves workspace file downloads for a lemming instance.
+  Serves instance-scoped artifact downloads.
 
-  This controller handles path-based workspace artifacts from
-  `/lemmings/instances/:id/artifacts/*path`, resolving the path through
-  `LemmingInstances.artifact_absolute_path/2` to enforce world scoping and
-  workspace path safety.
+  It supports:
 
-  It is intentionally separate from durable Artifact-record downloads; it
-  streams files that exist in the runtime workspace.
+  - Durable Artifact-record downloads from
+    `/lemmings/instances/:instance_id/artifacts/:artifact_id/download`
+  - Legacy workspace artifact path downloads from
+    `/lemmings/instances/:instance_id/artifacts/*path`
   """
   use LemmingsOsWeb, :controller
 
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Artifacts.LocalStorage
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.Worlds
 
-  def show(conn, %{"id" => id, "path" => path_segments} = params) when is_list(path_segments) do
+  def download(conn, %{"artifact_id" => artifact_id} = params) when is_binary(artifact_id) do
     with %{} = world <- resolve_world(params),
+         {:ok, instance_id} <- fetch_instance_id(params),
+         {:ok, instance} <- LemmingInstances.get_instance(instance_id, world: world),
+         {:ok, artifact} <- Artifacts.get_artifact_download(instance, artifact_id),
+         {:ok, absolute_path} <- LocalStorage.resolve_storage_ref(artifact.storage_ref),
+         {:ok, content} <- File.read(absolute_path) do
+      conn
+      |> put_resp_header("content-type", artifact.content_type)
+      |> put_resp_header("x-content-type-options", "nosniff")
+      |> put_resp_header("content-disposition", content_disposition(artifact.filename))
+      |> send_resp(200, content)
+    else
+      nil -> send_resp(conn, 404, "World not found")
+      {:error, :missing_instance_id} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :not_found} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :invalid_storage_ref} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :storage_unavailable} -> send_resp(conn, 404, "Artifact not found")
+      {:error, :enoent} -> send_resp(conn, 404, "Artifact not found")
+      {:error, _reason} -> send_resp(conn, 404, "Artifact not found")
+    end
+  end
+
+  def download(conn, _params), do: send_resp(conn, 404, "Artifact not found")
+
+  def show(conn, %{"path" => path_segments} = params) when is_list(path_segments) do
+    with %{} = world <- resolve_world(params),
+         {:ok, instance_id} <- fetch_instance_id(params),
          {:ok, instance} <-
-           LemmingsOs.LemmingInstances.get_instance(id, world: world, preload: [:lemming]),
+           LemmingInstances.get_instance(instance_id, world: world, preload: [:lemming]),
          relative_path <- Path.join(path_segments),
          {:ok, %{absolute_path: absolute_path, relative_path: normalized_path}} <-
            LemmingInstances.artifact_absolute_path(instance, relative_path),
@@ -33,6 +60,7 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
       |> send_resp(200, content)
     else
       nil -> send_resp(conn, 404, "World not found")
+      {:error, :missing_instance_id} -> send_resp(conn, 404, "Artifact not found")
       {:error, :not_found} -> send_resp(conn, 404, "Instance not found")
       {:error, :invalid_path} -> send_resp(conn, 404, "Artifact not found")
       {:error, :path_outside_workspace} -> send_resp(conn, 404, "Artifact not found")
@@ -42,6 +70,21 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
   end
 
   def show(conn, _params), do: send_resp(conn, 404, "Artifact not found")
+
+  defp fetch_instance_id(%{"instance_id" => instance_id})
+       when is_binary(instance_id) and instance_id != "",
+       do: {:ok, instance_id}
+
+  defp fetch_instance_id(%{"id" => instance_id})
+       when is_binary(instance_id) and instance_id != "",
+       do: {:ok, instance_id}
+
+  defp fetch_instance_id(_params), do: {:error, :missing_instance_id}
+
+  defp content_disposition(filename) when is_binary(filename) do
+    basename = filename |> Path.basename() |> String.replace("\"", "")
+    ~s(attachment; filename="#{basename}")
+  end
 
   defp resolve_world(%{"world" => world_id}) when is_binary(world_id) and world_id != "" do
     Worlds.get_world(world_id)

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -82,7 +82,12 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
   defp fetch_instance_id(_params), do: {:error, :missing_instance_id}
 
   defp content_disposition(filename) when is_binary(filename) do
-    basename = filename |> Path.basename() |> String.replace("\"", "")
+    basename =
+      filename
+      |> Path.basename()
+      |> String.replace("\"", "")
+      |> String.replace(~r/[\x00-\x1F\x7F]/, "")
+
     ~s(attachment; filename="#{basename}")
   end
 

--- a/lib/lemmings_os_web/live/cities_live.ex
+++ b/lib/lemmings_os_web/live/cities_live.ex
@@ -28,6 +28,7 @@ defmodule LemmingsOsWeb.CitiesLive do
 
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
+  alias LemmingsOs.Artifacts
   alias LemmingsOs.Connections
   alias LemmingsOs.Helpers
   alias LemmingsOs.SecretBank
@@ -36,7 +37,7 @@ defmodule LemmingsOsWeb.CitiesLive do
   alias LemmingsOsWeb.PageData.CitiesPageSnapshot
   require Logger
 
-  @detail_tabs ~w(overview secrets connections)
+  @detail_tabs ~w(overview secrets connections artifacts)
 
   def mount(params, _session, socket) do
     connection_types = Connections.list_connection_types()
@@ -60,6 +61,7 @@ defmodule LemmingsOsWeb.CitiesLive do
      |> assign(:city_connection_rows, [])
      |> assign(:city_connection_editing_id, nil)
      |> assign(:city_connection_edit_form, nil)
+     |> assign(:city_artifact_rows, [])
      |> load_snapshot(params)}
   end
 
@@ -454,6 +456,7 @@ defmodule LemmingsOsWeb.CitiesLive do
         |> stream(:cities, snapshot.cities, reset: true)
         |> assign_city_secret_surface(snapshot)
         |> assign_city_connection_surface(snapshot)
+        |> assign_city_artifact_surface(snapshot)
         |> put_shell_breadcrumb(shell_breadcrumb(snapshot))
 
       {:error, :not_found} ->
@@ -466,6 +469,7 @@ defmodule LemmingsOsWeb.CitiesLive do
         |> assign(:city_secret_env_policy, [])
         |> assign(:city_secret_activity, [])
         |> reset_city_connection_surface()
+        |> reset_city_artifact_surface()
         |> put_shell_breadcrumb([shell_item(:cities, "/cities")])
     end
   end
@@ -601,6 +605,37 @@ defmodule LemmingsOsWeb.CitiesLive do
     |> assign(:city_connection_editing_id, nil)
     |> assign(:city_connection_edit_form, nil)
   end
+
+  defp assign_city_artifact_surface(socket, %{selected_city: nil}),
+    do: reset_city_artifact_surface(socket)
+
+  defp assign_city_artifact_surface(socket, %{selected_city: %{id: city_id}} = snapshot)
+       when is_binary(city_id) do
+    with {:ok, world} <- fetch_snapshot_world(snapshot),
+         %City{} = city <- Cities.get_city(world, city_id),
+         {:ok, artifacts} <- Artifacts.list_artifacts_for_scope(city) do
+      artifacts =
+        artifacts
+        |> exact_city_artifacts(city)
+        |> Artifacts.decorate_scope_slugs()
+
+      assign(socket, :city_artifact_rows, artifacts)
+    else
+      _ -> reset_city_artifact_surface(socket)
+    end
+  end
+
+  defp assign_city_artifact_surface(socket, _snapshot), do: reset_city_artifact_surface(socket)
+
+  defp reset_city_artifact_surface(socket) do
+    assign(socket, :city_artifact_rows, [])
+  end
+
+  defp exact_city_artifacts(artifacts, %City{id: city_id}) when is_binary(city_id) do
+    Enum.filter(artifacts, &(&1.city_id == city_id))
+  end
+
+  defp exact_city_artifacts(_artifacts, _city), do: []
 
   defp load_selected_city_scope(%{
          assigns: %{snapshot: %{selected_city: %{id: city_id}} = snapshot}

--- a/lib/lemmings_os_web/live/cities_live.html.heex
+++ b/lib/lemmings_os_web/live/cities_live.html.heex
@@ -246,6 +246,15 @@
               >
                 {dgettext("layout", ".nav_connections")}
               </.button>
+              <.button
+                id="city-tab-artifacts"
+                type="button"
+                phx-click="select_city_tab"
+                phx-value-tab="artifacts"
+                variant={if(@selected_city_tab == "artifacts", do: "secondary", else: "neutral")}
+              >
+                {dgettext("layout", "Artifacts")}
+              </.button>
             </div>
 
             <div
@@ -318,6 +327,11 @@
             delete_event="delete_city_connection"
             lifecycle_event="city_connection_lifecycle"
             test_event="test_city_connection"
+          />
+          <ArtifactsComponents.artifact_surface
+            :if={@snapshot.selected_city && @selected_city_tab == "artifacts"}
+            id_prefix="city"
+            rows={@city_artifact_rows}
           />
           <.city_effective_config_panel
             :if={@snapshot.selected_city && @selected_city_tab == "overview"}

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -5,6 +5,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
 
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
+  alias LemmingsOs.Artifacts
   alias LemmingsOs.Config.Resolver
   alias LemmingsOs.Connections
   alias LemmingsOs.Departments
@@ -17,7 +18,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   alias LemmingsOsWeb.PageData.DepartmentCollaborationSnapshot
   require Logger
 
-  @detail_tabs ~w(overview lemmings settings secrets connections)
+  @detail_tabs ~w(overview lemmings settings secrets connections artifacts)
 
   def mount(_params, _session, socket) do
     connection_types = Connections.list_connection_types()
@@ -49,7 +50,8 @@ defmodule LemmingsOsWeb.DepartmentsLive do
      |> assign(:department_connection_create_open, false)
      |> assign(:department_connection_rows, [])
      |> assign(:department_connection_editing_id, nil)
-     |> assign(:department_connection_edit_form, nil)}
+     |> assign(:department_connection_edit_form, nil)
+     |> assign(:department_artifact_rows, [])}
   end
 
   def handle_params(params, _uri, socket) do
@@ -494,6 +496,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
         |> assign(:department_secret_env_policy, [])
         |> assign(:department_secret_activity, [])
         |> assign(:department_connection_rows, [])
+        |> assign(:department_artifact_rows, [])
         |> assign(
           :department_connection_create_form,
           ConnectionsSurface.create_form(socket.assigns.department_connection_types)
@@ -547,6 +550,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_secret_env_policy, [])
     |> assign(:department_secret_activity, [])
     |> assign(:department_connection_rows, [])
+    |> assign(:department_artifact_rows, [])
     |> assign(
       :department_connection_create_form,
       ConnectionsSurface.create_form(socket.assigns.department_connection_types)
@@ -572,6 +576,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_secret_env_policy, SecretBank.list_env_fallback_policy())
     |> assign(:department_secret_activity, SecretBank.list_recent_activity(department, limit: 10))
     |> assign(:department_connection_rows, Connections.list_visible_connections(department))
+    |> assign(:department_artifact_rows, list_scope_artifacts(department))
     |> assign(
       :department_connection_create_form,
       ConnectionsSurface.create_form(socket.assigns.department_connection_types)
@@ -682,4 +687,23 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   defp secret_form_with_key(bank_key) do
     to_form(%{"bank_key" => String.trim(bank_key || ""), "value" => ""}, as: :secret)
   end
+
+  defp list_scope_artifacts(scope) do
+    case Artifacts.list_artifacts_for_scope(scope) do
+      {:ok, artifacts} ->
+        artifacts
+        |> exact_scope_artifacts(scope)
+        |> Artifacts.decorate_scope_slugs()
+
+      {:error, :invalid_scope} ->
+        []
+    end
+  end
+
+  defp exact_scope_artifacts(artifacts, %Department{id: department_id})
+       when is_binary(department_id) do
+    Enum.filter(artifacts, &(&1.department_id == department_id))
+  end
+
+  defp exact_scope_artifacts(_artifacts, _scope), do: []
 end

--- a/lib/lemmings_os_web/live/departments_live.html.heex
+++ b/lib/lemmings_os_web/live/departments_live.html.heex
@@ -37,6 +37,7 @@
       connection_rows={@department_connection_rows}
       connection_editing_id={@department_connection_editing_id}
       connection_edit_form={@department_connection_edit_form}
+      artifact_rows={@department_artifact_rows}
     />
 
     <div

--- a/lib/lemmings_os_web/live/instance_live.ex
+++ b/lib/lemmings_os_web/live/instance_live.ex
@@ -267,7 +267,7 @@ defmodule LemmingsOsWeb.InstanceLive do
         message = artifact_promotion_error(reason)
 
         Logger.warning(
-          "artifact promotion failed tool_execution_id=#{tool_execution_id} relative_path=#{inspect(relative_path)} reason=#{inspect(reason)}",
+          "artifact promotion failed tool_execution_id=#{tool_execution_id} reason_token=#{promotion_reason_token(reason)}",
           world_id: socket.assigns.instance.world_id,
           city_id: socket.assigns.instance.city_id,
           department_id: socket.assigns.instance.department_id,
@@ -1290,5 +1290,15 @@ defmodule LemmingsOsWeb.InstanceLive do
     do: dgettext("lemmings", "Artifact promotion failed validation.")
 
   defp artifact_promotion_error(reason),
-    do: dgettext("lemmings", "Artifact promotion failed (%{reason}).", reason: inspect(reason))
+    do:
+      dgettext("lemmings", "Artifact promotion failed (%{reason}).",
+        reason: promotion_reason_token(reason)
+      )
+
+  defp promotion_reason_token(%Ecto.Changeset{}), do: "validation_failed"
+
+  defp promotion_reason_token({reason, _details}) when is_atom(reason),
+    do: Atom.to_string(reason)
+
+  defp promotion_reason_token(reason) when is_atom(reason), do: Atom.to_string(reason)
 end

--- a/lib/lemmings_os_web/live/instance_live.ex
+++ b/lib/lemmings_os_web/live/instance_live.ex
@@ -2,7 +2,9 @@ defmodule LemmingsOsWeb.InstanceLive do
   use LemmingsOsWeb, :live_view
 
   import LemmingsOsWeb.MockShell
+  require Logger
 
+  alias LemmingsOs.Artifacts
   alias LemmingsOs.LemmingCalls.PubSub, as: LemmingCallPubSub
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.LemmingInstances.PubSub, as: InstancePubSub
@@ -42,7 +44,8 @@ defmodule LemmingsOsWeb.InstanceLive do
         delegated_work_available_targets: [],
         delegated_work_active_count: 0,
         delegated_work_historical_count: 0,
-        delegated_parent_instance_path: nil
+        delegated_parent_instance_path: nil,
+        artifact_promotion_messages: %{}
       )
       |> stream(:messages, [], reset: true)
 
@@ -226,6 +229,60 @@ defmodule LemmingsOsWeb.InstanceLive do
     {:noreply, put_flash(socket, :info, dgettext("lemmings", "Workspace path copied."))}
   end
 
+  def handle_event(
+        "promote_workspace_artifact",
+        _params,
+        %{assigns: %{instance: nil}} = socket
+      ) do
+    {:noreply,
+     put_flash(socket, :error, dgettext("lemmings", "Unable to promote this file right now."))}
+  end
+
+  def handle_event("promote_workspace_artifact", %{"artifact_promotion" => params}, socket) do
+    tool_execution_id = normalize_id_param(Map.get(params, "tool_execution_id"))
+    relative_path = Map.get(params, "relative_path")
+    mode = normalize_promotion_mode(Map.get(params, "mode"))
+
+    attrs =
+      %{
+        relative_path: relative_path,
+        lemming_instance_id: socket.assigns.instance.id
+      }
+      |> maybe_put_value(:mode, mode)
+      |> maybe_put_value(:created_by_tool_execution_id, tool_execution_id)
+
+    case Artifacts.promote_workspace_file(instance_artifact_scope(socket.assigns.instance), attrs) do
+      {:ok, artifact} ->
+        message =
+          dgettext("lemmings", "Artifact promoted: %{filename}", filename: artifact.filename)
+
+        socket =
+          socket
+          |> put_artifact_promotion_message(tool_execution_id, :success, message)
+          |> load_instance(socket.assigns.instance.id, %{"world" => current_world_id(socket)})
+
+        {:noreply, socket}
+
+      {:error, reason} ->
+        message = artifact_promotion_error(reason)
+
+        Logger.warning(
+          "artifact promotion failed tool_execution_id=#{tool_execution_id} relative_path=#{inspect(relative_path)} reason=#{inspect(reason)}",
+          world_id: socket.assigns.instance.world_id,
+          city_id: socket.assigns.instance.city_id,
+          department_id: socket.assigns.instance.department_id,
+          lemming_id: socket.assigns.instance.lemming_id
+        )
+
+        socket =
+          socket
+          |> put_artifact_promotion_message(tool_execution_id, :error, message)
+          |> put_flash(:error, message)
+
+        {:noreply, socket}
+    end
+  end
+
   def handle_event(_event, _params, socket), do: {:noreply, socket}
 
   defp load_instance(socket, id, params) do
@@ -235,6 +292,7 @@ defmodule LemmingsOsWeb.InstanceLive do
           {:ok, instance} ->
             messages = LemmingInstances.list_messages(instance)
             tool_executions = LemmingTools.list_tool_executions(world, instance)
+            artifacts_by_filename = list_instance_artifacts_by_filename(instance)
             delegated_work = InstanceDelegationSnapshot.build(instance)
             runtime_state = runtime_state(instance)
             status_now = DateTime.utc_now() |> DateTime.truncate(:second)
@@ -264,6 +322,9 @@ defmodule LemmingsOsWeb.InstanceLive do
               transcript_entries(
                 messages,
                 tool_executions,
+                artifacts_by_filename,
+                socket.assigns.artifact_promotion_messages,
+                runtime_state,
                 delegated_work.calls,
                 delegated_work.mode,
                 instance
@@ -310,7 +371,8 @@ defmodule LemmingsOsWeb.InstanceLive do
       delegated_work_available_targets: [],
       delegated_work_active_count: 0,
       delegated_work_historical_count: 0,
-      delegated_parent_instance_path: nil
+      delegated_parent_instance_path: nil,
+      artifact_promotion_messages: %{}
     )
     |> stream(:messages, [], reset: true)
     |> cancel_status_tick()
@@ -728,11 +790,28 @@ defmodule LemmingsOsWeb.InstanceLive do
 
   defp follow_up_helper_copy(status), do: follow_up_status_copy(status)
 
-  defp transcript_entries(messages, tool_executions, delegated_calls, mode, instance)
+  defp transcript_entries(
+         messages,
+         tool_executions,
+         artifacts_by_filename,
+         promotion_messages,
+         runtime_state,
+         delegated_calls,
+         mode,
+         instance
+       )
        when is_list(messages) and is_list(tool_executions) and is_list(delegated_calls) do
     messages
     |> transcript_message_entries(delegated_calls, mode, instance)
-    |> Kernel.++(transcript_tool_execution_entries(tool_executions))
+    |> Kernel.++(
+      transcript_tool_execution_entries(
+        tool_executions,
+        artifacts_by_filename,
+        promotion_messages,
+        runtime_state,
+        instance
+      )
+    )
     |> Kernel.++(transcript_delegated_call_entries(delegated_calls, mode))
     |> Enum.sort_by(&transcript_sort_key/1)
     |> inject_transcript_day_dividers()
@@ -792,13 +871,32 @@ defmodule LemmingsOsWeb.InstanceLive do
     end)
   end
 
-  defp transcript_tool_execution_entries(tool_executions) do
+  defp transcript_tool_execution_entries(
+         tool_executions,
+         artifacts_by_filename,
+         promotion_messages,
+         runtime_state,
+         instance
+       ) do
     Enum.map(tool_executions, fn tool_execution ->
+      promotion_candidate = tool_execution_promotion_candidate(tool_execution)
+      promoted_artifact = artifact_for_candidate(promotion_candidate, artifacts_by_filename)
+
       %{
         id: "tool-execution-#{tool_execution.id}",
         type: :tool_execution,
         inserted_at: Map.get(tool_execution, :inserted_at),
-        tool_execution: tool_execution
+        tool_execution: tool_execution,
+        promotion_candidate: promotion_candidate,
+        promoted_artifact: promoted_artifact,
+        promotion_action:
+          promotion_action_for_candidate(
+            promotion_candidate,
+            promoted_artifact,
+            runtime_state,
+            instance
+          ),
+        promotion_message: Map.get(promotion_messages, tool_execution.id)
       }
     end)
   end
@@ -931,4 +1029,266 @@ defmodule LemmingsOsWeb.InstanceLive do
        do: Map.get(call, :caller_instance_path)
 
   defp delegated_parent_instance_path(_delegated_work), do: nil
+
+  defp list_instance_artifacts_by_filename(instance) do
+    case Artifacts.list_artifacts_for_instance(
+           instance_artifact_scope(instance),
+           instance.id,
+           include_non_ready: true
+         ) do
+      {:ok, artifacts} ->
+        Enum.reduce(artifacts, %{}, fn artifact, acc ->
+          Map.put_new(acc, artifact.filename, artifact)
+        end)
+
+      {:error, _reason} ->
+        %{}
+    end
+  end
+
+  defp instance_artifact_scope(instance) do
+    %{
+      world_id: instance.world_id,
+      city_id: instance.city_id,
+      department_id: instance.department_id,
+      lemming_id: instance.lemming_id,
+      lemming_instance_id: instance.id
+    }
+  end
+
+  defp tool_execution_promotion_candidate(%{tool_name: "fs.write_text_file"} = tool_execution) do
+    case tool_execution_artifact_relative_path(tool_execution) do
+      path when is_binary(path) and path != "" ->
+        if safe_relative_path?(path) do
+          %{relative_path: path, filename: Path.basename(path)}
+        else
+          nil
+        end
+
+      _path ->
+        nil
+    end
+  end
+
+  defp tool_execution_promotion_candidate(_tool_execution), do: nil
+
+  defp artifact_for_candidate(%{filename: filename}, artifacts_by_filename)
+       when is_binary(filename) and is_map(artifacts_by_filename) do
+    Map.get(artifacts_by_filename, filename)
+  end
+
+  defp artifact_for_candidate(_candidate, _artifacts_by_filename), do: nil
+
+  defp promotion_action_for_candidate(nil, _promoted_artifact, _runtime_state, _instance),
+    do: :none
+
+  defp promotion_action_for_candidate(
+         %{relative_path: _relative_path},
+         nil,
+         _runtime_state,
+         _instance
+       ),
+       do: :promote
+
+  defp promotion_action_for_candidate(
+         %{relative_path: relative_path},
+         promoted_artifact,
+         runtime_state,
+         instance
+       ) do
+    case workspace_file_fingerprint(instance, runtime_state, relative_path) do
+      {:ok, fingerprint} ->
+        if fingerprint_matches_artifact?(fingerprint, promoted_artifact) do
+          :none
+        else
+          :update_existing
+        end
+
+      {:error, _reason} ->
+        :none
+    end
+  end
+
+  defp tool_execution_artifact_relative_path(%{args: %{"path" => path}})
+       when is_binary(path) and path != "",
+       do: path
+
+  defp tool_execution_artifact_relative_path(%{args: %{path: path}})
+       when is_binary(path) and path != "",
+       do: path
+
+  defp tool_execution_artifact_relative_path(%{result: %{"path" => path}})
+       when is_binary(path) and path != "",
+       do: path
+
+  defp tool_execution_artifact_relative_path(%{result: %{path: path}})
+       when is_binary(path) and path != "",
+       do: path
+
+  defp tool_execution_artifact_relative_path(_tool_execution), do: nil
+
+  defp safe_relative_path?(path) when is_binary(path) do
+    path_segments = String.split(path, "/", trim: true)
+
+    Path.type(path) == :relative and path_segments != [] and
+      Enum.all?(path_segments, &(&1 not in [".", ".."]))
+  end
+
+  defp workspace_file_fingerprint(instance, runtime_state, relative_path) do
+    with {:ok, absolute_path} <-
+           resolve_workspace_source_path(instance, runtime_state, relative_path),
+         {:ok, %File.Stat{size: size}} <- File.stat(absolute_path),
+         {:ok, checksum} <- file_checksum(absolute_path) do
+      {:ok, %{size_bytes: size, checksum: checksum}}
+    else
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_workspace_source_path(instance, runtime_state, relative_path) do
+    work_area_ref =
+      case Map.get(runtime_state, :work_area_ref) do
+        ref when is_binary(ref) and ref != "" -> ref
+        _other -> instance.id
+      end
+
+    case WorkArea.resolve(work_area_ref, relative_path) do
+      {:ok, %{absolute_path: absolute_path}} ->
+        if File.regular?(absolute_path) do
+          {:ok, absolute_path}
+        else
+          resolve_workspace_source_path_legacy(instance, relative_path)
+        end
+
+      {:error, :work_area_unavailable} ->
+        resolve_workspace_source_path_legacy(instance, relative_path)
+
+      {:error, :invalid_path} ->
+        {:error, :path_outside_workspace}
+    end
+  end
+
+  defp resolve_workspace_source_path_legacy(instance, relative_path) do
+    case LemmingInstances.artifact_absolute_path(instance, relative_path) do
+      {:ok, %{absolute_path: absolute_path}} ->
+        if File.regular?(absolute_path) do
+          {:ok, absolute_path}
+        else
+          {:error, :source_not_found}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp file_checksum(path) do
+    case File.open(path, [:read, :binary]) do
+      {:ok, device} ->
+        digest =
+          Enum.reduce(IO.binstream(device, 65_536), :crypto.hash_init(:sha256), fn chunk, acc ->
+            :crypto.hash_update(acc, chunk)
+          end)
+          |> :crypto.hash_final()
+          |> Base.encode16(case: :lower)
+
+        :ok = File.close(device)
+        {:ok, digest}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fingerprint_matches_artifact?(
+         %{size_bytes: size_bytes, checksum: checksum},
+         %{size_bytes: artifact_size_bytes, checksum: artifact_checksum}
+       )
+       when is_integer(size_bytes) and is_integer(artifact_size_bytes) and is_binary(checksum) and
+              is_binary(artifact_checksum) do
+    size_bytes == artifact_size_bytes and checksum == artifact_checksum
+  end
+
+  defp fingerprint_matches_artifact?(_fingerprint, _artifact), do: false
+
+  defp normalize_promotion_mode(""), do: nil
+  defp normalize_promotion_mode(nil), do: nil
+  defp normalize_promotion_mode(mode), do: mode
+
+  defp normalize_id_param(value) when is_binary(value) and value != "", do: value
+  defp normalize_id_param(_value), do: nil
+
+  defp maybe_put_value(map, _key, nil), do: map
+  defp maybe_put_value(map, key, value), do: Map.put(map, key, value)
+
+  defp put_artifact_promotion_message(socket, nil, _kind, _message), do: socket
+
+  defp put_artifact_promotion_message(socket, tool_execution_id, kind, message) do
+    message_data = %{kind: kind, text: message}
+    current = Map.get(socket.assigns, :artifact_promotion_messages, %{})
+
+    assign(
+      socket,
+      :artifact_promotion_messages,
+      Map.put(current, tool_execution_id, message_data)
+    )
+  end
+
+  defp artifact_promotion_error(:mode_required) do
+    dgettext(
+      "lemmings",
+      "An Artifact with this filename already exists. Update it after changing the workspace file."
+    )
+  end
+
+  defp artifact_promotion_error(:invalid_mode),
+    do: dgettext("lemmings", "Choose a valid promotion action for this Artifact.")
+
+  defp artifact_promotion_error(:invalid_scope),
+    do: dgettext("lemmings", "Artifact promotion scope is invalid for this session.")
+
+  defp artifact_promotion_error(:instance_not_found),
+    do: dgettext("lemmings", "Runtime instance not found for Artifact promotion.")
+
+  defp artifact_promotion_error(:missing_instance_id),
+    do: dgettext("lemmings", "Artifact promotion is missing the runtime instance.")
+
+  defp artifact_promotion_error(:invalid_filename),
+    do: dgettext("lemmings", "This filename cannot be promoted as an Artifact.")
+
+  defp artifact_promotion_error(:path_outside_workspace),
+    do: dgettext("lemmings", "Only files inside this workspace can be promoted.")
+
+  defp artifact_promotion_error(:file_not_found),
+    do: dgettext("lemmings", "Workspace file not found for Artifact promotion.")
+
+  defp artifact_promotion_error(:source_not_found),
+    do: dgettext("lemmings", "Workspace file not found for Artifact promotion.")
+
+  defp artifact_promotion_error(:invalid_source_path),
+    do: dgettext("lemmings", "Workspace file path is invalid for Artifact promotion.")
+
+  defp artifact_promotion_error(:source_not_regular_file),
+    do: dgettext("lemmings", "Only regular files can be promoted as Artifacts.")
+
+  defp artifact_promotion_error(:storage_unavailable),
+    do: dgettext("lemmings", "Artifact storage is unavailable right now.")
+
+  defp artifact_promotion_error({:copy_failed, _reason}),
+    do: dgettext("lemmings", "Artifact file copy failed.")
+
+  defp artifact_promotion_error({:size_failed, _reason}),
+    do: dgettext("lemmings", "Artifact size calculation failed.")
+
+  defp artifact_promotion_error({:checksum_failed, _reason}),
+    do: dgettext("lemmings", "Artifact checksum calculation failed.")
+
+  defp artifact_promotion_error(:invalid_attrs),
+    do: dgettext("lemmings", "Artifact promotion request is invalid.")
+
+  defp artifact_promotion_error(%Ecto.Changeset{}),
+    do: dgettext("lemmings", "Artifact promotion failed validation.")
+
+  defp artifact_promotion_error(reason),
+    do: dgettext("lemmings", "Artifact promotion failed (%{reason}).", reason: inspect(reason))
 end

--- a/lib/lemmings_os_web/live/instance_live.html.heex
+++ b/lib/lemmings_os_web/live/instance_live.html.heex
@@ -363,6 +363,10 @@
                 id={"card-tool-execution-#{entry.tool_execution.id}"}
                 tool_execution={entry.tool_execution}
                 world_id={@world && @world.id}
+                promotion_candidate={Map.get(entry, :promotion_candidate)}
+                promoted_artifact={Map.get(entry, :promoted_artifact)}
+                promotion_action={Map.get(entry, :promotion_action)}
+                promotion_message={Map.get(entry, :promotion_message)}
                 display_now={@status_now}
               />
 

--- a/lib/lemmings_os_web/live/lemmings_live.ex
+++ b/lib/lemmings_os_web/live/lemmings_live.ex
@@ -5,6 +5,7 @@ defmodule LemmingsOsWeb.LemmingsLive do
 
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
+  alias LemmingsOs.Artifacts
   alias LemmingsOs.Config.Resolver
   alias LemmingsOs.Departments
   alias LemmingsOs.Departments.Department
@@ -47,6 +48,8 @@ defmodule LemmingsOsWeb.LemmingsLive do
        overview_path: nil,
        edit_path: nil,
        secrets_path: nil,
+       artifacts_path: nil,
+       lemming_artifact_rows: [],
        lemming_secret_form: blank_secret_form(),
        lemming_secret_metadata: [],
        lemming_secret_env_policy: [],
@@ -317,6 +320,8 @@ defmodule LemmingsOsWeb.LemmingsLive do
           overview_path: nil,
           edit_path: nil,
           secrets_path: nil,
+          artifacts_path: nil,
+          lemming_artifact_rows: [],
           lemming_secret_form: blank_secret_form(),
           lemming_secret_metadata: [],
           lemming_secret_env_policy: [],
@@ -352,6 +357,8 @@ defmodule LemmingsOsWeb.LemmingsLive do
       overview_path: nil,
       edit_path: nil,
       secrets_path: nil,
+      artifacts_path: nil,
+      lemming_artifact_rows: [],
       lemming_secret_form: blank_secret_form(),
       lemming_secret_metadata: [],
       lemming_secret_env_policy: [],
@@ -384,6 +391,8 @@ defmodule LemmingsOsWeb.LemmingsLive do
       overview_path: detail_path(lemming, socket, "overview"),
       edit_path: detail_path(lemming, socket, "edit"),
       secrets_path: detail_path(lemming, socket, "secrets"),
+      artifacts_path: detail_path(lemming, socket, "artifacts"),
+      lemming_artifact_rows: list_scope_artifacts(lemming),
       lemming_secret_metadata: SecretBank.list_effective_metadata(lemming),
       lemming_secret_env_policy: SecretBank.list_env_fallback_policy(),
       lemming_secret_activity: SecretBank.list_recent_activity(lemming, limit: 10)
@@ -606,6 +615,10 @@ defmodule LemmingsOsWeb.LemmingsLive do
 
   defp active_detail_tab(%{assigns: %{live_action: :show}}, %{"tab" => "edit"}), do: "edit"
   defp active_detail_tab(%{assigns: %{live_action: :show}}, %{"tab" => "secrets"}), do: "secrets"
+
+  defp active_detail_tab(%{assigns: %{live_action: :show}}, %{"tab" => "artifacts"}),
+    do: "artifacts"
+
   defp active_detail_tab(%{assigns: %{live_action: :show}}, _params), do: "overview"
   defp active_detail_tab(_socket, _params), do: "overview"
 
@@ -672,6 +685,24 @@ defmodule LemmingsOsWeb.LemmingsLive do
   end
 
   defp refresh_lemming_instances(socket), do: socket
+
+  defp list_scope_artifacts(scope) do
+    case Artifacts.list_artifacts_for_scope(scope) do
+      {:ok, artifacts} ->
+        artifacts
+        |> exact_scope_artifacts(scope)
+        |> Artifacts.decorate_scope_slugs()
+
+      {:error, :invalid_scope} ->
+        []
+    end
+  end
+
+  defp exact_scope_artifacts(artifacts, %Lemming{id: lemming_id}) when is_binary(lemming_id) do
+    Enum.filter(artifacts, &(&1.lemming_id == lemming_id))
+  end
+
+  defp exact_scope_artifacts(_artifacts, _scope), do: []
 
   defp load_lemming_instances(%World{} = world, %Lemming{} = lemming) do
     world

--- a/lib/lemmings_os_web/live/lemmings_live.html.heex
+++ b/lib/lemmings_os_web/live/lemmings_live.html.heex
@@ -37,6 +37,8 @@
         overview_path={@overview_path}
         edit_path={@edit_path}
         secrets_path={@secrets_path}
+        artifacts_path={@artifacts_path}
+        artifact_rows={@lemming_artifact_rows}
         secret_form={@lemming_secret_form}
         secret_metadata={@lemming_secret_metadata}
         secret_env_policy={@lemming_secret_env_policy}

--- a/lib/lemmings_os_web/live/world_live.ex
+++ b/lib/lemmings_os_web/live/world_live.ex
@@ -5,6 +5,7 @@ defmodule LemmingsOsWeb.WorldLive do
 
   alias LemmingsOs.Cities
   alias LemmingsOs.Cities.City
+  alias LemmingsOs.Artifacts
   alias LemmingsOs.Connections
   alias LemmingsOs.Helpers
   alias LemmingsOs.SecretBank
@@ -35,6 +36,7 @@ defmodule LemmingsOsWeb.WorldLive do
      |> assign(:world_connection_rows, [])
      |> assign(:world_connection_editing_id, nil)
      |> assign(:world_connection_edit_form, nil)
+     |> assign(:world_artifact_rows, [])
      |> load_snapshot()}
   end
 
@@ -334,6 +336,7 @@ defmodule LemmingsOsWeb.WorldLive do
         |> assign(:last_import_result, normalize_import_result(import_result))
         |> assign_world_secret_surface(snapshot.world.id)
         |> assign_world_connection_surface(snapshot.world.id)
+        |> assign_world_artifact_surface(snapshot.world.id)
 
       {:error, :not_found} ->
         socket
@@ -352,6 +355,7 @@ defmodule LemmingsOsWeb.WorldLive do
         |> assign(:world_connection_create_open, false)
         |> assign(:world_connection_editing_id, nil)
         |> assign(:world_connection_edit_form, nil)
+        |> assign(:world_artifact_rows, [])
     end
   end
 
@@ -404,6 +408,7 @@ defmodule LemmingsOsWeb.WorldLive do
   defp normalize_tab("runtime"), do: "runtime"
   defp normalize_tab("secrets"), do: "secrets"
   defp normalize_tab("connections"), do: "connections"
+  defp normalize_tab("artifacts"), do: "artifacts"
   defp normalize_tab(_tab), do: "overview"
 
   defp load_world_scope(%{assigns: %{snapshot: %{world: %{id: world_id}}}})
@@ -465,6 +470,27 @@ defmodule LemmingsOsWeb.WorldLive do
     |> assign(:world_connection_create_open, false)
     |> assign(:world_connection_editing_id, nil)
     |> assign(:world_connection_edit_form, nil)
+  end
+
+  defp assign_world_artifact_surface(socket, world_id) when is_binary(world_id) do
+    case Worlds.get_world(world_id) do
+      %World{} = world -> assign_world_artifact_surface(socket, world)
+      nil -> assign_world_artifact_surface(socket, nil)
+    end
+  end
+
+  defp assign_world_artifact_surface(socket, %World{} = world) do
+    rows =
+      case Artifacts.list_artifacts_for_scope(world) do
+        {:ok, artifacts} -> Artifacts.decorate_scope_slugs(artifacts)
+        {:error, :invalid_scope} -> []
+      end
+
+    assign(socket, :world_artifact_rows, rows)
+  end
+
+  defp assign_world_artifact_surface(socket, nil) do
+    assign(socket, :world_artifact_rows, [])
   end
 
   defp blank_secret_form, do: to_form(%{"bank_key" => "", "value" => ""}, as: :secret)

--- a/lib/lemmings_os_web/live/world_live.html.heex
+++ b/lib/lemmings_os_web/live/world_live.html.heex
@@ -23,5 +23,6 @@
     connection_rows={@world_connection_rows}
     connection_editing_id={@world_connection_editing_id}
     connection_edit_form={@world_connection_edit_form}
+    artifact_rows={@world_artifact_rows}
   />
 </Layouts.app>

--- a/lib/lemmings_os_web/router.ex
+++ b/lib/lemmings_os_web/router.ex
@@ -30,7 +30,12 @@ defmodule LemmingsOsWeb.Router do
     live "/lemmings/import", ImportLemmingLive, :import
     live "/lemmings", LemmingsLive, :index
     live "/lemmings/:id", LemmingsLive, :show
-    get "/lemmings/instances/:id/artifacts/*path", InstanceArtifactController, :show
+
+    get "/lemmings/instances/:instance_id/artifacts/:artifact_id/download",
+        InstanceArtifactController,
+        :download
+
+    get "/lemmings/instances/:instance_id/artifacts/*path", InstanceArtifactController, :show
     get "/lemmings/instances/:id/raw.md", InstanceRawSnapshotController, :show
     live "/lemmings/instances/:id/raw", InstanceRawLive, :show
     live "/lemmings/instances/:id", InstanceLive, :show

--- a/llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md
+++ b/llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md
@@ -1,8 +1,8 @@
 # Task 01: Data Model and Schema
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ⏳ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-db-performance-architect` - Database architect for schema design, indexes, migrations, and query performance.

--- a/llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md
+++ b/llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md
@@ -1,0 +1,84 @@
+# Task 01: Data Model and Schema
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-db-performance-architect` - Database architect for schema design, indexes, migrations, and query performance.
+
+## Agent Invocation
+Act as `dev-db-performance-architect`. Implement only the durable Artifact data model and schema foundation.
+
+## Objective
+Add the `artifacts` table, `LemmingsOs.Artifacts.Artifact` schema, changeset validations, associations, factory support, and focused schema/migration tests.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Existing schemas under `lib/lemmings_os/**`
+- [ ] Existing migrations under `priv/repo/migrations/`
+- [ ] `test/support/factory.ex`
+
+## Expected Outputs
+- [ ] Migration creating `artifacts` with required fields, nullable provenance, timestamps, and explicit indexes for scope, provenance, and update lookup.
+- [ ] `LemmingsOs.Artifacts.Artifact` schema with `@required`, `@optional`, `changeset/2`, allowed type/status validation, metadata default, metadata contract validation, and associations.
+- [ ] Factory support for valid Artifact test data.
+- [ ] Focused tests for required fields, allowed `type`, allowed `status`, metadata default, metadata contract validation, and scope shape validation.
+
+## Acceptance Criteria
+- [ ] `world_id`, `filename`, `type`, `content_type`, `storage_ref`, `size_bytes`, `checksum`, `status`, and `metadata` are validated.
+- [ ] `metadata` is not used as arbitrary free-form tool output.
+- [ ] `metadata` is validated through a small embedded/schema-like contract.
+- [ ] Initial allowed metadata may be limited to `source: "manual_promotion"`.
+- [ ] `metadata` must not contain raw prompts, model output, tool output, file contents, debug dumps, or secrets.
+- [ ] `type` accepts only `markdown | pdf | json | csv | email | html | image | text | other`.
+- [ ] `status` accepts only `ready | archived | deleted | error`.
+- [ ] Provenance FKs to instance/tool execution nilify on delete; owning hierarchy uses the safest behavior consistent with the source plan.
+- [ ] Add an index on `world_id`.
+- [ ] Add an index on `(world_id, city_id, department_id)`.
+- [ ] Add an index on `lemming_instance_id`.
+- [ ] Add an index on `created_by_tool_execution_id`.
+- [ ] Add a non-unique update lookup index on `(world_id, city_id, department_id, lemming_id, filename)`.
+- [ ] Do not make the filename lookup index unique because `Promote as New Artifact` must remain possible.
+- [ ] No DB enums are introduced.
+- [ ] Validation messages use `dgettext("errors", ...)`.
+- [ ] Tests pass with the narrowest relevant command.
+
+## Technical Notes
+### Relevant Code Locations
+```
+priv/repo/migrations/                 # Migration patterns
+test/support/factory.ex               # Factory patterns
+lib/lemmings_os/lemming_instances/    # Existing instance/tool associations
+lib/lemmings_os/events/               # Existing generic event schema style
+```
+
+### Constraints
+- Do not implement storage copying, context APIs, download routes, or UI in this task.
+- Do not add dependencies.
+- Do not use map access syntax on structs.
+- Do not add Secret Bank access.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Create the migration and schema with tests.
+3. Keep the changes narrowly scoped to persistence/schema/factory.
+4. Run the narrowest relevant tests for the schema/migration changes.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Review migration rollback risk and FK behavior.
+2. Verify scope/provenance fields match the source plan.
+3. Confirm tests cover schema validation, metadata default, and metadata contract rejection cases.
+4. If approved: mark `[x]` on Approved.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md
+++ b/llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md
@@ -1,0 +1,75 @@
+# Task 02: Local Artifact Storage
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for Elixir/Phoenix contexts, filesystem boundaries, and tests.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Implement only the local Artifact storage boundary.
+
+## Objective
+Add configurable local managed storage for Artifact files, including safe storage refs, internal resolution, copy, checksum, and size calculation.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
+- [ ] `lib/lemmings_os/tools/work_area.ex`
+- [ ] Existing config files under `config/`
+
+## Expected Outputs
+- [ ] Config for `:artifact_storage` with `backend: :local` and env-overridable root path.
+- [ ] `LemmingsOs.Artifacts.LocalStorage` or equivalent module.
+- [ ] Safe copy into `<root>/<world_id>/<artifact_id>/<filename>`.
+- [ ] SHA-256 checksum and size calculation.
+- [ ] Opaque `local://artifacts/<world_id>/<artifact_id>/<filename>` storage refs.
+- [ ] Internal trusted resolution from storage ref to filesystem path.
+- [ ] Unit tests for storage path generation, invalid path rejection, copy, checksum, and size.
+
+## Acceptance Criteria
+- [ ] Database-facing values never contain raw workspace paths or resolved filesystem paths.
+- [ ] Storage root path is not logged or emitted in events.
+- [ ] Path traversal, absolute paths, backslash paths, drive-letter paths, null bytes, and symlink escapes are rejected where applicable.
+- [ ] Tests use temporary directories and restore app env after each test.
+- [ ] No Artifact context API or UI is implemented in this task.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/tools/work_area.ex     # Existing safe path handling patterns
+config/config.exs                      # App config defaults
+config/runtime.exs                     # Runtime env config if needed
+test/lemmings_os/tools/work_area_test.exs # Filesystem test patterns
+```
+
+### Constraints
+- Do not store file bytes in DB.
+- Do not add external storage backends.
+- Do not add dependencies.
+- Do not inspect file contents beyond checksum calculation.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Implement storage functions as a narrow internal boundary with typed tuple returns.
+3. Add deterministic tests using temp directories.
+4. Run narrow storage tests.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify path/ref behavior cannot leak or escape storage root.
+2. Confirm env/config defaults are documented enough for later docs task.
+3. Approve before Task 03 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md
+++ b/llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md
@@ -1,8 +1,8 @@
 # Task 02: Local Artifact Storage
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED 
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior backend engineer for Elixir/Phoenix contexts, filesystem boundaries, and tests.
@@ -14,29 +14,29 @@ Act as `dev-backend-elixir-engineer`. Implement only the local Artifact storage 
 Add configurable local managed storage for Artifact files, including safe storage refs, internal resolution, copy, checksum, and size calculation.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/coding_styles/elixir_tests.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
-- [ ] `lib/lemmings_os/tools/work_area.ex`
-- [ ] Existing config files under `config/`
+- [x] `llms/constitution.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/coding_styles/elixir_tests.md`
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
+- [x] `lib/lemmings_os/tools/work_area.ex`
+- [x] Existing config files under `config/`
 
 ## Expected Outputs
-- [ ] Config for `:artifact_storage` with `backend: :local` and env-overridable root path.
-- [ ] `LemmingsOs.Artifacts.LocalStorage` or equivalent module.
-- [ ] Safe copy into `<root>/<world_id>/<artifact_id>/<filename>`.
-- [ ] SHA-256 checksum and size calculation.
-- [ ] Opaque `local://artifacts/<world_id>/<artifact_id>/<filename>` storage refs.
-- [ ] Internal trusted resolution from storage ref to filesystem path.
-- [ ] Unit tests for storage path generation, invalid path rejection, copy, checksum, and size.
+- [x] Config for `:artifact_storage` with `backend: :local` and env-overridable root path.
+- [x] `LemmingsOs.Artifacts.LocalStorage` or equivalent module.
+- [x] Safe copy into `<root>/<world_id>/<artifact_id>/<filename>`.
+- [x] SHA-256 checksum and size calculation.
+- [x] Opaque `local://artifacts/<world_id>/<artifact_id>/<filename>` storage refs.
+- [x] Internal trusted resolution from storage ref to filesystem path.
+- [x] Unit tests for storage path generation, invalid path rejection, copy, checksum, and size.
 
 ## Acceptance Criteria
-- [ ] Database-facing values never contain raw workspace paths or resolved filesystem paths.
-- [ ] Storage root path is not logged or emitted in events.
-- [ ] Path traversal, absolute paths, backslash paths, drive-letter paths, null bytes, and symlink escapes are rejected where applicable.
-- [ ] Tests use temporary directories and restore app env after each test.
-- [ ] No Artifact context API or UI is implemented in this task.
+- [x] Database-facing values never contain raw workspace paths or resolved filesystem paths.
+- [x] Storage root path is not logged or emitted in events.
+- [x] Path traversal, absolute paths, backslash paths, drive-letter paths, null bytes, and symlink escapes are rejected where applicable.
+- [x] Tests use temporary directories and restore app env after each test.
+- [x] No Artifact context API or UI is implemented in this task.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -72,4 +72,19 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented local artifact storage boundary with config + runtime override and focused unit tests.
+
+### Assumptions
+- `store_copy/4` receives a trusted absolute source path from runtime/UI code.
+- Artifact storage backend for this phase is fixed to `:local`.
+
+### Files Changed
+- `config/config.exs`
+- `config/runtime.exs`
+- `lib/lemmings_os/artifacts/local_storage.ex`
+- `test/lemmings_os/artifacts/local_storage_test.exs`
+
+### Validation Commands
+- `mix format lib/lemmings_os/artifacts/local_storage.ex test/lemmings_os/artifacts/local_storage_test.exs config/config.exs config/runtime.exs`
+- `mix test test/lemmings_os/artifacts/local_storage_test.exs`
+- `mix precommit`

--- a/llms/tasks/0010_implement_artifact_model/03_artifacts_context_core.md
+++ b/llms/tasks/0010_implement_artifact_model/03_artifacts_context_core.md
@@ -1,0 +1,76 @@
+# Task 03: Artifacts Context Core
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for explicit World-scoped context APIs.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Implement the core `LemmingsOs.Artifacts` context APIs without promotion or UI.
+
+## Objective
+Expose a small explicit-scope context for creating, retrieving, listing, and updating Artifact metadata and lifecycle status.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md`
+- [ ] Existing context examples such as `lib/lemmings_os/lemming_tools.ex`
+
+## Expected Outputs
+- [ ] `LemmingsOs.Artifacts` context module.
+- [ ] `create_artifact/2` for trusted metadata creation.
+- [ ] `get_artifact/2` with explicit scope and no global lookup.
+- [ ] `list_artifacts_for_instance/2`.
+- [ ] `list_artifacts_for_scope/2` using an opts keyword list and private multi-clause `filter_query/2`.
+- [ ] `update_artifact_status/3`.
+- [ ] Safe descriptor/read-model helper that omits storage refs and paths from normal public returns.
+- [ ] Tests for scope enforcement and status filtering.
+
+## Acceptance Criteria
+- [ ] Every public API requires an explicit persisted hierarchy scope struct or validated scope map, with World boundary enforcement.
+- [ ] Default list/get APIs only return `ready`.
+- [ ] Any API that can include `archived`, `deleted`, or `error` must be named or optioned explicitly and covered by tests.
+- [ ] Functions that can fail return `{:ok, value}` or `{:error, reason}`.
+- [ ] Public non-trivial functions include `@doc` and `@spec`.
+- [ ] Web code is not changed in this task.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/lemming_tools.ex       # Context pattern with explicit world/instance scope
+lib/lemmings_os/events.ex              # Scope normalization ideas
+lib/lemmings_os/worlds/world.ex        # World struct
+lib/lemmings_os/cities/city.ex         # City struct
+lib/lemmings_os/departments/department.ex # Department struct
+lib/lemmings_os/lemmings/lemming.ex    # Lemming struct
+```
+
+### Constraints
+- Do not implement workspace promotion in this task.
+- Do not resolve storage refs for downloads here except through internal storage boundary if needed by tests.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Implement context APIs with explicit scope clauses.
+3. Add focused DataCase tests for scope enforcement and status filtering.
+4. Run narrow context tests.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify no global Artifact lookup exists.
+2. Verify list APIs use opts and `filter_query/2` per constitution.
+3. Approve before Task 04 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/03_artifacts_context_core.md
+++ b/llms/tasks/0010_implement_artifact_model/03_artifacts_context_core.md
@@ -1,8 +1,8 @@
 # Task 03: Artifacts Context Core
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior backend engineer for explicit World-scoped context APIs.
@@ -14,30 +14,30 @@ Act as `dev-backend-elixir-engineer`. Implement the core `LemmingsOs.Artifacts` 
 Expose a small explicit-scope context for creating, retrieving, listing, and updating Artifact metadata and lifecycle status.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md`
-- [ ] Existing context examples such as `lib/lemmings_os/lemming_tools.ex`
+- [x] `llms/constitution.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] `llms/tasks/0010_implement_artifact_model/01_data_model_and_schema.md`
+- [x] `llms/tasks/0010_implement_artifact_model/02_local_artifact_storage.md`
+- [x] Existing context examples such as `lib/lemmings_os/lemming_tools.ex`
 
 ## Expected Outputs
-- [ ] `LemmingsOs.Artifacts` context module.
-- [ ] `create_artifact/2` for trusted metadata creation.
-- [ ] `get_artifact/2` with explicit scope and no global lookup.
-- [ ] `list_artifacts_for_instance/2`.
-- [ ] `list_artifacts_for_scope/2` using an opts keyword list and private multi-clause `filter_query/2`.
-- [ ] `update_artifact_status/3`.
-- [ ] Safe descriptor/read-model helper that omits storage refs and paths from normal public returns.
-- [ ] Tests for scope enforcement and status filtering.
+- [x] `LemmingsOs.Artifacts` context module.
+- [x] `create_artifact/2` for trusted metadata creation.
+- [x] `get_artifact/2` with explicit scope and no global lookup.
+- [x] `list_artifacts_for_instance/2`.
+- [x] `list_artifacts_for_scope/2` using an opts keyword list and private multi-clause `filter_query/2`.
+- [x] `update_artifact_status/3`.
+- [x] Safe descriptor/read-model helper that omits storage refs and paths from normal public returns.
+- [x] Tests for scope enforcement and status filtering.
 
 ## Acceptance Criteria
-- [ ] Every public API requires an explicit persisted hierarchy scope struct or validated scope map, with World boundary enforcement.
-- [ ] Default list/get APIs only return `ready`.
-- [ ] Any API that can include `archived`, `deleted`, or `error` must be named or optioned explicitly and covered by tests.
-- [ ] Functions that can fail return `{:ok, value}` or `{:error, reason}`.
-- [ ] Public non-trivial functions include `@doc` and `@spec`.
-- [ ] Web code is not changed in this task.
+- [x] Every public API requires an explicit persisted hierarchy scope struct or validated scope map, with World boundary enforcement.
+- [x] Default list/get APIs only return `ready`.
+- [x] Any API that can include `archived`, `deleted`, or `error` must be named or optioned explicitly and covered by tests.
+- [x] Functions that can fail return `{:ok, value}` or `{:error, reason}`.
+- [x] Public non-trivial functions include `@doc` and `@spec`.
+- [x] Web code is not changed in this task.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -73,4 +73,18 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented explicit-scope `LemmingsOs.Artifacts` context APIs for create/get/list/update with safe descriptors and default `ready` filtering.
+
+### Assumptions
+- Public read models should omit `storage_ref` by default.
+- Inclusion of non-`ready` statuses must be explicit via options.
+
+### Files Changed
+- `lib/lemmings_os/artifacts.ex`
+- `test/lemmings_os/artifacts_test.exs`
+
+### Validation Commands
+- `mix format lib/lemmings_os/artifacts.ex test/lemmings_os/artifacts_test.exs`
+- `mix test test/lemmings_os/artifacts_test.exs`
+- `mix test test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts/local_storage_test.exs`
+- `mix precommit`

--- a/llms/tasks/0010_implement_artifact_model/04_promotion_and_update_flow.md
+++ b/llms/tasks/0010_implement_artifact_model/04_promotion_and_update_flow.md
@@ -1,0 +1,78 @@
+# Task 04: Promotion and Update Flow
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for context workflows, Ecto.Multi, and filesystem side effects.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Implement manual workspace-file promotion and explicit update/new behavior in the backend context only.
+
+## Objective
+Add `promote_workspace_file/2` and update behavior that copies trusted workspace files into managed artifact storage, computes metadata, and creates or updates durable Artifact rows.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-03 outputs
+- [ ] `lib/lemmings_os/lemming_instances.ex` existing `artifact_absolute_path/2`
+- [ ] `lib/lemmings_os/tools/work_area.ex`
+
+## Expected Outputs
+- [ ] `promote_workspace_file/2` backend API.
+- [ ] Existing artifact lookup by `world_id + city_id + department_id + lemming_id + filename`.
+- [ ] Explicit `mode: :update_existing` that overwrites managed file, recomputes checksum/size, keeps same row, and returns safe descriptor.
+- [ ] Explicit `mode: :promote_as_new` for filename collision avoidance.
+- [ ] Failure handling that does not persist raw workspace paths or file contents.
+- [ ] Tests for success, update, promote-as-new, invalid path, missing file, checksum/size changes, and no original path persistence.
+
+## Acceptance Criteria
+- [ ] Promotion creates `ready` artifacts.
+- [ ] Original workspace file is copied, not moved.
+- [ ] Original workspace path is not stored in DB, logs, events, or returned descriptors.
+- [ ] Same-scope filename update never happens without explicit caller intent.
+- [ ] Backend promotion requires explicit `mode: :update_existing` or `mode: :promote_as_new` when an existing same-scope filename is present.
+- [ ] Backend default must not silently update; missing or ambiguous mode fails with a safe error.
+- [ ] UI may default the selected action to update, but the backend still receives explicit mode intent.
+- [ ] Multi-step durable operations use `Ecto.Multi` where appropriate.
+- [ ] No UI changes are made in this task.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/lemming_instances.ex   # Existing workspace artifact path resolver
+lib/lemmings_os/tools/work_area.ex     # Safer work area resolver patterns
+lib/lemmings_os/artifacts.ex           # Context from Task 03
+lib/lemmings_os/artifacts/local_storage.ex # Storage boundary from Task 02
+```
+
+### Constraints
+- Manual trusted UI/runtime promotion only.
+- No automatic LLM/tool promotion.
+- Do not scan contents for secrets.
+- Do not inject artifact contents into LLM context.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Implement backend promotion/update behavior only.
+3. Add DataCase tests with temp workspace/storage roots.
+4. Run narrow promotion/context tests.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify no silent overwrite path exists.
+2. Verify failure behavior does not leak paths/content.
+3. Approve before Task 05 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/04_promotion_and_update_flow.md
+++ b/llms/tasks/0010_implement_artifact_model/04_promotion_and_update_flow.md
@@ -1,8 +1,8 @@
 # Task 04: Promotion and Update Flow
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED 
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior backend engineer for context workflows, Ecto.Multi, and filesystem side effects.
@@ -14,32 +14,32 @@ Act as `dev-backend-elixir-engineer`. Implement manual workspace-file promotion 
 Add `promote_workspace_file/2` and update behavior that copies trusted workspace files into managed artifact storage, computes metadata, and creates or updates durable Artifact rows.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/coding_styles/elixir_tests.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] Tasks 01-03 outputs
-- [ ] `lib/lemmings_os/lemming_instances.ex` existing `artifact_absolute_path/2`
-- [ ] `lib/lemmings_os/tools/work_area.ex`
+- [x] `llms/constitution.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/coding_styles/elixir_tests.md`
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] Tasks 01-03 outputs
+- [x] `lib/lemmings_os/lemming_instances.ex` existing `artifact_absolute_path/2`
+- [x] `lib/lemmings_os/tools/work_area.ex`
 
 ## Expected Outputs
-- [ ] `promote_workspace_file/2` backend API.
-- [ ] Existing artifact lookup by `world_id + city_id + department_id + lemming_id + filename`.
-- [ ] Explicit `mode: :update_existing` that overwrites managed file, recomputes checksum/size, keeps same row, and returns safe descriptor.
-- [ ] Explicit `mode: :promote_as_new` for filename collision avoidance.
-- [ ] Failure handling that does not persist raw workspace paths or file contents.
-- [ ] Tests for success, update, promote-as-new, invalid path, missing file, checksum/size changes, and no original path persistence.
+- [x] `promote_workspace_file/2` backend API.
+- [x] Existing artifact lookup by `world_id + city_id + department_id + lemming_id + filename`.
+- [x] Explicit `mode: :update_existing` that overwrites managed file, recomputes checksum/size, keeps same row, and returns safe descriptor.
+- [x] Explicit `mode: :promote_as_new` for filename collision avoidance.
+- [x] Failure handling that does not persist raw workspace paths or file contents.
+- [x] Tests for success, update, promote-as-new, invalid path, missing file, checksum/size changes, and no original path persistence.
 
 ## Acceptance Criteria
-- [ ] Promotion creates `ready` artifacts.
-- [ ] Original workspace file is copied, not moved.
-- [ ] Original workspace path is not stored in DB, logs, events, or returned descriptors.
-- [ ] Same-scope filename update never happens without explicit caller intent.
-- [ ] Backend promotion requires explicit `mode: :update_existing` or `mode: :promote_as_new` when an existing same-scope filename is present.
-- [ ] Backend default must not silently update; missing or ambiguous mode fails with a safe error.
-- [ ] UI may default the selected action to update, but the backend still receives explicit mode intent.
-- [ ] Multi-step durable operations use `Ecto.Multi` where appropriate.
-- [ ] No UI changes are made in this task.
+- [x] Promotion creates `ready` artifacts.
+- [x] Original workspace file is copied, not moved.
+- [x] Original workspace path is not stored in DB, logs, events, or returned descriptors.
+- [x] Same-scope filename update never happens without explicit caller intent.
+- [x] Backend promotion requires explicit `mode: :update_existing` or `mode: :promote_as_new` when an existing same-scope filename is present.
+- [x] Backend default must not silently update; missing or ambiguous mode fails with a safe error.
+- [x] UI may default the selected action to update, but the backend still receives explicit mode intent.
+- [x] Multi-step durable operations use `Ecto.Multi` where appropriate.
+- [x] No UI changes are made in this task.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -75,4 +75,19 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented `promote_workspace_file/2` in `LemmingsOs.Artifacts` with explicit collision modes and managed-storage copy flow.
+
+### Assumptions
+- Promotion receives trusted runtime context plus a workspace-relative path.
+- When no same-scope filename collision exists, promotion creates a new artifact regardless of mode.
+
+### Files Changed
+- `lib/lemmings_os/artifacts.ex`
+- `lib/lemmings_os/artifacts/promotion.ex`
+- `test/lemmings_os/artifacts/promotion_test.exs`
+
+### Validation Commands
+- `mix format lib/lemmings_os/artifacts.ex lib/lemmings_os/artifacts/promotion.ex test/lemmings_os/artifacts/promotion_test.exs`
+- `mix test test/lemmings_os/artifacts/promotion_test.exs`
+- `mix test test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts/local_storage_test.exs`
+- `mix precommit`

--- a/llms/tasks/0010_implement_artifact_model/05_artifact_events_and_observability.md
+++ b/llms/tasks/0010_implement_artifact_model/05_artifact_events_and_observability.md
@@ -1,69 +1,93 @@
-# Task 05: Artifact Events and Observability
+# Task 05: Artifact Instrumentation and Safe Logging
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
-`dev-logging-daily-guardian` - Logging quality guardian for safe structured events and metadata hygiene.
+`dev-logging-daily-guardian` - Logging quality guardian for safe structured metadata hygiene.
 
 ## Agent Invocation
-Act as `dev-logging-daily-guardian`. Add safe Artifact lifecycle observability without changing product behavior.
+Act as `dev-logging-daily-guardian`. Add lightweight, safe Artifact observability without introducing durable audit/event persistence.
 
 ## Objective
-Emit durable/safe Artifact events for lifecycle operations and add tests proving event/log payloads do not leak content, filesystem paths, storage refs, notes, full metadata, or secret values.
+Add lightweight, safe Artifact observability without introducing durable audit/event persistence.
 
 ## Inputs Required
 - [ ] `llms/constitution.md`
 - [ ] `llms/coding_styles/elixir.md`
 - [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
 - [ ] Tasks 01-04 outputs
-- [ ] `lib/lemmings_os/events.ex`
-- [ ] `test/lemmings_os/events_test.exs`
+- [ ] Existing Artifact context/promotion code and tests
 
 ## Expected Outputs
-- [ ] `LemmingsOs.Artifacts.Events` or equivalent event helper.
-- [ ] Emission for `artifact.created`, `artifact.promoted`, `artifact.updated`, `artifact.status_changed`, `artifact.deleted`, `artifact.read`, `artifact.promotion_failed`, and `artifact.error` as implemented paths allow.
-- [ ] Allowlisted event payload fields from the source plan only.
-- [ ] Tests proving forbidden fields are absent.
+- [ ] Durable Artifact audit wrappers are removed or unused.
+- [ ] Artifact lifecycle code does not write to the `events` table.
+- [ ] Durable Artifact event tests are removed.
+- [ ] Minimal instrumentation tests are added only if actual non-durable instrumentation behavior exists.
+- [ ] Task and docs references are updated to the reduced scope.
 
 ## Acceptance Criteria
-- [ ] Event payloads include safe hierarchy/provenance IDs and artifact metadata only.
-- [ ] Event payloads exclude file contents, `storage_ref`, resolved filesystem path, raw workspace path, full metadata blindly, notes by default, and secret values.
-- [ ] Reason values are safe reason tokens, not exception dumps containing paths/content.
-- [ ] Telemetry/logging metadata includes hierarchy fields where relevant.
-- [ ] Existing generic `LemmingsOs.Events` is reused; no duplicate event table is introduced.
+- [ ] No durable Artifact audit/event rows are required.
+- [ ] No Artifact lifecycle writes to `events`.
+- [ ] Logs/telemetry, if present, use allowlisted safe fields only.
+- [ ] Payloads/log metadata exclude file contents, `storage_ref`, resolved paths, raw workspace paths, notes, full metadata, and secrets.
+- [ ] Reason values are normalized to safe reason tokens if logged.
 
 ## Technical Notes
-### Relevant Code Locations
-```
-lib/lemmings_os/events.ex              # Durable event API
-lib/lemmings_os/events/event.ex        # Event schema
-lib/lemmings_os/lemming_instances/executor/tool_lifecycle.ex # Logging metadata examples
-test/lemmings_os/events_test.exs       # Durable event test patterns
-```
-
 ### Constraints
-- Do not log storage roots, storage refs, raw workspace paths, or file contents.
-- Do not add UI.
-- Do not call Secret Bank.
+- Do not add a replacement durable Artifact event wrapper.
+- Do not emit durable `artifact.read`.
+- Do not call Secret Bank from Artifact code.
+- Keep existing Artifact schema/storage/promotion/download/UI behavior unchanged.
 
 ## Execution Instructions
 
 ### For the Agent
-1. Read all inputs listed above.
-2. Add event helper and wire it into completed Artifact context operations.
-3. Add leakage-focused tests with sentinel path/content values.
-4. Run narrow events/context tests.
-5. Document assumptions, files changed, and test commands in Execution Summary.
+1. Remove durable Artifact event/audit helper usage.
+2. Remove Artifact lifecycle writes to durable `events`.
+3. Remove durable event tests for Artifact operations.
+4. Update task/docs references to match reduced scope.
+5. Run required validation commands and record exact outcomes.
 
 ### For the Human Reviewer
 After agent completes:
-1. Inspect event payload allowlist manually.
-2. Verify no sensitive values appear in event/log tests.
-3. Approve before Task 06 begins.
+1. Verify no Artifact lifecycle path writes to `events`.
+2. Verify durable event assertions were removed from Artifact tests.
+3. Verify docs/task scope reflects instrumentation-only behavior.
 
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented scope reduction by removing Artifact durable audit/event persistence from this PR slice.
+
+### Code Changes
+- Removed durable event helper alias and durable-emission hooks from:
+  - `lib/lemmings_os/artifacts.ex`
+  - `lib/lemmings_os/artifacts/promotion.ex`
+- Deleted durable Artifact event wrapper module:
+  - `lib/lemmings_os/artifacts/audit_events.ex`
+
+### Test Changes
+- Removed durable event test file asserting `events` table lifecycle rows:
+  - `test/lemmings_os/artifacts/audit_events_test.exs`
+- No replacement instrumentation tests were added because this patch does not add new non-durable instrumentation behavior.
+
+### Docs/Plan Changes
+- Renamed Task 05 to **Artifact Instrumentation and Safe Logging** and rewrote objective/acceptance criteria for non-durable scope.
+- Updated plan/task docs to remove durable Artifact lifecycle event requirements and `artifact.read` durable emission expectations.
+- Added future-work note that platform audit/event design must be handled separately.
+
+### Validation Commands
+- `mix format lib/lemmings_os/artifacts.ex lib/lemmings_os/artifacts/promotion.ex`
+- `mix test test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs`
+- `mix test`
+- `mix precommit`
+- `rg -n "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib/lemmings_os/artifacts* test/lemmings_os/artifacts*`
+
+### Validation Results
+- `mix format ...`: success
+- `mix test test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs`: success (`10 doctests, 17 tests, 0 failures`)
+- `mix test`: success (`159 doctests, 743 tests, 0 failures`)
+- `mix precommit`: success (dialyzer, credo, and checks passed)
+- `rg ...`: no matches in Artifact code/tests (Artifact code has no Secret Bank calls)

--- a/llms/tasks/0010_implement_artifact_model/05_artifact_events_and_observability.md
+++ b/llms/tasks/0010_implement_artifact_model/05_artifact_events_and_observability.md
@@ -1,0 +1,69 @@
+# Task 05: Artifact Events and Observability
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-logging-daily-guardian` - Logging quality guardian for safe structured events and metadata hygiene.
+
+## Agent Invocation
+Act as `dev-logging-daily-guardian`. Add safe Artifact lifecycle observability without changing product behavior.
+
+## Objective
+Emit durable/safe Artifact events for lifecycle operations and add tests proving event/log payloads do not leak content, filesystem paths, storage refs, notes, full metadata, or secret values.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-04 outputs
+- [ ] `lib/lemmings_os/events.ex`
+- [ ] `test/lemmings_os/events_test.exs`
+
+## Expected Outputs
+- [ ] `LemmingsOs.Artifacts.Events` or equivalent event helper.
+- [ ] Emission for `artifact.created`, `artifact.promoted`, `artifact.updated`, `artifact.status_changed`, `artifact.deleted`, `artifact.read`, `artifact.promotion_failed`, and `artifact.error` as implemented paths allow.
+- [ ] Allowlisted event payload fields from the source plan only.
+- [ ] Tests proving forbidden fields are absent.
+
+## Acceptance Criteria
+- [ ] Event payloads include safe hierarchy/provenance IDs and artifact metadata only.
+- [ ] Event payloads exclude file contents, `storage_ref`, resolved filesystem path, raw workspace path, full metadata blindly, notes by default, and secret values.
+- [ ] Reason values are safe reason tokens, not exception dumps containing paths/content.
+- [ ] Telemetry/logging metadata includes hierarchy fields where relevant.
+- [ ] Existing generic `LemmingsOs.Events` is reused; no duplicate event table is introduced.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/events.ex              # Durable event API
+lib/lemmings_os/events/event.ex        # Event schema
+lib/lemmings_os/lemming_instances/executor/tool_lifecycle.ex # Logging metadata examples
+test/lemmings_os/events_test.exs       # Durable event test patterns
+```
+
+### Constraints
+- Do not log storage roots, storage refs, raw workspace paths, or file contents.
+- Do not add UI.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Add event helper and wire it into completed Artifact context operations.
+3. Add leakage-focused tests with sentinel path/content values.
+4. Run narrow events/context tests.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Inspect event payload allowlist manually.
+2. Verify no sensitive values appear in event/log tests.
+3. Approve before Task 06 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/06_test_scenarios_and_safety_matrix.md
+++ b/llms/tasks/0010_implement_artifact_model/06_test_scenarios_and_safety_matrix.md
@@ -1,8 +1,8 @@
 # Task 06: Test Scenarios and Safety Matrix
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-test-scenarios` - Test scenario designer for acceptance, edge-case, and regression coverage.
@@ -28,7 +28,7 @@ Document the full test coverage required for the Artifact model across schema, s
 
 ## Acceptance Criteria
 - [ ] Covers all acceptance criteria from the source plan.
-- [ ] Covers wrong-scope, archived/deleted/error, missing physical file, path traversal, symlink escape, and failure events.
+- [ ] Covers wrong-scope, archived/deleted/error, missing physical file, path traversal, symlink escape, and safe failure handling without durable Artifact lifecycle events.
 - [ ] Covers UI promotion/update/new flows and safe descriptor rendering.
 - [ ] Covers no Secret Bank access and no automatic LLM context injection.
 - [ ] References `llms/coding_styles/elixir_tests.md` expectations: factories, deterministic data, stable selectors, no external network.
@@ -62,4 +62,22 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented the Artifact test scenario and safety matrix deliverable for Task 06.
+
+### Deliverables Added
+- Added `llms/tasks/0010_implement_artifact_model/test_plan.md` with:
+  - Scope/assumptions and risk-based test areas.
+  - Scenario ID groups by layer (`SCH`, `STO`, `CTX`, `PRO`, `OBS`, `DL`, `UI`, `SEC`, `REL`).
+  - Implementation-aware scenario matrix covering schema, storage, context, promotion/update, observability, download route, LiveView UI, security, and release validation.
+  - Explicit acceptance-criteria-to-scenario mapping from `plan.md`.
+  - Leakage/security sentinel matrix including secret/path/storage-ref/content/note sentinel values.
+  - Given/When/Then acceptance bullets for high-risk behaviors.
+  - Required narrow test commands plus final `mix test` and `mix precommit`.
+
+### Key Coverage Confirmations
+- Includes wrong-scope access, archived/deleted/error status filtering, missing physical file handling, traversal/symlink escape rejection, and safe failure behavior without durable Artifact lifecycle events.
+- Includes UI promotion/update/new flow coverage and safe descriptor rendering constraints.
+- Includes explicit checks for:
+  - no Secret Bank access in Artifact modules
+  - no automatic LLM context injection of Artifact contents
+  - no leakage of `storage_ref`, resolved filesystem paths, workspace paths, notes, full metadata, or file contents in public outputs/logging.

--- a/llms/tasks/0010_implement_artifact_model/06_test_scenarios_and_safety_matrix.md
+++ b/llms/tasks/0010_implement_artifact_model/06_test_scenarios_and_safety_matrix.md
@@ -1,0 +1,65 @@
+# Task 06: Test Scenarios and Safety Matrix
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-test-scenarios` - Test scenario designer for acceptance, edge-case, and regression coverage.
+
+## Agent Invocation
+Act as `qa-test-scenarios`. Create an implementation-aware test scenario matrix; do not write production code.
+
+## Objective
+Document the full test coverage required for the Artifact model across schema, storage, context, promotion, events, download route, UI, security, accessibility, and final validation.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-05 outputs
+- [ ] Existing test patterns under `test/`
+
+## Expected Outputs
+- [ ] `llms/tasks/0010_implement_artifact_model/test_plan.md` or equivalent scenario matrix.
+- [ ] Scenario IDs grouped by test layer.
+- [ ] Explicit leakage/security matrix with sentinel values.
+- [ ] Required narrow test commands for later implementation and validation tasks.
+
+## Acceptance Criteria
+- [ ] Covers all acceptance criteria from the source plan.
+- [ ] Covers wrong-scope, archived/deleted/error, missing physical file, path traversal, symlink escape, and failure events.
+- [ ] Covers UI promotion/update/new flows and safe descriptor rendering.
+- [ ] Covers no Secret Bank access and no automatic LLM context injection.
+- [ ] References `llms/coding_styles/elixir_tests.md` expectations: factories, deterministic data, stable selectors, no external network.
+
+## Technical Notes
+### Relevant Code Locations
+```
+test/lemmings_os/                  # DataCase patterns
+test/lemmings_os_web/live/         # LiveView test patterns
+test/lemmings_os_web/controllers/  # Controller test patterns
+test/support/factory.ex            # Factory patterns
+```
+
+### Constraints
+- Do not implement tests in this task unless explicitly requested by the human.
+- Do not change production code.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Create the scenario matrix in the task directory.
+3. Include scenario-to-acceptance mapping and recommended commands.
+4. Document assumptions and any coverage risks in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify all source-plan acceptance criteria map to scenarios.
+2. Approve before Task 07 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
+++ b/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
@@ -1,7 +1,7 @@
 # Task 07: Download Route and Controller
 
 ## Status
-- **Status**: ⏳ PENDING
+- **Status**: ⏳ COMPLETED
 - **Approved**: [ ] Human sign-off
 
 ## Assigned Agent
@@ -66,4 +66,31 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Implemented durable Artifact download route and controller flow with strict ordering:
+  1) resolve world scope, 2) resolve instance in world scope, 3) resolve ready Artifact in instance scope, 4) resolve internal storage ref, 5) stream file with safe headers.
+- Added route ordering in router so durable download route is matched before workspace catch-all:
+  - `GET /lemmings/instances/:instance_id/artifacts/:artifact_id/download`
+  - `GET /lemmings/instances/:instance_id/artifacts/*path`
+- Added scoped internal context API `Artifacts.get_artifact_download/2` that returns minimal trusted download metadata (`id`, `filename`, `content_type`, `storage_ref`) and enforces ready-only status.
+- Updated `InstanceArtifactController`:
+  - Added `download/2` for durable Artifact IDs.
+  - Kept `show/2` workspace catch-all behavior intact.
+  - Added param normalization for `instance_id` vs legacy `id`.
+  - Normalized missing rows, invalid storage refs, missing files, and out-of-scope access to safe 404 responses without path leakage.
+- Added controller tests covering:
+  - authorized durable download + safe headers
+  - wrong-scope rejection
+  - archived/deleted/error status rejection
+  - missing physical file behavior without leakage
+  - invalid storage ref behavior
+  - regression coverage for existing workspace catch-all route
+- Files changed:
+  - `lib/lemmings_os_web/router.ex`
+  - `lib/lemmings_os/artifacts.ex`
+  - `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`
+  - `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+- Validation commands run:
+  - `mix format lib/lemmings_os_web/router.ex lib/lemmings_os_web/controllers/instance_artifact_controller.ex lib/lemmings_os/artifacts.ex test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+  - `mix test test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+  - `mix test test/lemmings_os/artifacts_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+  - `mix precommit`

--- a/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
+++ b/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
@@ -1,0 +1,70 @@
+# Task 07: Download Route and Controller
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for Phoenix controllers, scoped context calls, and safe file responses.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Implement controlled durable Artifact download/open behavior only.
+
+## Objective
+Add an ID-based Artifact download route/controller that checks visible scope and status before resolving managed storage and sending the file.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-06 outputs
+- [ ] `lib/lemmings_os_web/router.ex`
+- [ ] `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`
+
+## Expected Outputs
+- [ ] Route `GET /lemmings/instances/:instance_id/artifacts/:artifact_id/download` before existing workspace catch-all route.
+- [ ] Controller action that resolves world/scope, instance, Artifact, status, and storage path in safe order.
+- [ ] `artifact.read` event on successful read.
+- [ ] Safe handling for missing DB rows, wrong scope, bad status, missing physical file, and invalid storage ref.
+- [ ] Controller tests for authorized download, wrong scope, rejected status, missing file, and response header safety.
+
+## Acceptance Criteria
+- [ ] Scope check happens before internal storage ref/path resolution.
+- [ ] `archived`, `deleted`, and `error` Artifacts are not downloadable by default.
+- [ ] Response does not expose resolved filesystem path or storage root.
+- [ ] Existing workspace route remains functional and separate.
+- [ ] File response uses safe content disposition and `x-content-type-options: nosniff`.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os_web/router.ex                    # Route order matters
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex # Existing scratch route
+test/lemmings_os_web/live/instance_live_test.exs # Existing workspace artifact tests
+test/lemmings_os_web/controllers/                # Controller tests
+```
+
+### Constraints
+- Do not implement timeline UI in this task.
+- Do not expose `storage_ref` outside the context/storage boundary.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Add durable route/controller behavior without breaking the existing catch-all workspace route.
+3. Add focused controller tests.
+4. Run narrow controller/context tests.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify route order and scope-before-path-resolution behavior.
+2. Approve before Task 08 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
+++ b/llms/tasks/0010_implement_artifact_model/07_download_route_and_controller.md
@@ -25,7 +25,6 @@ Add an ID-based Artifact download route/controller that checks visible scope and
 ## Expected Outputs
 - [ ] Route `GET /lemmings/instances/:instance_id/artifacts/:artifact_id/download` before existing workspace catch-all route.
 - [ ] Controller action that resolves world/scope, instance, Artifact, status, and storage path in safe order.
-- [ ] `artifact.read` event on successful read.
 - [ ] Safe handling for missing DB rows, wrong scope, bad status, missing physical file, and invalid storage ref.
 - [ ] Controller tests for authorized download, wrong scope, rejected status, missing file, and response header safety.
 

--- a/llms/tasks/0010_implement_artifact_model/08_instance_timeline_promotion_ui.md
+++ b/llms/tasks/0010_implement_artifact_model/08_instance_timeline_promotion_ui.md
@@ -1,8 +1,8 @@
 # Task 08: Instance Timeline Promotion UI
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ⏳ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-frontend-ui-engineer` - Phoenix LiveView frontend engineer for accessible, responsive UI using existing design patterns.

--- a/llms/tasks/0010_implement_artifact_model/08_instance_timeline_promotion_ui.md
+++ b/llms/tasks/0010_implement_artifact_model/08_instance_timeline_promotion_ui.md
@@ -1,0 +1,75 @@
+# Task 08: Instance Timeline Promotion UI
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-frontend-ui-engineer` - Phoenix LiveView frontend engineer for accessible, responsive UI using existing design patterns.
+
+## Agent Invocation
+Act as `dev-frontend-ui-engineer`. Add manual Artifact promotion UI to the existing instance timeline.
+
+## Objective
+Allow operators to manually promote generated workspace files from the instance timeline and render safe Artifact references after promotion.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-07 outputs
+- [ ] `lib/lemmings_os_web/live/instance_live.ex`
+- [ ] `lib/lemmings_os_web/live/instance_live.html.heex`
+- [ ] `lib/lemmings_os_web/components/instance_components.ex`
+- [ ] Existing LiveView tests for instance timeline
+
+## Expected Outputs
+- [ ] `Promote to Artifact` action for eligible workspace file events.
+- [ ] Existing same-scope filename state detects and presents `Update Artifact` and `Promote as New Artifact` actions.
+- [ ] Event handlers that call `LemmingsOs.Artifacts.promote_workspace_file/2` with explicit scope.
+- [ ] Safe Artifact reference rendering in timeline.
+- [ ] Notes display using unobtrusive accessible pattern such as `<details>`.
+- [ ] Stable DOM IDs for buttons, forms, references, status messages, and notes controls.
+
+## Acceptance Criteria
+- [ ] UI renders only safe descriptor fields: filename, type, status, size, created_at, creator instance/tool execution IDs where known.
+- [ ] UI does not render raw file contents, raw filesystem paths, storage root path, full metadata, prompt/model/tool raw output, or notes as large inline content.
+- [ ] Notes are not sent to LLM context by default.
+- [ ] Buttons are keyboard reachable and have clear accessible names.
+- [ ] Existing timeline behavior remains intact.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os_web/live/instance_live.ex        # Event handling and data loading
+lib/lemmings_os_web/live/instance_live.html.heex # Page layout
+lib/lemmings_os_web/components/instance_components.ex # Timeline card components
+test/lemmings_os_web/live/instance_live_test.exs # Stable selector patterns
+```
+
+### Constraints
+- Preserve existing visual language and component patterns.
+- Use HEEx `:if`, `:for`, and `{}` interpolation; avoid raw EEx blocks.
+- Do not embed `<script>` tags.
+- Do not call schemas or Repo directly from web code.
+- Do not call Secret Bank.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Add the smallest UI/data-loading changes needed for manual promotion.
+3. Add or update focused LiveView tests if necessary, but leave broad testing to Task 09.
+4. Run narrow LiveView tests affected by UI changes.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Review UI copy, safe fields, and stable DOM IDs.
+2. Verify no raw path/content leakage in rendered HTML.
+3. Approve before Task 09 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/09_liveview_and_controller_tests.md
+++ b/llms/tasks/0010_implement_artifact_model/09_liveview_and_controller_tests.md
@@ -1,8 +1,8 @@
 # Task 09: LiveView and Controller Tests
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ⏳ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-elixir-test-author` - QA-driven Elixir test writer for ExUnit, LiveView, controller, and integration tests.
@@ -67,4 +67,34 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented focused LiveView and controller coverage for missing Artifact scenarios and leakage regressions.
+
+### Scenario Coverage Added
+- `UI-03` update/new choice:
+  - Added UI support and tests to render both explicit collision actions:
+    - `Update Artifact`
+    - `Promote as New Artifact`
+  - Test: `S08m` now asserts both action buttons.
+- `UI-03`/`PRO-06` promote-as-new flow:
+  - Test: `S08n` submits `mode=promote_as_new` and asserts a second Artifact row is created for the same filename.
+- `UI-05`/`SEC-*` safe rendering regression:
+  - Test: `S08o` verifies Artifact reference summary excludes file content, `storage_ref`, workspace path sentinel, metadata sentinel, and note text in summary.
+  - Notes remain available via `<details>` control and dedicated notes element.
+- `DL-02` wrong-scope/wrong-instance guard:
+  - Added controller test `DL02b` ensuring artifact ids from another instance are rejected (`404`).
+- `DL-04`/`DL-05` leakage regression:
+  - Extended missing-file download test to assert no storage path/ref leakage in response headers as well as body.
+
+### Files Changed
+- `lib/lemmings_os_web/components/instance_components.ex`
+  - Added `artifact-promote-as-new-button-<tool_execution_id>` submit action (`mode=promote_as_new`) for collision state.
+- `test/lemmings_os_web/live/instance_live_test.exs`
+  - Extended `S08m`.
+  - Added `S08n`, `S08o`.
+- `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+  - Added `DL02b`.
+  - Strengthened `DL04` header leakage assertions.
+
+### Assumptions
+- “notes by default” interpreted as not included in the compact Artifact reference summary line; notes remain behind the existing `<details>` UI pattern.
+- Existing `test/lemmings_os/lemming_calls_runtime_test.exs` already covers “no automatic artifact content injection unless explicitly referenced” (`S02d`), so no new runtime test was required in this task.

--- a/llms/tasks/0010_implement_artifact_model/09_liveview_and_controller_tests.md
+++ b/llms/tasks/0010_implement_artifact_model/09_liveview_and_controller_tests.md
@@ -1,0 +1,70 @@
+# Task 09: LiveView and Controller Tests
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author` - QA-driven Elixir test writer for ExUnit, LiveView, controller, and integration tests.
+
+## Agent Invocation
+Act as `qa-elixir-test-author`. Implement missing tests from the Artifact test plan and source acceptance criteria.
+
+## Objective
+Add deterministic outcome-based tests for UI promotion, safe rendering, update/new choices, controlled downloads, status rejection, wrong scope, and leakage regressions.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/test_plan.md`
+- [ ] Tasks 01-08 outputs
+- [ ] `test/support/factory.ex`
+- [ ] Existing LiveView/controller tests
+
+## Expected Outputs
+- [ ] LiveView tests for promotion button, click promotion, promoted reference rendering, update/new choice, and notes display.
+- [ ] Controller tests for authorized download, wrong scope, deleted/archived/error rejection, missing physical file, and no path leakage.
+- [ ] Regression tests proving rendered HTML/events do not expose file contents, storage refs, storage roots, raw workspace paths, full metadata, or notes by default.
+- [ ] If not already present, tests proving no automatic LLM context injection of artifact contents.
+
+## Acceptance Criteria
+- [ ] Tests use factories and deterministic temp dirs.
+- [ ] Tests use stable selectors with `element/2`, `has_element?/2`, and controller response assertions.
+- [ ] Tests avoid large raw HTML assertions except targeted leakage checks.
+- [ ] No external network is used.
+- [ ] Narrow test command passes.
+
+## Technical Notes
+### Relevant Code Locations
+```
+test/lemmings_os_web/live/instance_live_test.exs       # LiveView timeline tests
+test/lemmings_os_web/controllers/                      # Controller tests
+test/lemmings_os/artifacts_test.exs                    # Context tests if created
+test/lemmings_os/artifacts/local_storage_test.exs      # Storage tests if created
+```
+
+### Constraints
+- Do not broaden production behavior beyond what tests require for accepted source criteria.
+- Do not add fixture-style helpers or `*_fixture` functions.
+- Do not use sleeps for LiveView behavior unless an existing helper pattern requires it.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Identify acceptance criteria not covered by Tasks 01-08 tests.
+3. Add focused tests and only minimal production fixes if needed to satisfy intended behavior.
+4. Run the narrow relevant test files.
+5. Document assumptions, files changed, and test commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify test failures would be actionable.
+2. Confirm leakage assertions cover sentinel values.
+3. Approve before Task 10 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
+++ b/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
@@ -1,0 +1,65 @@
+# Task 10: Documentation and ADR
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`docs-feature-documentation-author` - Feature documentation writer aligned with implemented application behavior.
+
+## Agent Invocation
+Act as `docs-feature-documentation-author`. Document actual implemented Artifact behavior after inspecting code and tests.
+
+## Objective
+Add operator/developer documentation for Artifacts and update architecture references for durable promoted runtime outputs.
+
+## Inputs Required
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-09 outputs
+- [ ] Implemented Artifact code/tests
+- [ ] `docs/adr/0008-lemming-persistence-model.md`
+- [ ] `docs/adr/0005-tool-execution-model.md` only if implementation touches its concerns
+
+## Expected Outputs
+- [ ] `docs/features/artifacts.md`.
+- [ ] Updated `docs/adr/0008-lemming-persistence-model.md`.
+- [ ] Optional `docs/adr/0005-tool-execution-model.md` update only if needed.
+- [ ] Any relevant operator/developer docs updated where they mention generated outputs/workspace files.
+
+## Acceptance Criteria
+- [ ] Docs explain File vs Artifact, manual promotion, scope/provenance, storage, type/status model, timeline behavior, download/open behavior, security/privacy rules, observability events, out of scope, and future work.
+- [ ] ADR 0008 states Artifact metadata is in Postgres and bytes are outside Postgres in managed file storage.
+- [ ] Docs state Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
+- [ ] Docs mention config/env var for local artifact storage root.
+- [ ] Docs match actual implementation rather than aspirational behavior.
+
+## Technical Notes
+### Relevant Code Locations
+```
+docs/features/                       # Feature docs
+docs/adr/0008-lemming-persistence-model.md
+docs/adr/0005-tool-execution-model.md
+```
+
+### Constraints
+- Do not add undocumented behavior.
+- Do not claim external storage/S3 support.
+- Do not document automatic promotion or future workflows as implemented.
+
+## Execution Instructions
+
+### For the Agent
+1. Inspect implemented code/tests first.
+2. Write concise documentation aligned with actual behavior.
+3. Run a docs-only format/check if available; otherwise no code checks required.
+4. Document assumptions, files changed, and validation in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Verify docs do not overstate feature scope.
+2. Approve before Task 11 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
+++ b/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
@@ -1,8 +1,8 @@
 # Task 10: Documentation and ADR
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `docs-feature-documentation-author` - Feature documentation writer aligned with implemented application behavior.
@@ -14,24 +14,24 @@ Act as `docs-feature-documentation-author`. Document actual implemented Artifact
 Add operator/developer documentation for Artifacts and update architecture references for durable promoted runtime outputs.
 
 ## Inputs Required
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] Tasks 01-09 outputs
-- [ ] Implemented Artifact code/tests
-- [ ] `docs/adr/0008-lemming-persistence-model.md`
-- [ ] `docs/adr/0005-tool-execution-model.md` only if implementation touches its concerns
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] Tasks 01-09 outputs
+- [x] Implemented Artifact code/tests
+- [x] `docs/adr/0008-lemming-persistence-model.md`
+- [x] `docs/adr/0005-tool-execution-model.md` reviewed for scope impact
 
 ## Expected Outputs
-- [ ] `docs/features/artifacts.md`.
-- [ ] Updated `docs/adr/0008-lemming-persistence-model.md`.
-- [ ] Optional `docs/adr/0005-tool-execution-model.md` update only if needed.
-- [ ] Any relevant operator/developer docs updated where they mention generated outputs/workspace files.
+- [x] `docs/features/artifacts.md`.
+- [x] Updated `docs/adr/0008-lemming-persistence-model.md`.
+- [x] Optional `docs/adr/0005-tool-execution-model.md` update only if needed (not required after review).
+- [x] Any relevant operator/developer docs updated where they mention generated outputs/workspace files.
 
 ## Acceptance Criteria
-- [ ] Docs explain File vs Artifact, manual promotion, scope/provenance, storage, type/status model, timeline behavior, download/open behavior, security/privacy rules, observability scope, out of scope, and future work.
-- [ ] ADR 0008 states Artifact metadata is in Postgres and bytes are outside Postgres in managed file storage.
-- [ ] Docs state Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
-- [ ] Docs mention config/env var for local artifact storage root.
-- [ ] Docs match actual implementation rather than aspirational behavior.
+- [x] Docs explain File vs Artifact, manual promotion, scope/provenance, storage, type/status model, timeline behavior, download/open behavior, security/privacy rules, observability scope, out of scope, and future work.
+- [x] ADR 0008 states Artifact metadata is in Postgres and bytes are outside Postgres in managed file storage.
+- [x] Docs state Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
+- [x] Docs mention config/env var for local artifact storage root.
+- [x] Docs match actual implementation rather than aspirational behavior.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -62,4 +62,37 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+Implemented Artifact feature documentation and persistence ADR clarifications aligned with current code/tests.
+
+### Documentation Changes
+- Replaced `docs/features/artifacts.md` with implementation-aligned feature docs covering:
+  - File vs Artifact distinction
+  - manual promotion-only behavior
+  - scope/provenance contract
+  - type/status model
+  - local managed storage and `storage_ref`
+  - collision/update modes
+  - timeline promotion/rendering behavior
+  - durable download and workspace compatibility routes
+  - security/privacy boundaries
+  - observability scope
+  - explicit out-of-scope and future work
+
+- Updated `docs/adr/0008-lemming-persistence-model.md`:
+  - Added explicit Artifact persistence boundary subsection stating metadata in Postgres and file bytes outside Postgres in managed local storage.
+  - Clarified Artifact bytes are never embedded in Postgres transcript/context rows, ETS, DETS, logs/telemetry payloads, or automatic LLM context assembly.
+
+- Updated `README.md` feature docs index to include `docs/features/artifacts.md`.
+
+### ADR 0005 Scope Check
+- Reviewed `docs/adr/0005-tool-execution-model.md`.
+- No changes required because Artifact implementation does not alter tool execution model decisions in ADR 0005.
+
+### Files Changed
+- `docs/features/artifacts.md`
+- `docs/adr/0008-lemming-persistence-model.md`
+- `README.md`
+- `llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md`
+
+### Validation
+- `mix precommit`

--- a/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
+++ b/llms/tasks/0010_implement_artifact_model/10_documentation_and_adr.md
@@ -27,7 +27,7 @@ Add operator/developer documentation for Artifacts and update architecture refer
 - [ ] Any relevant operator/developer docs updated where they mention generated outputs/workspace files.
 
 ## Acceptance Criteria
-- [ ] Docs explain File vs Artifact, manual promotion, scope/provenance, storage, type/status model, timeline behavior, download/open behavior, security/privacy rules, observability events, out of scope, and future work.
+- [ ] Docs explain File vs Artifact, manual promotion, scope/provenance, storage, type/status model, timeline behavior, download/open behavior, security/privacy rules, observability scope, out of scope, and future work.
 - [ ] ADR 0008 states Artifact metadata is in Postgres and bytes are outside Postgres in managed file storage.
 - [ ] Docs state Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
 - [ ] Docs mention config/env var for local artifact storage root.

--- a/llms/tasks/0010_implement_artifact_model/11_security_and_secretbank_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/11_security_and_secretbank_audit.md
@@ -1,0 +1,72 @@
+# Task 11: Security and SecretBank Audit
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-security` - Security reviewer for authorization, input validation, secrets management, OWASP risks, and data leakage.
+
+## Agent Invocation
+Act as `audit-security`. Review the implemented Artifact slice and implement focused fixes for security issues found.
+
+## Objective
+Verify the Artifact implementation preserves scope isolation, path safety, privacy, logging/event safety, LLM context safety, and Secret Bank boundaries.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-10 outputs
+- [ ] Implemented code/tests/docs
+
+## Expected Outputs
+- [ ] Security audit findings documented in this task file.
+- [ ] Focused fixes for confirmed high/medium findings where safe to implement in-scope.
+- [ ] Added/updated regression tests for security fixes.
+- [ ] Explicit SecretBank call-site inventory.
+
+## Acceptance Criteria
+- [ ] Run and document `rg "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test`.
+- [ ] Confirm no Artifact implementation code calls `LemmingsOs.SecretBank` or resolves runtime secrets.
+- [ ] Confirm Artifact context does not inspect contents for secrets and does not integrate with Secret Bank.
+- [ ] Confirm download/open checks visible scope before resolving `storage_ref` to a path.
+- [ ] Confirm events/logs exclude file contents, storage refs, resolved paths, raw workspace paths, notes by default, full metadata dumps, and secret values.
+- [ ] Confirm artifact contents are not automatically added to LLM context.
+- [ ] Confirm all path inputs reject traversal/symlink escapes and fail closed.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/artifacts*             # Artifact backend implementation
+lib/lemmings_os_web/controllers/       # Download/open route
+lib/lemmings_os_web/live/instance_live* # Promotion UI
+lib/lemmings_os/secret_bank*           # Approved Secret Bank boundary, should not be used by Artifacts
+lib/lemmings_os/lemming_instances/executor/context_messages.ex # LLM context safety check
+```
+
+### Constraints
+- Do not broaden scope into a general auth system.
+- Do not add secret scanning.
+- Do not call Secret Bank from Artifact code.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Audit code paths and run the required `rg` inventory.
+3. Implement focused fixes for confirmed issues.
+4. Add regression tests for fixes.
+5. Run narrow security-related tests.
+6. Document findings, fixes, residual risks, and commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Review any residual risk and decide whether follow-up tasks are needed.
+2. Approve before Task 12 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/11_security_and_secretbank_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/11_security_and_secretbank_audit.md
@@ -1,8 +1,8 @@
 # Task 11: Security and SecretBank Audit
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETE 
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 `audit-security` - Security reviewer for authorization, input validation, secrets management, OWASP risks, and data leakage.
@@ -22,19 +22,19 @@ Verify the Artifact implementation preserves scope isolation, path safety, priva
 - [ ] Implemented code/tests/docs
 
 ## Expected Outputs
-- [ ] Security audit findings documented in this task file.
-- [ ] Focused fixes for confirmed high/medium findings where safe to implement in-scope.
-- [ ] Added/updated regression tests for security fixes.
-- [ ] Explicit SecretBank call-site inventory.
+- [x] Security audit findings documented in this task file.
+- [x] Focused fixes for confirmed high/medium findings where safe to implement in-scope.
+- [x] Added/updated regression tests for security fixes.
+- [x] Explicit SecretBank call-site inventory.
 
 ## Acceptance Criteria
-- [ ] Run and document `rg "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test`.
-- [ ] Confirm no Artifact implementation code calls `LemmingsOs.SecretBank` or resolves runtime secrets.
-- [ ] Confirm Artifact context does not inspect contents for secrets and does not integrate with Secret Bank.
-- [ ] Confirm download/open checks visible scope before resolving `storage_ref` to a path.
-- [ ] Confirm events/logs exclude file contents, storage refs, resolved paths, raw workspace paths, notes by default, full metadata dumps, and secret values.
-- [ ] Confirm artifact contents are not automatically added to LLM context.
-- [ ] Confirm all path inputs reject traversal/symlink escapes and fail closed.
+- [x] Run and document `rg "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test`.
+- [x] Confirm no Artifact implementation code calls `LemmingsOs.SecretBank` or resolves runtime secrets.
+- [x] Confirm Artifact context does not inspect contents for secrets and does not integrate with Secret Bank.
+- [x] Confirm download/open checks visible scope before resolving `storage_ref` to a path.
+- [x] Confirm events/logs exclude file contents, storage refs, resolved paths, raw workspace paths, notes by default, full metadata dumps, and secret values.
+- [x] Confirm artifact contents are not automatically added to LLM context.
+- [x] Confirm all path inputs reject traversal/symlink escapes and fail closed.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -69,4 +69,63 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### SecretBank Inventory (`rg "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test`)
+- Matches were found in Secret Bank modules, world/city/department/lemming secret UI surfaces, and connection/tool runtime adapters.
+- No Artifact module matches:
+  - No matches in `lib/lemmings_os/artifacts.ex`
+  - No matches in `lib/lemmings_os/artifacts/*`
+  - No matches in `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`
+  - No matches in Artifact tests
+
+### Findings
+1. **Medium**: Artifact promotion failure logs leaked raw relative paths and raw inspected reasons.
+   - Location: `lib/lemmings_os_web/live/instance_live.ex`
+   - Risk: path disclosure in logs; accidental detail leakage from `inspect(reason)`.
+   - Fix: replaced with reason token logging only (`reason_token=<token>`), removed raw relative path from message.
+2. **Medium**: Filename control characters were accepted by local storage filename validation.
+   - Location: `lib/lemmings_os/artifacts/local_storage.ex`
+   - Risk: unsafe filename propagation into headers/logging/display.
+   - Fix: reject ASCII control characters (`0x00-0x1F`, `0x7F`) in filenames.
+3. **Medium**: Download `content-disposition` used basename + quote stripping only.
+   - Location: `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`
+   - Risk: malformed legacy filenames could cause unsafe header values.
+   - Fix: strip control characters from filename before header composition.
+
+### Confirmations Against Acceptance Criteria
+- **Secret Bank boundary**: Artifact implementation does not call `LemmingsOs.SecretBank` and does not resolve runtime secrets.
+- **No secret scanning integration**: Artifact flow does not inspect artifact file contents for secrets.
+- **Scope-before-path ordering (download route)**:
+  1. Resolve world + instance scope.
+  2. `Artifacts.get_artifact_download(instance, artifact_id)` enforces visible scope + `ready` status.
+  3. Only then `LocalStorage.resolve_storage_ref(storage_ref)` resolves path.
+- **LLM context safety**:
+  - `Executor.ContextMessages` and finalization payload include summarized metadata only.
+  - Artifact file contents are not auto-loaded into model context.
+- **Path safety fail-closed**:
+  - Traversal, absolute paths, and symlink escapes are rejected in:
+    - `LemmingsOs.LemmingInstances.artifact_absolute_path/2`
+    - `LemmingsOs.Artifacts.LocalStorage.resolve_storage_ref/1`
+    - `LemmingsOs.Artifacts.LocalStorage.store_copy/4`
+
+### Regression Tests Added/Updated
+- `test/lemmings_os_web/live/instance_live_test.exs`
+  - `S08m2`: verifies promotion failure logs omit raw relative path and include only reason token.
+- `test/lemmings_os/artifacts/local_storage_test.exs`
+  - expanded unsafe filename set to include `\n` and `\r`.
+- `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+  - `DL01b`: verifies control chars are stripped from `content-disposition` filename.
+
+### Commands Run
+- `rg -n "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test`
+- `mix format lib/lemmings_os_web/live/instance_live.ex lib/lemmings_os/artifacts/local_storage.ex lib/lemmings_os_web/controllers/instance_artifact_controller.ex test/lemmings_os/artifacts/local_storage_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os_web/live/instance_live_test.exs`
+- `mix test test/lemmings_os/artifacts/local_storage_test.exs`
+- `mix test test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+- `mix test test/lemmings_os_web/live/instance_live_test.exs`
+- `MIX_ENV=test mix precommit`
+
+### Validation Results
+- All targeted tests passed.
+- `MIX_ENV=test mix precommit` passed (Dialyzer + Credo clean).
+
+### Residual Risks
+- Existing generic executor/tool lifecycle logging still records tool relative paths for runtime observability (outside Artifact-specific code paths). If policy requires global path suppression, that should be a separate cross-cutting task.

--- a/llms/tasks/0010_implement_artifact_model/12_accessibility_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/12_accessibility_audit.md
@@ -1,0 +1,71 @@
+# Task 12: Accessibility Audit
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-accessibility` - Accessibility auditor for Phoenix LiveView apps.
+
+## Agent Invocation
+Act as `audit-accessibility`. Review the Artifact promotion/update/download UI and implement focused accessibility fixes.
+
+## Objective
+Ensure Artifact timeline controls and references are usable with keyboard and assistive technologies while preserving safe rendering behavior.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] Tasks 08-11 outputs
+- [ ] `lib/lemmings_os_web/live/instance_live.ex`
+- [ ] `lib/lemmings_os_web/live/instance_live.html.heex`
+- [ ] `lib/lemmings_os_web/components/instance_components.ex`
+- [ ] Existing LiveView tests
+
+## Expected Outputs
+- [ ] Accessibility audit findings documented in this task file.
+- [ ] Focused UI fixes for labels, keyboard reachability, focus management, status feedback, and details/popover semantics.
+- [ ] LiveView tests or assertions for key accessibility regressions where practical.
+
+## Acceptance Criteria
+- [ ] Promotion, update, promote-as-new, and download controls have stable IDs and clear accessible names.
+- [ ] Status/flash feedback is perceivable and does not require mouse interaction.
+- [ ] Notes disclosure is keyboard usable and semantically appropriate.
+- [ ] Focus behavior is not broken after promotion/update actions.
+- [ ] No accessibility fix introduces raw content/path/metadata leakage.
+- [ ] Narrow LiveView tests pass.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os_web/live/instance_live.ex
+lib/lemmings_os_web/live/instance_live.html.heex
+lib/lemmings_os_web/components/instance_components.ex
+test/lemmings_os_web/live/instance_live_test.exs
+```
+
+### Constraints
+- Preserve existing design system and visual language.
+- Do not embed scripts in HEEx.
+- Do not introduce broad UI redesigns.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Audit keyboard, focus, naming, and semantic behavior.
+3. Implement focused fixes only.
+4. Add/update tests where practical.
+5. Run narrow LiveView tests.
+6. Document findings, fixes, residual risks, and commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Review UI behavior manually if possible.
+2. Approve before Task 13 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/12_accessibility_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/12_accessibility_audit.md
@@ -1,8 +1,8 @@
 # Task 12: Accessibility Audit
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETE 
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `audit-accessibility` - Accessibility auditor for Phoenix LiveView apps.
@@ -24,17 +24,17 @@ Ensure Artifact timeline controls and references are usable with keyboard and as
 - [ ] Existing LiveView tests
 
 ## Expected Outputs
-- [ ] Accessibility audit findings documented in this task file.
-- [ ] Focused UI fixes for labels, keyboard reachability, focus management, status feedback, and details/popover semantics.
-- [ ] LiveView tests or assertions for key accessibility regressions where practical.
+- [x] Accessibility audit findings documented in this task file.
+- [x] Focused UI fixes for labels, keyboard reachability, focus management, status feedback, and details/popover semantics.
+- [x] LiveView tests or assertions for key accessibility regressions where practical.
 
 ## Acceptance Criteria
-- [ ] Promotion, update, promote-as-new, and download controls have stable IDs and clear accessible names.
-- [ ] Status/flash feedback is perceivable and does not require mouse interaction.
-- [ ] Notes disclosure is keyboard usable and semantically appropriate.
-- [ ] Focus behavior is not broken after promotion/update actions.
-- [ ] No accessibility fix introduces raw content/path/metadata leakage.
-- [ ] Narrow LiveView tests pass.
+- [x] Promotion, update, promote-as-new, and download controls have stable IDs and clear accessible names.
+- [x] Status/flash feedback is perceivable and does not require mouse interaction.
+- [x] Notes disclosure is keyboard usable and semantically appropriate.
+- [x] Focus behavior is not broken after promotion/update actions.
+- [x] No accessibility fix introduces raw content/path/metadata leakage.
+- [x] Narrow LiveView tests pass.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -68,4 +68,55 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Findings
+1. **Medium**: Artifact help affordance used an inert `<button>` with `title`, which is mouse-biased and provides weak keyboard/AT semantics.
+   - Location: `lib/lemmings_os_web/components/instance_components.ex`
+   - Fix: replaced with semantic `<details>/<summary>` help disclosure and stable IDs.
+2. **Medium**: Promotion status feedback lacked explicit live-region semantics and focus behavior for non-visual users.
+   - Location: `lib/lemmings_os_web/components/instance_components.ex`
+   - Fix: added `aria-live`, `aria-atomic`, `tabindex="-1"`, and `phx-mounted` focus to status message.
+3. **Low**: Notes disclosure and download link lacked stronger semantic wiring.
+   - Location: `lib/lemmings_os_web/components/instance_components.ex`
+   - Fix: added `summary` id + `aria-controls` for notes body and explicit `aria-label` for download link.
+
+### Implemented Changes
+- Added stable accessibility IDs:
+  - `artifact-promotion-heading-*`
+  - `artifact-promotion-help-*`
+  - `artifact-reference-notes-summary-*`
+- Promotion region:
+  - `role="region"` and `aria-labelledby` on promotion container.
+  - `aria-describedby` on promotion form tying source/help/status.
+- Promotion action buttons:
+  - preserved stable IDs and labels.
+  - added `phx-disable-with` progress copy for submit feedback.
+- Promotion status:
+  - role remains `status`/`alert` based on outcome.
+  - added `aria-live` (`polite` or `assertive`) + `aria-atomic="true"`.
+  - added `tabindex="-1"` and mount focus command.
+- Notes disclosure:
+  - semantic `<details>/<summary>` retained.
+  - summary now references notes content via `aria-controls`.
+- Download control:
+  - retains stable ID.
+  - now includes explicit accessible name with filename.
+
+### Regression Tests Updated
+- `test/lemmings_os_web/live/instance_live_test.exs`
+  - Expanded `S08l` with assertions for:
+    - promotion help IDs and form `aria-describedby`
+    - status live-region attributes
+    - download link accessible name
+  - Expanded `S08m` with assertion for notes summary `aria-controls`.
+
+### Commands Run
+- `mix format lib/lemmings_os_web/components/instance_components.ex test/lemmings_os_web/live/instance_live_test.exs`
+- `mix test test/lemmings_os_web/live/instance_live_test.exs`
+- `MIX_ENV=test mix precommit`
+
+### Validation Results
+- Narrow LiveView tests passed.
+- `MIX_ENV=test mix precommit` passed (Dialyzer + Credo clean).
+
+### Residual Risks
+- Focus announcement is scoped to promotion status mount only. If future behavior requires focus restoration to the triggering button, that should be handled in a dedicated follow-up interaction pattern task.

--- a/llms/tasks/0010_implement_artifact_model/13_staff_elixir_pr_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/13_staff_elixir_pr_audit.md
@@ -1,0 +1,73 @@
+# Task 13: Staff Elixir PR Audit
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-pr-elixir` - Staff-level PR reviewer for Elixir/Phoenix correctness, design quality, security, performance, logging, and tests.
+
+## Agent Invocation
+Act as `audit-pr-elixir`. Perform a staff-level Elixir/Phoenix review of the full Artifact implementation and implement focused fixes for confirmed findings.
+
+## Objective
+Catch correctness, design, scope, performance, logging, and test-quality issues before release validation, explicitly checking constitution and Elixir style compliance.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-12 outputs
+- [ ] Full implementation diff
+
+## Expected Outputs
+- [ ] Findings-first PR audit documented in this task file.
+- [ ] Focused fixes for confirmed high/medium findings where safe to implement.
+- [ ] Regression tests for fixes when executable logic changes.
+- [ ] Explicit checklist result for constitution/style-guide compliance.
+
+## Acceptance Criteria
+- [ ] Verify `llms/constitution.md` MUST rules: explicit World scoping, tuple returns, `filter_query/2` for list APIs, `@doc` on important public functions, tests for executable logic, no hardcoded secrets, no unsafe atom creation.
+- [ ] Verify `llms/coding_styles/elixir.md`: context boundaries, one module per file, grouped aliases, structs not map access, `with`/pattern matching where appropriate, no web-to-Repo/schema bypass, safe logging/telemetry metadata.
+- [ ] Verify `llms/coding_styles/elixir_tests.md`: factories, deterministic data, no external network, stable selectors, no fixture-style helpers, no broad raw HTML assertions except leakage checks.
+- [ ] Review migration/index performance and query plans at code level.
+- [ ] Review storage and download failure modes.
+- [ ] Review observability payloads and SecretBank audit results.
+- [ ] Run narrow tests for any fixes made.
+
+## Technical Notes
+### Relevant Code Locations
+```
+lib/lemmings_os/artifacts*             # Backend implementation
+lib/lemmings_os_web/controllers/       # Download implementation
+lib/lemmings_os_web/live/instance_live* # UI integration
+test/                                  # Test coverage
+priv/repo/migrations/                  # Migration/index review
+```
+
+### Constraints
+- Findings must be ordered by severity with file/line references.
+- Do not perform git operations.
+- Do not broaden the feature scope.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above before reviewing code.
+2. Review implementation against source plan, constitution, and coding style docs.
+3. Document findings first.
+4. Implement focused fixes only for confirmed in-scope issues.
+5. Run narrow tests for fixes.
+6. Document residual risks, files changed, and commands in Execution Summary.
+
+### For the Human Reviewer
+After agent completes:
+1. Review findings and fixes.
+2. Decide if additional implementation tasks are needed.
+3. Approve before Task 14 begins.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/13_staff_elixir_pr_audit.md
+++ b/llms/tasks/0010_implement_artifact_model/13_staff_elixir_pr_audit.md
@@ -1,8 +1,8 @@
 # Task 13: Staff Elixir PR Audit
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: ✅ COMPLETE
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 `audit-pr-elixir` - Staff-level PR reviewer for Elixir/Phoenix correctness, design quality, security, performance, logging, and tests.
@@ -14,27 +14,27 @@ Act as `audit-pr-elixir`. Perform a staff-level Elixir/Phoenix review of the ful
 Catch correctness, design, scope, performance, logging, and test-quality issues before release validation, explicitly checking constitution and Elixir style compliance.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/coding_styles/elixir_tests.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] Tasks 01-12 outputs
-- [ ] Full implementation diff
+- [x] `llms/constitution.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/coding_styles/elixir_tests.md`
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] Tasks 01-12 outputs
+- [x] Full implementation diff
 
 ## Expected Outputs
-- [ ] Findings-first PR audit documented in this task file.
-- [ ] Focused fixes for confirmed high/medium findings where safe to implement.
-- [ ] Regression tests for fixes when executable logic changes.
-- [ ] Explicit checklist result for constitution/style-guide compliance.
+- [x] Findings-first PR audit documented in this task file.
+- [x] Focused fixes for confirmed high/medium findings where safe to implement.
+- [x] Regression tests for fixes when executable logic changes.
+- [x] Explicit checklist result for constitution/style-guide compliance.
 
 ## Acceptance Criteria
-- [ ] Verify `llms/constitution.md` MUST rules: explicit World scoping, tuple returns, `filter_query/2` for list APIs, `@doc` on important public functions, tests for executable logic, no hardcoded secrets, no unsafe atom creation.
-- [ ] Verify `llms/coding_styles/elixir.md`: context boundaries, one module per file, grouped aliases, structs not map access, `with`/pattern matching where appropriate, no web-to-Repo/schema bypass, safe logging/telemetry metadata.
-- [ ] Verify `llms/coding_styles/elixir_tests.md`: factories, deterministic data, no external network, stable selectors, no fixture-style helpers, no broad raw HTML assertions except leakage checks.
-- [ ] Review migration/index performance and query plans at code level.
-- [ ] Review storage and download failure modes.
-- [ ] Review observability payloads and SecretBank audit results.
-- [ ] Run narrow tests for any fixes made.
+- [x] Verify `llms/constitution.md` MUST rules: explicit World scoping, tuple returns, `filter_query/2` for list APIs, `@doc` on important public functions, tests for executable logic, no hardcoded secrets, no unsafe atom creation.
+- [x] Verify `llms/coding_styles/elixir.md`: context boundaries, one module per file, grouped aliases, structs not map access, `with`/pattern matching where appropriate, no web-to-Repo/schema bypass, safe logging/telemetry metadata.
+- [x] Verify `llms/coding_styles/elixir_tests.md`: factories, deterministic data, no external network, stable selectors, no fixture-style helpers, no broad raw HTML assertions except leakage checks.
+- [x] Review migration/index performance and query plans at code level.
+- [x] Review storage and download failure modes.
+- [x] Review observability payloads and SecretBank audit results.
+- [x] Run narrow tests for any fixes made.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -70,4 +70,67 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Summary
+- Staff-level audit completed across Artifact context, promotion/storage, download controller, LiveView integration, migration, and artifact-specific tests.
+- One **medium** issue was confirmed and fixed in-scope.
+- No blockers were found after fixes; all relevant checks are green.
+- Merge recommendation for this task scope: **APPROVE**.
+
+### Risk Assessment
+- **Low** after fixes: explicit world/scope boundaries, tuple-return APIs, no unsafe atom creation, and passing targeted tests + `mix precommit`.
+
+### Findings
+1. **MAJOR (fixed)**: HEEx template used raw EEx blocks (`<%= ... %>`) in Artifact tool cards, violating project HEEx rules and risking further template drift.
+   - Where: `lib/lemmings_os_web/components/instance_components.ex` around `tool-execution-summary` and payload `<pre>` blocks (`tool-execution-args/result/error` IDs near lines 276, 514, 524, 534).
+   - Why it matters: constitution/style explicitly require HEEx interpolation and `:if/:for`, not EEx blocks in templates.
+   - Fix: replaced EEx `if/else` with HEEx `:if` spans and replaced EEx payload interpolation with HEEx `{...}` interpolation.
+
+### Compliance Checklist Results
+- Constitution MUST checks: **PASS**
+  - Explicit world/scope boundaries: context/controller calls are scope-gated (`Artifacts.get_artifact_download(instance, artifact_id)` and scoped query filters).
+  - Tuple return contracts: Artifact context/promotion/storage APIs return tuples for failure paths.
+  - `filter_query/2` present for list/get query composition.
+  - Important public functions are documented with `@doc`.
+  - No hardcoded secrets found in Artifact implementation.
+  - No `String.to_atom/1` on user input found.
+- `llms/coding_styles/elixir.md`: **PASS**
+  - Context boundaries respected; web layer calls contexts.
+  - One-module-per-file respected.
+  - Logging metadata is structured and scope-aware in Artifact promotion failure path.
+- `llms/coding_styles/elixir_tests.md`: **PASS**
+  - Factory-driven setup retained.
+  - Deterministic tests; no external network.
+  - LiveView tests use stable selectors and outcome assertions.
+
+### Migration/Performance Notes
+- Migration indexes cover dominant lookups:
+  - world scope
+  - hierarchy scope
+  - instance/provenance references
+  - scope+filename collision checks
+- Residual performance concern (not changed in this task): durable download currently reads full file into memory before response in `InstanceArtifactController` (`File.read/1`), which can pressure memory for large artifacts.
+
+### Storage/Download Failure Mode Notes
+- Path traversal and invalid refs are fail-closed in `LocalStorage` + controller behavior.
+- Status gating (`ready` only) and scope checks happen before durable file resolution.
+
+### Observability/SecretBank Notes
+- Promotion failure logging now uses reason tokens and avoids raw path leakage.
+- Security task output (Task 11) findings remain addressed; no SecretBank coupling added in Artifact flow.
+
+### Files Changed
+- `lib/lemmings_os_web/components/instance_components.ex`
+
+### Validation Commands
+- `mix format lib/lemmings_os_web/components/instance_components.ex`
+- `mix test test/lemmings_os_web/live/instance_live_test.exs`
+- `mix test test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+- `mix precommit`
+
+### Validation Results
+- `test/lemmings_os_web/live/instance_live_test.exs`: pass
+- `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`: pass
+- `mix precommit`: pass (Dialyzer + Credo clean)
+
+### Residual Risks
+- Durable download path still uses `File.read/1` + `send_resp/3`; consider a follow-up to stream/sendfile for large artifact safety.

--- a/llms/tasks/0010_implement_artifact_model/14_release_validation.md
+++ b/llms/tasks/0010_implement_artifact_model/14_release_validation.md
@@ -1,7 +1,7 @@
 # Task 14: Release Validation
 
 ## Status
-- **Status**: ⏳ PENDING
+- **Status**: ✅ COMPLETE
 - **Approved**: [ ] Human sign-off
 
 ## Assigned Agent
@@ -14,28 +14,28 @@ Act as `rm-release-manager`. Prepare final release validation for the Artifact m
 Close the Artifact implementation with migration notes, rollback guidance, validation evidence, and final checks against constitution and style guides.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/coding_styles/elixir_tests.md`
-- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
-- [ ] Tasks 01-13 outputs
-- [ ] Full implementation diff and test results
+- [x] `llms/constitution.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/coding_styles/elixir_tests.md`
+- [x] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [x] Tasks 01-13 outputs
+- [x] Full implementation diff and test results
 
 ## Expected Outputs
-- [ ] Release/validation summary documented in this task file.
-- [ ] Migration risk and rollback notes.
-- [ ] Final test command evidence.
-- [ ] Residual risk list and human sign-off checklist.
+- [x] Release/validation summary documented in this task file.
+- [x] Migration risk and rollback notes.
+- [x] Final test command evidence.
+- [x] Residual risk list and human sign-off checklist.
 
 ## Acceptance Criteria
-- [ ] Re-read and explicitly check `llms/constitution.md`, `llms/coding_styles/elixir.md`, and `llms/coding_styles/elixir_tests.md`.
-- [ ] Run narrow relevant tests first and record commands/results.
-- [ ] Run `mix test` and record result.
-- [ ] Run `mix precommit` and record result.
-- [ ] Confirm `mix format` or precommit formatting check passes.
-- [ ] Confirm no SecretBank/SecretsBank Artifact access via documented `rg` result from Task 11 or a fresh final check.
-- [ ] Confirm docs/ADR are updated and match implementation.
-- [ ] Confirm migration rollback impact is clearly stated.
+- [x] Re-read and explicitly check `llms/constitution.md`, `llms/coding_styles/elixir.md`, and `llms/coding_styles/elixir_tests.md`.
+- [x] Run narrow relevant tests first and record commands/results.
+- [x] Run `mix test` and record result.
+- [x] Run `mix precommit` and record result.
+- [x] Confirm `mix format` or precommit formatting check passes.
+- [x] Confirm no SecretBank/SecretsBank Artifact access via documented `rg` result from Task 11 or a fresh final check.
+- [x] Confirm docs/ADR are updated and match implementation.
+- [x] Confirm migration rollback impact is clearly stated.
 
 ## Technical Notes
 ### Relevant Commands
@@ -73,4 +73,69 @@ After agent completes:
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Release Overview
+- Release slice: Artifact model implementation (Tasks 01-14)
+- Date: 2026-05-01
+- Validation scope: backend artifact model, promotion/storage flow, download controller path, instance timeline integration, docs/ADR alignment
+- Risk level: **Medium** (new durable data model + managed file storage path + user-facing download behavior)
+
+### Constitution / Style Re-Check
+- Re-read and checked against:
+  - `llms/constitution.md`
+  - `llms/coding_styles/elixir.md`
+  - `llms/coding_styles/elixir_tests.md`
+- Result: **PASS** for this slice after Task 11-13 fixes (scope isolation, tuple contracts, HEEx compliance, deterministic tests, no unsafe atom creation, no hardcoded secrets in Artifact code).
+
+### Validation Evidence (Narrow → Broad)
+1. Narrow Artifact-focused tests:
+   - `mix test test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts/local_storage_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os/artifacts_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os_web/live/instance_live_test.exs`
+   - Result: `18 doctests, 83 tests, 0 failures`
+2. Full test suite:
+   - `mix test`
+   - Result: `160 doctests, 758 tests, 0 failures`
+3. Final quality gate:
+   - `mix precommit`
+   - Result: **PASS** (`dialyzer` clean, `credo` clean, formatter checks passing through precommit)
+
+### SecretBank Boundary Confirmation
+- Fresh final check (Artifact-focused paths):
+  - `rg -n "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib/lemmings_os/artifacts.ex lib/lemmings_os/artifacts lib/lemmings_os_web/controllers/instance_artifact_controller.ex test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os_web/live/instance_live_test.exs`
+  - Result: no matches in Artifact implementation and Artifact tests.
+- Cross-repo grep still shows expected SecretBank usage in non-Artifact modules (world/city/department/lemming secrets surfaces and secret_bank tests), consistent with Task 11 conclusions.
+
+### Docs / ADR Alignment Check
+- Verified updated docs are present and aligned with implementation:
+  - `docs/features/artifacts.md`
+  - `docs/adr/0008-lemming-persistence-model.md`
+  - `README.md` feature index link
+- Confirmed documentation states metadata vs bytes split and no automatic secret-bank/artifact-content injection behavior.
+
+### Migration Risk Notes
+- Migration: `priv/repo/migrations/20260501120000_create_artifacts.exs`
+- DB changes:
+  - New `artifacts` table with FK scope fields, lifecycle/status fields, checksum/size, metadata.
+  - Indexes on world scope, hierarchy scope, instance/provenance references, and scope+filename lookup.
+- Risk assessment:
+  - **Runtime risk**: low-to-medium for migration execution (table create + indexes; no backfill step).
+  - **Operational risk**: medium overall because durable feature behavior depends on both DB metadata and filesystem storage consistency.
+
+### Rollback Guidance
+- Application rollback: deploy previous app version to disable Artifact surface behavior.
+- Database rollback impact:
+  - Rolling back this migration drops the `artifacts` table and all persisted Artifact metadata rows.
+  - Managed artifact files under local storage root are not automatically reconciled by DB rollback and may become orphaned.
+- Recommended rollback approach:
+  1. If rollback is required, prefer app rollback first while keeping DB unchanged if possible.
+  2. If schema rollback is required, explicitly accept metadata loss and schedule orphaned-file cleanup under artifact storage root.
+  3. Capture backup/snapshot before destructive DB rollback in production.
+
+### Residual Risks
+- Durable download path currently uses `File.read/1` + `send_resp/3`, which can increase memory pressure for very large files.
+- No automatic orphan cleanup policy for managed files if rows are deleted/rolled back outside normal lifecycle paths.
+- Promotion status focus behavior is improved but limited to current timeline pattern (per Task 12 notes).
+
+### Human Sign-off Checklist
+- [ ] Review command evidence above (narrow tests, full `mix test`, `mix precommit`).
+- [ ] Confirm migration/rollback impact is acceptable for target environment.
+- [ ] Confirm release timing for any potential large-file usage.
+- [ ] Approve final release or request follow-up hardening tasks.

--- a/llms/tasks/0010_implement_artifact_model/14_release_validation.md
+++ b/llms/tasks/0010_implement_artifact_model/14_release_validation.md
@@ -1,0 +1,76 @@
+# Task 14: Release Validation
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`rm-release-manager` - Release manager for migration risk, rollout notes, rollback planning, and final validation evidence.
+
+## Agent Invocation
+Act as `rm-release-manager`. Prepare final release validation for the Artifact model implementation.
+
+## Objective
+Close the Artifact implementation with migration notes, rollback guidance, validation evidence, and final checks against constitution and style guides.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0010_implement_artifact_model/plan.md`
+- [ ] Tasks 01-13 outputs
+- [ ] Full implementation diff and test results
+
+## Expected Outputs
+- [ ] Release/validation summary documented in this task file.
+- [ ] Migration risk and rollback notes.
+- [ ] Final test command evidence.
+- [ ] Residual risk list and human sign-off checklist.
+
+## Acceptance Criteria
+- [ ] Re-read and explicitly check `llms/constitution.md`, `llms/coding_styles/elixir.md`, and `llms/coding_styles/elixir_tests.md`.
+- [ ] Run narrow relevant tests first and record commands/results.
+- [ ] Run `mix test` and record result.
+- [ ] Run `mix precommit` and record result.
+- [ ] Confirm `mix format` or precommit formatting check passes.
+- [ ] Confirm no SecretBank/SecretsBank Artifact access via documented `rg` result from Task 11 or a fresh final check.
+- [ ] Confirm docs/ADR are updated and match implementation.
+- [ ] Confirm migration rollback impact is clearly stated.
+
+## Technical Notes
+### Relevant Commands
+```bash
+mix test test/lemmings_os/artifacts_test.exs
+mix test test/lemmings_os_web/live/instance_live_test.exs
+mix test test/lemmings_os_web/controllers
+mix test
+mix precommit
+rg "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib test
+```
+Adjust narrow test paths to the actual files created during implementation.
+
+### Constraints
+- Do not perform git operations.
+- Do not hide failures; document blockers clearly.
+- Do not approve release if `mix precommit` fails without a documented human waiver.
+
+## Execution Instructions
+
+### For the Agent
+1. Read all inputs listed above.
+2. Review task summaries and final diff.
+3. Run validation commands in narrow-to-broad order.
+4. Document exact commands and outcomes.
+5. Prepare migration/rollback notes and final residual risks.
+6. Do not mark complete unless final validation passes or a blocker is explicitly documented.
+
+### For the Human Reviewer
+After agent completes:
+1. Review final validation evidence.
+2. Execute git operations if satisfied.
+3. Provide final release sign-off or request follow-up fixes.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*

--- a/llms/tasks/0010_implement_artifact_model/execution_plan.md
+++ b/llms/tasks/0010_implement_artifact_model/execution_plan.md
@@ -1,0 +1,31 @@
+# Artifact Domain Model Execution Plan
+
+## Scope Update (2026-05-01)
+
+This PR slice excludes durable Artifact audit/event persistence.
+
+### In-scope for this slice
+- Keep Artifact schema, storage, promotion/update, download route, UI, and core docs behavior.
+- Keep safety constraints for observability:
+  - no file contents
+  - no `storage_ref`
+  - no resolved filesystem path
+  - no raw workspace path
+  - no notes/full metadata dumps
+  - no secrets
+- Allow only lightweight, optional non-durable observability (safe logs/telemetry).
+
+### Out-of-scope for this slice
+- Durable Artifact lifecycle event writes to `events`.
+- Durable event wrappers such as `LemmingsOs.Artifacts.AuditEvents`.
+- Durable `artifact.read` audit.
+- Platform-wide audit taxonomy and policy design.
+
+## Task 05 Rename
+
+- From: `Artifact Events and Observability`
+- To: `Artifact Instrumentation and Safe Logging`
+
+## Future Work Note
+
+Platform audit/event model should be designed separately. That future design should define durable vs transient events, actor attribution, retention, immutability, event taxonomy, read/download audit, filtering/export, and whether the current `events` table is the audit log or a domain activity log.

--- a/llms/tasks/0010_implement_artifact_model/plan.md
+++ b/llms/tasks/0010_implement_artifact_model/plan.md
@@ -260,7 +260,7 @@ Promotion must:
 3. compute `size_bytes`
 4. compute SHA-256 `checksum`
 5. create/update Artifact row
-6. emit safe lifecycle events
+6. emit optional safe telemetry/log metadata (non-durable only)
 7. return safe Artifact descriptor
 
 ### Update behavior
@@ -279,60 +279,26 @@ Update means:
 - recompute checksum
 - recompute size
 - keep same Artifact row
-- emit `artifact.updated`
 
 No versioning.
 
 ---
 
-## Phase 4 — Observability and events
+## Phase 4 — Instrumentation and safe logging
 
 ### Goal
 
-Artifact operations must produce safe audit/telemetry events without leaking content or paths.
+Add lightweight, safe Artifact observability without introducing durable audit/event persistence.
 
 ### Tasks
 
-- Add `LemmingsOs.Artifacts.Events` or equivalent event helper.
-- Emit events from create/promote/update/status/delete/read/error paths.
-- Ensure reason tokens are safe.
-- Add tests that event payloads do not include raw file contents, workspace paths, storage refs, or resolved paths.
+- Remove/stop using Artifact durable event wrappers.
+- Do not write Artifact lifecycle rows to `events`.
+- Keep instrumentation optional and non-durable only (logs/telemetry).
+- Ensure reason values are normalized safe tokens if logged.
+- Add or keep tests focused on safety guarantees when applicable.
 
-### Required event vocabulary
-
-```text
-artifact.created
-artifact.promoted
-artifact.updated
-artifact.status_changed
-artifact.deleted
-artifact.read
-artifact.promotion_failed
-artifact.error
-```
-
-### Safe event fields
-
-```elixir
-%{
-  artifact_id: artifact.id,
-  world_id: artifact.world_id,
-  city_id: artifact.city_id,
-  department_id: artifact.department_id,
-  lemming_id: artifact.lemming_id,
-  lemming_instance_id: artifact.lemming_instance_id,
-  created_by_tool_execution_id: artifact.created_by_tool_execution_id,
-  filename: artifact.filename,
-  type: artifact.type,
-  content_type: artifact.content_type,
-  status: artifact.status,
-  size_bytes: artifact.size_bytes,
-  checksum: artifact.checksum,
-  reason_token: reason_token
-}
-```
-
-### Forbidden event fields
+### Forbidden observability fields
 
 - file contents
 - `storage_ref`
@@ -412,7 +378,6 @@ Provide minimal controlled open/download behavior from the instance UI.
 - Reject `archived`, `deleted`, and `error` by default.
 - Resolve `storage_ref` internally to local file path.
 - Stream/send file response.
-- Emit `artifact.read` event/telemetry.
 - Add tests for authorized download, missing file, wrong scope, and rejected status.
 
 ### Suggested route options
@@ -466,7 +431,7 @@ Document the Artifact behavior and update architecture references.
 - Timeline behavior
 - Download/open behavior
 - Security/privacy rules
-- Observability events
+- Observability scope (non-durable in this PR slice)
 - Out of scope and future work
 
 ### ADR update
@@ -488,7 +453,7 @@ Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
 2. Local storage module
 3. Context API
 4. Promotion/update logic
-5. Events
+5. Instrumentation/safe logging
 6. Download route
 7. Timeline UI integration
 8. Docs
@@ -510,7 +475,7 @@ Reason: UI should come after the context/storage contract is stable.
 - Promotion computes size.
 - Promotion does not store original workspace path.
 - Promotion returns safe descriptor.
-- Promotion failure emits safe failure event.
+- Promotion failure remains safe and does not leak sensitive file/path data.
 - Existing Artifact update recomputes checksum and size.
 - `get_artifact/2` enforces scope.
 - `list_artifacts_for_scope/1` excludes deleted/error/archived unless explicitly requested by context function.
@@ -536,11 +501,10 @@ Reason: UI should come after the context/storage contract is stable.
 
 ### Observability tests
 
-- Lifecycle events are emitted.
-- Event payload includes safe metadata.
-- Event payload excludes file contents.
-- Event payload excludes storage ref/resolved paths.
-- Event payload excludes notes/full metadata by default.
+- No Artifact lifecycle writes to durable `events`.
+- Logs/telemetry metadata (if present) excludes file contents.
+- Logs/telemetry metadata (if present) excludes storage_ref/resolved paths/raw workspace paths.
+- Logs/telemetry metadata (if present) excludes notes/full metadata by default.
 
 ---
 
@@ -550,9 +514,9 @@ Reason: UI should come after the context/storage contract is stable.
 - [ ] Artifact promotion does not inspect file contents for secrets.
 - [ ] Artifact file contents are never logged.
 - [ ] Artifact file contents are never injected into LLM context automatically.
-- [ ] Artifact events do not include `storage_ref` or resolved filesystem path.
+- [ ] Artifact observability metadata does not include `storage_ref` or resolved filesystem path.
 - [ ] Artifact metadata is minimal and schema-validated.
-- [ ] Artifact notes are not emitted in events by default.
+- [ ] Artifact notes are not emitted in observability metadata by default.
 - [ ] Download/open route checks visible scope before resolving file path.
 
 ---
@@ -572,12 +536,12 @@ Reason: UI should come after the context/storage contract is stable.
 - [ ] Artifact can be opened/downloaded through controlled route.
 - [ ] Archived/deleted/error Artifacts are not normally selectable or downloadable.
 - [ ] Context APIs require explicit scope.
-- [ ] Events are emitted with safe payloads.
+- [ ] No Artifact lifecycle writes to the durable `events` table.
 - [ ] Artifact module does not access Secret Bank.
 - [ ] Artifact contents are not automatically added to LLM context.
 - [ ] `docs/features/artifacts.md` is added.
 - [ ] ADR 0008 is updated.
-- [ ] Tests cover schema, storage, promotion, update, download, UI, and safe events.
+- [ ] Tests cover schema, storage, promotion, update, download, UI, and observability safety constraints.
 - [ ] `mix format`, `mix test`, and `mix precommit` pass.
 
 ---
@@ -619,13 +583,13 @@ A physical file may be missing or unreadable after DB row exists.
 Mitigation:
 
 - mark Artifact `error` when detected
-- emit `artifact.error`
 - reject from normal tool-safe resolution
 
 ---
 
 ## Future work enabled
 
+- Platform audit/event model should be designed separately. That future design should define durable vs transient events, actor attribution, retention, immutability, event taxonomy, read/download audit, filtering/export, and whether the current `events` table is the audit log or a domain activity log.
 - `pdf.generate -> artifact_id`
 - `email.create_draft -> accepts artifact_id attachments`
 - `approval.request -> displays referenced artifacts`
@@ -635,4 +599,3 @@ Mitigation:
 - external storage backends
 - cross-Department sharing
 - user-uploaded documents/templates
-

--- a/llms/tasks/0010_implement_artifact_model/plan.md
+++ b/llms/tasks/0010_implement_artifact_model/plan.md
@@ -1,0 +1,638 @@
+# Artifact Domain Model — Initial Implementation Plan
+
+## Status
+
+Initial implementation plan for GitHub issue #27.
+
+## Goal
+
+Implement the first Artifact domain model for LemmingsOS.
+
+An Artifact is a manually promoted runtime output backed by a physical file and tracked with durable metadata, scope, provenance, lifecycle status, and a safe storage reference.
+
+This work must establish the foundation for future workflows such as PDF generation, email attachments, approvals, and knowledge ingestion without implementing those workflows now.
+
+---
+
+## Product decisions locked
+
+### File vs Artifact
+
+```text
+File = bytes in workspace/storage.
+Artifact = promoted runtime output with scope, provenance, lifecycle, metadata, and storage reference.
+```
+
+Workspace files remain scratch files by default.
+
+A file becomes an Artifact only when a human manually promotes it from the instance chat/timeline UI.
+
+### Artifact creation
+
+For this issue:
+
+- manual human promotion only
+- no automatic LLM/tool promotion
+- no prompt rules for deciding what becomes an Artifact
+- no direct tool-created Artifacts
+
+### Artifact storage
+
+- Artifact is always backed by a physical file.
+- File bytes are never stored in the database.
+- The database stores metadata and an opaque `storage_ref`.
+- Promoted files are copied into app-managed local artifact storage.
+- The original workspace file is not moved and is not tracked after promotion.
+
+### Scope and provenance
+
+Artifact ownership is scope-based.
+
+Artifact provenance is optional.
+
+- `world_id` required
+- `city_id` nullable
+- `department_id` nullable
+- `lemming_id` nullable
+- `lemming_instance_id` nullable
+- `created_by_tool_execution_id` nullable
+
+Artifacts must survive creator instance cleanup. Provenance references must nilify, not cascade-delete Artifacts.
+
+### Lifecycle
+
+Allowed statuses:
+
+```elixir
+~w(ready archived deleted error)
+```
+
+Promotion creates `ready` Artifacts.
+
+Only `ready` Artifacts are normally visible/selectable/usable by future tools.
+
+`archived`, `deleted`, and `error` are rejected by normal Artifact resolution APIs.
+
+---
+
+## Out of scope
+
+Do not implement:
+
+- automatic LLM/tool promotion
+- prompt rules for Artifact creation
+- MinIO/S3/external storage backends
+- PDF generation
+- email sending or email attachments
+- approval workflow
+- full Artifact browser/library
+- cross-Department sharing
+- public/share links
+- Artifact versioning
+- secret scanning
+- RAG/knowledge ingestion
+- user-uploaded documents/templates
+- physical cleanup/retention/purge
+- rich preview UI for every file type
+
+---
+
+## Proposed implementation phases
+
+## Phase 1 — Data model and schema
+
+### Goal
+
+Introduce the durable Artifact record.
+
+### Tasks
+
+- Add migration for `artifacts` table.
+- Add `LemmingsOs.Artifacts.Artifact` schema.
+- Add schema validations for required fields.
+- Add string validation for allowed `type` values.
+- Add string validation for allowed `status` values.
+- Add basic scope validation.
+- Add nullable provenance associations.
+- Add tests for schema validation and changesets.
+
+### Suggested table
+
+```text
+artifacts
+  id uuid primary key
+
+  world_id uuid not null
+  city_id uuid null
+  department_id uuid null
+  lemming_id uuid null
+  lemming_instance_id uuid null
+  created_by_tool_execution_id uuid null
+
+  type varchar not null
+  filename varchar not null
+  content_type varchar not null
+  storage_ref text not null
+  size_bytes bigint not null
+  checksum varchar not null
+  status varchar not null
+  notes text null
+  metadata jsonb not null default '{}'
+
+  inserted_at timestamp not null
+  updated_at timestamp not null
+```
+
+### Required validations
+
+- `world_id` required
+- `filename` required
+- `type` required
+- `content_type` required
+- `storage_ref` required
+- `size_bytes` required
+- `checksum` required
+- `status` required
+- `metadata` defaults to `%{}`
+- `type` in `markdown | pdf | json | csv | email | html | image | text | other`
+- `status` in `ready | archived | deleted | error`
+
+### Notes
+
+Do not use DB enums.
+
+Use plain string fields and schema/context validation.
+
+---
+
+## Phase 2 — Local artifact storage
+
+### Goal
+
+Create a minimal local storage boundary for managed Artifact files.
+
+### Tasks
+
+- Add config for local Artifact storage root.
+- Add local storage module.
+- Implement copy into managed Artifact storage.
+- Implement SHA-256 checksum calculation.
+- Implement size calculation.
+- Implement safe `storage_ref` generation.
+- Implement internal storage ref resolution for trusted runtime/download code.
+- Add tests for storage path generation, copying, checksum, and size.
+
+### Config
+
+Suggested default:
+
+```elixir
+config :lemmings_os, :artifact_storage,
+  backend: :local,
+  root_path: System.get_env("LEMMINGS_ARTIFACT_STORAGE_PATH", "storage/artifacts")
+```
+
+### Physical layout
+
+```text
+<artifact_storage_root>/<world_id>/<artifact_id>/<filename>
+```
+
+### DB storage ref
+
+```text
+local://artifacts/<world_id>/<artifact_id>/<filename>
+```
+
+### Constraints
+
+Do not store:
+
+- raw workspace path
+- resolved filesystem path
+- file bytes in DB
+- storage root path in logs/events
+
+---
+
+## Phase 3 — Artifacts context API
+
+### Goal
+
+Expose a small context API for creating, promoting, listing, getting, and updating Artifact status.
+
+### Tasks
+
+- Add `LemmingsOs.Artifacts` context.
+- Implement `create_artifact/2`.
+- Implement `promote_workspace_file/2`.
+- Implement `get_artifact/2`.
+- Implement `list_artifacts_for_instance/2`.
+- Implement `list_artifacts_for_scope/2`.
+- Implement `update_artifact_status/3`.
+- Add tests for scope enforcement.
+- Add tests for promotion success and failure.
+- Add tests for status filtering.
+
+### Public functions
+
+```elixir
+create_artifact(scope, attrs)
+promote_workspace_file(scope, attrs)
+get_artifact(scope, artifact_id)
+list_artifacts_for_instance(scope, lemming_instance_id)
+list_artifacts_for_scope(scope)
+update_artifact_status(scope, artifact_id, status)
+```
+
+### Scope rule
+
+All public functions require explicit scope.
+
+No global Artifact lookup.
+
+### Promotion behavior
+
+Promotion must:
+
+1. receive a workspace file path from trusted UI/runtime context
+2. copy the file into managed Artifact storage
+3. compute `size_bytes`
+4. compute SHA-256 `checksum`
+5. create/update Artifact row
+6. emit safe lifecycle events
+7. return safe Artifact descriptor
+
+### Update behavior
+
+If an existing Artifact matches:
+
+```text
+world_id + city_id + department_id + lemming_id + filename
+```
+
+allow update.
+
+Update means:
+
+- overwrite managed Artifact file
+- recompute checksum
+- recompute size
+- keep same Artifact row
+- emit `artifact.updated`
+
+No versioning.
+
+---
+
+## Phase 4 — Observability and events
+
+### Goal
+
+Artifact operations must produce safe audit/telemetry events without leaking content or paths.
+
+### Tasks
+
+- Add `LemmingsOs.Artifacts.Events` or equivalent event helper.
+- Emit events from create/promote/update/status/delete/read/error paths.
+- Ensure reason tokens are safe.
+- Add tests that event payloads do not include raw file contents, workspace paths, storage refs, or resolved paths.
+
+### Required event vocabulary
+
+```text
+artifact.created
+artifact.promoted
+artifact.updated
+artifact.status_changed
+artifact.deleted
+artifact.read
+artifact.promotion_failed
+artifact.error
+```
+
+### Safe event fields
+
+```elixir
+%{
+  artifact_id: artifact.id,
+  world_id: artifact.world_id,
+  city_id: artifact.city_id,
+  department_id: artifact.department_id,
+  lemming_id: artifact.lemming_id,
+  lemming_instance_id: artifact.lemming_instance_id,
+  created_by_tool_execution_id: artifact.created_by_tool_execution_id,
+  filename: artifact.filename,
+  type: artifact.type,
+  content_type: artifact.content_type,
+  status: artifact.status,
+  size_bytes: artifact.size_bytes,
+  checksum: artifact.checksum,
+  reason_token: reason_token
+}
+```
+
+### Forbidden event fields
+
+- file contents
+- `storage_ref`
+- resolved filesystem path
+- raw workspace path
+- full metadata blindly
+- notes by default
+- secret values
+
+---
+
+## Phase 5 — Instance timeline/UI integration
+
+### Goal
+
+Allow operators to manually promote generated workspace files from the existing instance chat/timeline.
+
+### Tasks
+
+- Identify where current file events are rendered in the instance session/timeline.
+- Add `Promote to Artifact` action to file events.
+- Add handler that calls `LemmingsOs.Artifacts.promote_workspace_file/2`.
+- Detect same scope + lemming + filename existing Artifact.
+- Show `Update Artifact` and `Promote as New Artifact` when applicable.
+- Show promoted Artifact reference in timeline.
+- Display notes unobtrusively when present.
+- Add LiveView tests for promotion button and artifact reference rendering.
+
+### Timeline display
+
+Show safe descriptor only:
+
+```text
+filename
+type
+status
+size
+created_at
+creator instance, if known
+tool execution, if known
+```
+
+Do not show:
+
+- raw file contents
+- raw filesystem path
+- storage root path
+- full metadata
+- prompt/model/tool raw output
+
+### Notes UI
+
+`notes` should be visible but not intrusive.
+
+Acceptable UI patterns:
+
+- tooltip
+- popover
+- modal
+- details expansion
+
+Do not send notes to LLM context by default.
+
+---
+
+## Phase 6 — Artifact open/download route
+
+### Goal
+
+Provide minimal controlled open/download behavior from the instance UI.
+
+### Tasks
+
+- Add route for Artifact download/open.
+- Resolve Artifact by explicit scope.
+- Check Artifact belongs to current visible scope.
+- Reject `archived`, `deleted`, and `error` by default.
+- Resolve `storage_ref` internally to local file path.
+- Stream/send file response.
+- Emit `artifact.read` event/telemetry.
+- Add tests for authorized download, missing file, wrong scope, and rejected status.
+
+### Suggested route options
+
+Option A:
+
+```text
+/artifacts/:id/download
+```
+
+Option B:
+
+```text
+/lemmings/instances/:instance_id/artifacts/:artifact_id/download
+```
+
+Prefer whichever aligns better with existing instance UI routes.
+
+### Authorization rule
+
+For this issue:
+
+```text
+User can open/download an Artifact if it belongs to the current visible scope.
+```
+
+No new permission model.
+
+---
+
+## Phase 7 — Documentation
+
+### Goal
+
+Document the Artifact behavior and update architecture references.
+
+### Tasks
+
+- Add `docs/features/artifacts.md`.
+- Update `docs/adr/0008-lemming-persistence-model.md`.
+- Optionally update `docs/adr/0005-tool-execution-model.md` only if needed.
+- Update any operator/developer docs that mention workspace files or generated outputs.
+
+### `docs/features/artifacts.md` should cover
+
+- File vs Artifact
+- Manual promotion rule
+- Scope and provenance
+- Local storage model
+- Type/status model
+- Timeline behavior
+- Download/open behavior
+- Security/privacy rules
+- Observability events
+- Out of scope and future work
+
+### ADR update
+
+`docs/adr/0008-lemming-persistence-model.md` should state:
+
+```text
+Artifacts are durable promoted runtime outputs.
+Artifact metadata is stored in Postgres.
+Artifact bytes are stored outside Postgres in managed file storage.
+Artifact contents are not stored in Postgres, ETS, DETS, logs, or LLM context.
+```
+
+---
+
+## Suggested implementation order
+
+1. Migration + schema
+2. Local storage module
+3. Context API
+4. Promotion/update logic
+5. Events
+6. Download route
+7. Timeline UI integration
+8. Docs
+9. Final tests/precommit
+
+Reason: UI should come after the context/storage contract is stable.
+
+---
+
+## Testing plan
+
+### Unit/context tests
+
+- Artifact changeset validates required fields.
+- Artifact changeset rejects invalid `type`.
+- Artifact changeset rejects invalid `status`.
+- Promotion copies file into managed storage.
+- Promotion computes SHA-256 checksum.
+- Promotion computes size.
+- Promotion does not store original workspace path.
+- Promotion returns safe descriptor.
+- Promotion failure emits safe failure event.
+- Existing Artifact update recomputes checksum and size.
+- `get_artifact/2` enforces scope.
+- `list_artifacts_for_scope/1` excludes deleted/error/archived unless explicitly requested by context function.
+
+### UI/LiveView tests
+
+- File event renders `Promote to Artifact`.
+- Clicking promote creates Artifact.
+- Promoted Artifact appears in timeline.
+- Existing same-scope filename shows update/new options.
+- Artifact reference does not render raw file contents.
+- Notes are not rendered as large inline content.
+
+### Download tests
+
+- Ready Artifact can be downloaded from visible scope.
+- Wrong scope cannot download.
+- Deleted Artifact cannot download.
+- Archived Artifact cannot download.
+- Error Artifact cannot download.
+- Missing physical file marks/returns error safely.
+- Download response does not expose resolved filesystem path.
+
+### Observability tests
+
+- Lifecycle events are emitted.
+- Event payload includes safe metadata.
+- Event payload excludes file contents.
+- Event payload excludes storage ref/resolved paths.
+- Event payload excludes notes/full metadata by default.
+
+---
+
+## Security checklist
+
+- [ ] Artifact context does not access Secret Bank.
+- [ ] Artifact promotion does not inspect file contents for secrets.
+- [ ] Artifact file contents are never logged.
+- [ ] Artifact file contents are never injected into LLM context automatically.
+- [ ] Artifact events do not include `storage_ref` or resolved filesystem path.
+- [ ] Artifact metadata is minimal and schema-validated.
+- [ ] Artifact notes are not emitted in events by default.
+- [ ] Download/open route checks visible scope before resolving file path.
+
+---
+
+## Acceptance criteria
+
+- [ ] Artifact schema/table exists and supports scope, provenance, file metadata, status, notes, and metadata.
+- [ ] Artifact bytes are stored in local artifact storage, not DB.
+- [ ] Artifact storage root is configurable via app config/env var.
+- [ ] Workspace file promotion copies file into managed storage.
+- [ ] Promotion creates `ready` Artifact.
+- [ ] Promotion computes `size_bytes` and SHA-256 `checksum`.
+- [ ] Original workspace path is not persisted.
+- [ ] Manual promotion action exists in instance timeline for file events.
+- [ ] Same scope + lemming + filename can update existing Artifact.
+- [ ] Promoted Artifact appears in timeline as safe reference.
+- [ ] Artifact can be opened/downloaded through controlled route.
+- [ ] Archived/deleted/error Artifacts are not normally selectable or downloadable.
+- [ ] Context APIs require explicit scope.
+- [ ] Events are emitted with safe payloads.
+- [ ] Artifact module does not access Secret Bank.
+- [ ] Artifact contents are not automatically added to LLM context.
+- [ ] `docs/features/artifacts.md` is added.
+- [ ] ADR 0008 is updated.
+- [ ] Tests cover schema, storage, promotion, update, download, UI, and safe events.
+- [ ] `mix format`, `mix test`, and `mix precommit` pass.
+
+---
+
+## Risks / watch points
+
+### Filename-based update matching
+
+Matching by scope + lemming + filename is simple, but filename collisions are possible.
+
+Mitigation:
+
+- show explicit UI choice: `Update Artifact` vs `Promote as New Artifact`
+- never silently overwrite without user action
+
+### Storage ref leakage
+
+`storage_ref` and resolved filesystem paths should remain internal.
+
+Mitigation:
+
+- public APIs return safe descriptors only
+- download route resolves path internally after scope check
+- events/logs use `artifact_id`
+
+### Scope ambiguity
+
+Artifacts can exist at World/City/Department scope.
+
+Mitigation:
+
+- validate legal scope shapes
+- require explicit scope in every public context function
+
+### Error lifecycle
+
+A physical file may be missing or unreadable after DB row exists.
+
+Mitigation:
+
+- mark Artifact `error` when detected
+- emit `artifact.error`
+- reject from normal tool-safe resolution
+
+---
+
+## Future work enabled
+
+- `pdf.generate -> artifact_id`
+- `email.create_draft -> accepts artifact_id attachments`
+- `approval.request -> displays referenced artifacts`
+- `knowledge.upload -> ingests artifact_id`
+- Artifact browser/library
+- Artifact versioning
+- external storage backends
+- cross-Department sharing
+- user-uploaded documents/templates
+

--- a/llms/tasks/0010_implement_artifact_model/test_plan.md
+++ b/llms/tasks/0010_implement_artifact_model/test_plan.md
@@ -1,0 +1,173 @@
+# Artifact Model Test Scenario Matrix
+
+## Scope & Assumptions
+- Scope: Task 0010 Artifact model implementation (Tasks 01-10), with explicit focus on acceptance coverage requested by Task 06.
+- Source documents read: `llms/constitution.md`, `llms/coding_styles/elixir_tests.md`, `llms/tasks/0010_implement_artifact_model/plan.md`, and Task 01-05 outputs.
+- Test style assumptions:
+  - Use factory-driven deterministic setup (`insert/2`, `build/2`).
+  - No external network calls in tests.
+  - Use stable selectors/IDs for LiveView assertions.
+  - Scope arguments are explicit (`world`/scope struct), no implicit global lookups.
+- This document defines what to test; it does not implement tests.
+
+## Risk Areas
+- Scope escape: wrong-world or wrong-instance artifact access.
+- File/path safety: traversal, symlink escape, invalid local storage refs.
+- Lifecycle safety: non-ready artifacts accidentally selectable/downloadable.
+- Data leakage: workspace paths, storage refs, notes, raw metadata, content leaking via descriptors/logs/errors/UI.
+- Update semantics: accidental overwrite without explicit update mode.
+- Reliability: missing physical file after DB row exists; safe degradation.
+- Non-goals drift: durable Artifact lifecycle events or Secret Bank usage introduced by mistake.
+
+## Scenario ID Groups
+- `SCH-*`: schema and changeset validations.
+- `STO-*`: local storage boundary.
+- `CTX-*`: Artifacts context API and scope filtering.
+- `PRO-*`: promotion/update flows.
+- `OBS-*`: observability and safety guarantees.
+- `DL-*`: download/open controller route behavior.
+- `UI-*`: instance timeline promotion and rendering behavior.
+- `SEC-*`: security, leakage, and forbidden integrations.
+- `REL-*`: release and end-to-end validation commands.
+
+## Scenario Matrix
+| ID | Priority | Layer | Area | Scenario | Preconditions | Steps | Expected Result | Notes |
+|---|---|---|---|---|---|---|---|---|
+| SCH-01 | P0 | Unit | Validation | Required Artifact fields enforced | Valid world IDs/factory attrs | Remove one required field per case and validate changeset | Changeset invalid with localized error | `world_id`, `filename`, `type`, `content_type`, `storage_ref`, `size_bytes`, `checksum`, `status`, `metadata` |
+| SCH-02 | P0 | Unit | Validation | Allowed `type` whitelist | Baseline valid attrs | Iterate invalid and valid types | Invalid rejected, allowed types accepted | `markdown,pdf,json,csv,email,html,image,text,other` |
+| SCH-03 | P0 | Unit | Validation | Allowed `status` whitelist | Baseline valid attrs | Iterate invalid and valid statuses | Invalid rejected, allowed statuses accepted | `ready,archived,deleted,error` |
+| SCH-04 | P1 | Unit | Validation | Metadata default and contract validation | Baseline attrs | Omit metadata; then add disallowed keys | Omitted defaults to `%{}`; disallowed payload rejected | Protect against prompt/output/secret dumps |
+| SCH-05 | P0 | Integration | DB/Schema | Provenance nullify behavior on delete | Artifact references instance/tool execution | Delete referenced provenance rows | Artifact remains; provenance FK fields nilified | Ensures Artifacts survive instance cleanup |
+| STO-01 | P0 | Unit | Filesystem Safety | Storage ref builder output format | world_id + artifact_id + filename | Build storage ref | Exact `local://artifacts/<world>/<artifact>/<filename>` format | Opaque DB-facing value |
+| STO-02 | P0 | Unit | Filesystem Safety | Reject invalid `storage_ref` patterns | None | Resolve refs with traversal/absolute/backslash/drive/null byte inputs | Resolution returns safe error | Includes platform-specific separators |
+| STO-03 | P0 | Unit | Filesystem Safety | Copy source file into managed storage | Temp source file exists | Run `store_copy` | File copied, checksum + size computed correctly | Bytes only in filesystem, never DB |
+| STO-04 | P0 | Unit | Security | Symlink escape detection | Managed dir + outside file + symlink | Resolve/read symlink target | Operation fails safely if target escapes root | Must deny outside-root read |
+| STO-05 | P1 | Unit | Safety | Managed storage path not exposed by API | Created artifact | Inspect returned descriptor/log payloads | No root path or resolved absolute path present | Internal-only storage path |
+| CTX-01 | P0 | Integration | Scope/Auth | `create_artifact/2` enforces world scope consistency | Scope + attrs with mismatched world_id | Call create | Returns `{:error, :scope_mismatch}` | No row written |
+| CTX-02 | P0 | Integration | Scope/Auth | `get_artifact` default returns ready-only | Ready + archived rows in-scope | Call `get_artifact/2` and include_non_ready variant | Default hides archived; opt-in can fetch | Also verify wrong-world not found |
+| CTX-03 | P0 | Integration | Scope/Auth | `list_artifacts_for_scope` status filtering | Mixed statuses | Call default and explicit statuses | Default only ready; explicit statuses honored | Deleted/error excluded by default |
+| CTX-04 | P0 | Integration | Scope/Auth | `list_artifacts_for_instance` isolates instance | Two instances same world | Query by instance id | Only target instance artifacts returned | No cross-instance bleed |
+| CTX-05 | P1 | Integration | Lifecycle | `update_artifact_status/3` accepts only allowed statuses | Ready artifact | Update to archived/deleted/error/invalid | Allowed transitions persist; invalid rejected | Validate world scoping |
+| CTX-06 | P0 | Unit | Safety | Public descriptor omits `storage_ref` and internal paths | Artifact row exists | Call descriptor helper/public API | Safe descriptor excludes sensitive fields | Includes id/filename/type/status/size/checksum/timestamps only |
+| PRO-01 | P0 | Integration | Promotion | Promote workspace file to ready artifact | Instance scope + workspace file exists | Call `promote_workspace_file/2` | Row created `status=ready`; bytes copied; checksum/size set | Manual promotion only |
+| PRO-02 | P0 | Integration | Promotion | Promotion copies file without moving source | Workspace file exists | Promote then re-read source | Source file remains unchanged | No destructive move |
+| PRO-03 | P0 | Integration | Promotion | Original workspace path not persisted | Workspace path contains sentinel | Promote and inspect DB/descriptor | Raw workspace path absent from row + descriptor | Check metadata, notes, filename, storage_ref fields |
+| PRO-04 | P0 | Integration | Update Semantics | Collision requires explicit mode | Existing same scope+lemming+filename | Promote with missing/ambiguous mode | Safe error; no overwrite | Prevent silent updates |
+| PRO-05 | P0 | Integration | Update Semantics | `mode: :update_existing` overwrites managed bytes | Existing artifact + new source bytes | Promote with update mode | Same artifact row kept; checksum/size updated | Deterministic before/after assertions |
+| PRO-06 | P0 | Integration | Update Semantics | `mode: :promote_as_new` creates distinct artifact | Existing artifact present | Promote with promote_as_new | New artifact row created; old row preserved | Non-unique filename index intent |
+| PRO-07 | P0 | Integration | Failure Safety | Missing source file fails safely | Non-existent workspace path | Attempt promotion | Safe error token; no content/path leakage | No partial artifact row |
+| PRO-08 | P1 | Integration | Failure Safety | Invalid source path traversal is rejected | Path like `../secret.txt` | Attempt promotion | `{:error, :invalid_path}` (or equivalent safe token) | No filesystem escape |
+| OBS-01 | P0 | Integration | Observability | No durable Artifact lifecycle writes to `events` | Baseline event count | Promote/update/read/download flows | No new durable Artifact lifecycle rows | Task 05 scope lock |
+| OBS-02 | P0 | Unit | Observability | If telemetry/logs exist, payload allowlist only | Telemetry handler/log capture | Trigger success/failure operations | Payload excludes content/storage_ref/paths/notes/full metadata/secrets | Verify key set explicitly |
+| OBS-03 | P1 | Unit | Observability | Failure reasons normalized to safe tokens | Controlled failure cases | Inspect emitted reason | Reason values are bounded tokens | No exception dumps |
+| DL-01 | P0 | Integration | Controller/Auth | Ready artifact downloads within visible scope | Instance + ready artifact + file exists | GET durable download route with valid world scope | `200`, attachment headers, file bytes returned | Route must be before workspace catch-all |
+| DL-02 | P0 | Integration | Controller/Auth | Wrong scope denied before path resolution | Artifact in different world | Request with unrelated world scope | 404/forbidden-style safe failure | Assert storage resolution not invoked first |
+| DL-03 | P0 | Integration | Controller/Lifecycle | Archived/deleted/error artifacts blocked | Artifact statuses set non-ready | Request download | Safe not found/forbidden, no file send | Default policy is ready-only |
+| DL-04 | P0 | Integration | Controller/Failure | Missing physical file handled safely | DB row exists, file removed | Request download | Safe failure; optional status update to `error`; no path leak | Ensure deterministic response code |
+| DL-05 | P0 | Integration | Controller/Security | Response headers are safe | Ready artifact exists | Request download | `x-content-type-options: nosniff`, safe content disposition | No absolute path in headers/body |
+| DL-06 | P1 | Integration | Controller/Compatibility | Existing workspace artifact route still works | Workspace file in instance work area | Request legacy catch-all route | Existing behavior unchanged | Prevent regression from route ordering |
+| UI-01 | P0 | LiveView | Timeline UX | File event renders `Promote to Artifact` action | Timeline includes file-producing tool event | Render view and target stable control ID | Action visible and actionable | Stable DOM IDs required |
+| UI-02 | P0 | LiveView | Promotion UX | Promote action creates and displays artifact reference | Same as UI-01 | Trigger promote action | Timeline shows safe artifact descriptor fields | No raw file content dump |
+| UI-03 | P0 | LiveView | Update/New UX | Existing filename collision presents update/new choices | Existing artifact same scope+filename | Open promotion UI | Both actions available with explicit mode intent | Prevent implicit overwrite |
+| UI-04 | P1 | LiveView | Notes Rendering | Notes are visible but non-intrusive | Artifact has notes | Render artifact reference | Notes shown via compact UI pattern | Avoid large inline blocks |
+| UI-05 | P0 | LiveView | Safe Rendering | Descriptor rendering excludes `storage_ref`/paths/content | Artifact with sentinel sensitive values | Render timeline row | Sentinel sensitive values absent from UI | Validate escaped/safe text rendering |
+| SEC-01 | P0 | Unit | Security | Artifact code has no Secret Bank dependency | None | Static grep + compile references | No direct/indirect Secret Bank calls in artifact modules | Include tests/docs guard note |
+| SEC-02 | P0 | Integration | Security | Artifact contents not auto-injected into LLM runtime context | Artifact exists with unique sentinel content | Trigger runtime context assembly flow | Sentinel content absent unless explicitly referenced by feature | Protect default model context |
+| SEC-03 | P0 | Integration | Security | Path traversal and symlink escape across promotion + download | Malicious workspace path/symlink setup | Attempt promote/download | Requests fail safely without leakage | End-to-end hardening case |
+| SEC-04 | P1 | Integration | Security | Wrong-scope artifact IDs are non-enumerable | Multiple worlds with known IDs | Probe cross-world IDs | Consistent safe not-found behavior | No existence oracle |
+| REL-01 | P0 | Manual/CI | Validation | Narrow suites pass for touched layer | Tests implemented per layer | Run narrow `mix test` targets | All targeted suites green | Use before full suite |
+| REL-02 | P0 | Manual/CI | Validation | Full `mix test` passes | Code complete | Run `mix test` | All tests pass | Zero failures |
+| REL-03 | P0 | Manual/CI | Validation | Final `mix precommit` passes | Formatting + tests + credo/dialyzer ready | Run `mix precommit` | Passes with zero warnings/errors | Required quality gate |
+
+## Acceptance Criteria Mapping
+| Plan Acceptance Criterion | Scenario Coverage |
+|---|---|
+| Schema/table supports scope/provenance/metadata/lifecycle | SCH-01, SCH-02, SCH-03, SCH-04, SCH-05 |
+| Bytes in local storage, not DB | STO-03, PRO-01, PRO-02 |
+| Configurable artifact storage root | STO-01, STO-03 |
+| Promotion copies workspace file into managed storage | PRO-01, PRO-02 |
+| Promotion creates `ready` artifact | PRO-01 |
+| Promotion computes `size_bytes` and SHA-256 | STO-03, PRO-01, PRO-05 |
+| Original workspace path not persisted | PRO-03 |
+| Manual promotion action exists in timeline | UI-01 |
+| Same scope + lemming + filename can update existing | PRO-05, UI-03 |
+| Promoted artifact appears in timeline as safe reference | UI-02, UI-05 |
+| Controlled open/download route | DL-01 |
+| `archived/deleted/error` not selectable/downloadable by default | CTX-02, CTX-03, DL-03 |
+| Context APIs require explicit scope | CTX-01, CTX-02, CTX-03, CTX-04 |
+| No durable Artifact lifecycle writes to `events` | OBS-01 |
+| Artifact module does not access Secret Bank | SEC-01 |
+| Artifact contents not auto-added to LLM context | SEC-02 |
+| Docs updated (features + ADR) | REL-01 (docs-touch verification within slice), REL-03 |
+| Tests cover schema/storage/promotion/update/download/UI/observability safety | SCH-*, STO-*, CTX-*, PRO-*, OBS-*, DL-*, UI-*, SEC-* |
+| `mix format`, `mix test`, `mix precommit` pass | REL-01, REL-02, REL-03 |
+
+## Leakage/Security Matrix (Sentinel Values)
+Use fixed sentinel values in tests to detect unintended leakage across DB rows, descriptors, logs, telemetry, controller responses, and LiveView rendering.
+
+| Sentinel | Example Value | Must Never Appear In | Covered By |
+|---|---|---|---|
+| Secret token | `sk_test_artifact_leak_9f6d` | logs, telemetry payloads, descriptors, UI, HTTP errors | OBS-02, UI-05, DL-04, SEC-02 |
+| Workspace absolute path | `/tmp/workspaces/w1/i1/private/secret.txt` | DB metadata, descriptors, logs, HTTP bodies | PRO-03, PRO-07, DL-04 |
+| Storage ref | `local://artifacts/world/artifact/secret.md` | UI labels, public descriptors, logs by default | CTX-06, UI-05, OBS-02 |
+| Resolved storage root path | `/var/lib/lemmings/artifacts/world/a1/secret.md` | headers, response body, logs, telemetry | STO-05, DL-05, OBS-02 |
+| Notes sentinel | `NOTE_LEAK_SENTINEL_DO_NOT_LOG` | logs/telemetry and large inline timeline blocks | UI-04, OBS-02 |
+| Raw content sentinel | `TOP_SECRET_ARTIFACT_CONTENT` | DB fields other than managed file bytes, logs, descriptors, default runtime context | PRO-01, PRO-03, OBS-02, SEC-02 |
+
+## Acceptance Criteria (Given/When/Then)
+- Given an artifact outside the visible world scope, when it is requested through context or download route, then it is rejected with a safe not-found/forbidden-style result.
+- Given an artifact in `archived`, `deleted`, or `error` status, when default list/get/download APIs are used, then it is excluded or rejected.
+- Given a managed artifact row whose file is missing, when download is requested, then the request fails safely without exposing filesystem details and without durable event writes.
+- Given a malicious path (`../`, absolute path, symlink escape), when promotion or resolution is attempted, then the operation is rejected and no sensitive values leak.
+- Given an existing same-scope same-filename artifact, when promotion is requested without explicit mode, then no overwrite occurs and a safe collision result is returned.
+- Given explicit `update_existing`, when promotion succeeds, then checksum/size are recomputed and the same artifact row is preserved.
+- Given explicit `promote_as_new`, when promotion succeeds, then a new artifact row is created while prior rows remain.
+- Given timeline promotion and artifact rendering, when the UI displays descriptors, then only safe descriptor fields are shown and no raw contents/storage refs/internal paths are rendered.
+- Given observability hooks around artifact operations, when events are emitted, then payloads contain allowlisted metadata only and no durable Artifact lifecycle rows are written to `events`.
+- Given runtime context assembly for LLM calls, when no explicit artifact-reference feature is used, then artifact content is not injected automatically.
+
+## Required Narrow Test Commands
+Run narrow commands by layer first, then full validation.
+
+1. Schema/storage/context/promotion:
+```bash
+mix test test/lemmings_os/artifacts/artifact_test.exs \
+  test/lemmings_os/artifacts/local_storage_test.exs \
+  test/lemmings_os/artifacts_test.exs \
+  test/lemmings_os/artifacts/promotion_test.exs
+```
+2. Download/controller scope and headers (after Task 07 test file exists):
+```bash
+mix test test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+```
+3. LiveView promotion/update/new rendering (after Task 08/09 updates):
+```bash
+mix test test/lemmings_os_web/live/instance_live_test.exs
+```
+4. Artifact + runtime non-injection guard:
+```bash
+mix test test/lemmings_os/lemming_calls_runtime_test.exs
+```
+5. Final suite:
+```bash
+mix test
+mix precommit
+```
+
+## Regression Checklist
+- [ ] No silent artifact overwrite on filename collision.
+- [ ] No wrong-scope artifact fetch/download.
+- [ ] No non-ready artifact default visibility/download.
+- [ ] No raw workspace or resolved storage paths in DB/public outputs.
+- [ ] No `storage_ref` leakage outside trusted internal boundary.
+- [ ] No durable Artifact lifecycle rows written to `events`.
+- [ ] No Secret Bank calls inside Artifact modules.
+- [ ] No automatic artifact content injection into LLM context.
+- [ ] Route ordering preserves both durable download route and legacy workspace catch-all route.
+- [ ] Stable LiveView selectors/IDs cover promote/update/new actions.
+
+## Out-of-scope
+- Durable audit/event taxonomy design and retention policy.
+- External storage backends (S3/MinIO).
+- Automatic LLM/tool-driven artifact promotion.
+- Artifact version history and full artifact library UX.

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -136,10 +136,10 @@ msgstr "Attempting to reconnect"
 msgid ".error_something_went_wrong"
 msgstr "Something went wrong!"
 
-#: lib/lemmings_os_web/live/cities_live.ex:177
-#: lib/lemmings_os_web/live/departments_live.ex:159
-#: lib/lemmings_os_web/live/lemmings_live.ex:157
-#: lib/lemmings_os_web/live/world_live.ex:76
+#: lib/lemmings_os_web/live/cities_live.ex:179
+#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/lemmings_live.ex:160
+#: lib/lemmings_os_web/live/world_live.ex:78
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr "Invalid secret key format. Use UPPERCASE letters, numbers, and _."
@@ -278,6 +278,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "Lemming deletion is not available because safety cannot yet be proven."
 
+#: lib/lemmings_os/artifacts/artifact.ex:105
+#: lib/lemmings_os/artifacts/artifact.ex:106
+#: lib/lemmings_os/artifacts/artifact.ex:211
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -293,6 +296,7 @@ msgstr "Lemming deletion is not available because safety cannot yet be proven."
 msgid ".invalid_choice"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:179
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -301,6 +305,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:104
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -312,11 +317,14 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os/secret_bank/secret.ex:64
-#: lib/lemmings_os_web/live/instance_live.ex:685
+#: lib/lemmings_os_web/live/instance_live.ex:747
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:109
+#: lib/lemmings_os/artifacts/artifact.ex:151
+#: lib/lemmings_os/artifacts/artifact.ex:203
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139
@@ -450,76 +458,76 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:170
-#: lib/lemmings_os_web/live/cities_live.ex:209
-#: lib/lemmings_os_web/live/cities_live.ex:274
-#: lib/lemmings_os_web/live/cities_live.ex:360
-#: lib/lemmings_os_web/live/cities_live.ex:387
-#: lib/lemmings_os_web/live/cities_live.ex:415
-#: lib/lemmings_os_web/live/cities_live.ex:433
+#: lib/lemmings_os_web/live/cities_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:211
+#: lib/lemmings_os_web/live/cities_live.ex:276
+#: lib/lemmings_os_web/live/cities_live.ex:362
+#: lib/lemmings_os_web/live/cities_live.ex:389
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:435
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr "City is unavailable"
 
-#: lib/lemmings_os_web/live/departments_live.ex:152
-#: lib/lemmings_os_web/live/departments_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:261
-#: lib/lemmings_os_web/live/departments_live.ex:355
-#: lib/lemmings_os_web/live/departments_live.ex:382
-#: lib/lemmings_os_web/live/departments_live.ex:410
-#: lib/lemmings_os_web/live/departments_live.ex:428
+#: lib/lemmings_os_web/live/departments_live.ex:154
+#: lib/lemmings_os_web/live/departments_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:263
+#: lib/lemmings_os_web/live/departments_live.ex:357
+#: lib/lemmings_os_web/live/departments_live.ex:384
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:430
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr "Department is unavailable"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:150
-#: lib/lemmings_os_web/live/lemmings_live.ex:189
+#: lib/lemmings_os_web/live/lemmings_live.ex:153
+#: lib/lemmings_os_web/live/lemmings_live.ex:192
 #, elixir-autogen, elixir-format
 msgid ".error_lemming_unavailable"
 msgstr "Lemming is unavailable"
 
-#: lib/lemmings_os_web/live/cities_live.ex:223
-#: lib/lemmings_os_web/live/departments_live.ex:208
-#: lib/lemmings_os_web/live/lemmings_live.ex:203
-#: lib/lemmings_os_web/live/world_live.ex:120
+#: lib/lemmings_os_web/live/cities_live.ex:225
+#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/lemmings_live.ex:206
+#: lib/lemmings_os_web/live/world_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr "Failed to delete secret"
 
-#: lib/lemmings_os_web/live/cities_live.ex:216
-#: lib/lemmings_os_web/live/departments_live.ex:201
-#: lib/lemmings_os_web/live/lemmings_live.ex:196
-#: lib/lemmings_os_web/live/world_live.ex:113
+#: lib/lemmings_os_web/live/cities_live.ex:218
+#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/lemmings_live.ex:199
+#: lib/lemmings_os_web/live/world_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr "Only local values can be deleted at this scope"
 
-#: lib/lemmings_os_web/live/cities_live.ex:220
-#: lib/lemmings_os_web/live/departments_live.ex:205
-#: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:117
+#: lib/lemmings_os_web/live/cities_live.ex:222
+#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/lemmings_live.ex:203
+#: lib/lemmings_os_web/live/world_live.ex:119
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr "Secret key not found"
 
-#: lib/lemmings_os_web/live/cities_live.ex:192
-#: lib/lemmings_os_web/live/departments_live.ex:177
-#: lib/lemmings_os_web/live/lemmings_live.ex:172
-#: lib/lemmings_os_web/live/world_live.ex:91
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/lemmings_live.ex:175
+#: lib/lemmings_os_web/live/world_live.ex:93
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr "Failed to save secret"
 
-#: lib/lemmings_os_web/live/cities_live.ex:185
-#: lib/lemmings_os_web/live/departments_live.ex:170
-#: lib/lemmings_os_web/live/lemmings_live.ex:165
-#: lib/lemmings_os_web/live/world_live.ex:84
+#: lib/lemmings_os_web/live/cities_live.ex:187
+#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/lemmings_live.ex:168
+#: lib/lemmings_os_web/live/world_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr "Secret value is required"
 
-#: lib/lemmings_os_web/live/world_live.ex:69
-#: lib/lemmings_os_web/live/world_live.ex:106
+#: lib/lemmings_os_web/live/world_live.ex:71
+#: lib/lemmings_os_web/live/world_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr "World is unavailable"

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -78,7 +78,7 @@ msgid ".nav_departments"
 msgstr "Departments"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:681
+#: lib/lemmings_os_web/components/world_components.ex:699
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -106,7 +106,7 @@ msgid ".nav_settings"
 msgstr "Settings"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:996
+#: lib/lemmings_os_web/components/world_components.ex:1025
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "New Lemming"
@@ -203,22 +203,22 @@ msgstr "Environment Notes"
 msgid ".page_title_home"
 msgstr "Home"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:26
+#: lib/lemmings_os_web/live/lemmings_live.ex:27
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/live/cities_live.ex:46
+#: lib/lemmings_os_web/live/cities_live.ex:47
 #, elixir-autogen
 msgid ".page_title_cities"
 msgstr "Cities"
 
-#: lib/lemmings_os_web/live/departments_live.ex:27
+#: lib/lemmings_os_web/live/departments_live.ex:28
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/live/world_live.ex:23
+#: lib/lemmings_os_web/live/world_live.ex:24
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr "World"
@@ -918,60 +918,60 @@ msgstr "Name"
 msgid ".connections_empty"
 msgstr "No visible connections for this scope."
 
-#: lib/lemmings_os_web/live/cities_live.ex:269
-#: lib/lemmings_os_web/live/departments_live.ex:256
-#: lib/lemmings_os_web/live/world_live.ex:164
+#: lib/lemmings_os_web/live/cities_live.ex:271
+#: lib/lemmings_os_web/live/departments_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:166
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr "Connection created."
 
-#: lib/lemmings_os_web/live/cities_live.ex:383
-#: lib/lemmings_os_web/live/departments_live.ex:378
-#: lib/lemmings_os_web/live/world_live.ex:278
+#: lib/lemmings_os_web/live/cities_live.ex:385
+#: lib/lemmings_os_web/live/departments_live.ex:380
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr "Connection deleted."
 
-#: lib/lemmings_os_web/live/cities_live.ex:284
-#: lib/lemmings_os_web/live/cities_live.ex:338
-#: lib/lemmings_os_web/live/cities_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:274
-#: lib/lemmings_os_web/live/departments_live.ex:333
-#: lib/lemmings_os_web/live/departments_live.ex:359
-#: lib/lemmings_os_web/live/world_live.ex:180
-#: lib/lemmings_os_web/live/world_live.ex:238
-#: lib/lemmings_os_web/live/world_live.ex:261
+#: lib/lemmings_os_web/live/cities_live.ex:286
+#: lib/lemmings_os_web/live/cities_live.ex:340
+#: lib/lemmings_os_web/live/cities_live.ex:366
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:335
+#: lib/lemmings_os_web/live/departments_live.ex:361
+#: lib/lemmings_os_web/live/world_live.ex:182
+#: lib/lemmings_os_web/live/world_live.ex:240
+#: lib/lemmings_os_web/live/world_live.ex:263
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr "Invalid connection payload. Provide valid YAML or JSON."
 
-#: lib/lemmings_os_web/live/cities_live.ex:300
-#: lib/lemmings_os_web/live/cities_live.ex:332
-#: lib/lemmings_os_web/live/cities_live.ex:367
-#: lib/lemmings_os_web/live/cities_live.ex:390
-#: lib/lemmings_os_web/live/cities_live.ex:418
-#: lib/lemmings_os_web/live/departments_live.ex:294
-#: lib/lemmings_os_web/live/departments_live.ex:327
-#: lib/lemmings_os_web/live/departments_live.ex:362
-#: lib/lemmings_os_web/live/departments_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:413
-#: lib/lemmings_os_web/live/world_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:232
-#: lib/lemmings_os_web/live/world_live.ex:264
-#: lib/lemmings_os_web/live/world_live.ex:284
-#: lib/lemmings_os_web/live/world_live.ex:307
+#: lib/lemmings_os_web/live/cities_live.ex:302
+#: lib/lemmings_os_web/live/cities_live.ex:334
+#: lib/lemmings_os_web/live/cities_live.ex:369
+#: lib/lemmings_os_web/live/cities_live.ex:392
+#: lib/lemmings_os_web/live/cities_live.ex:420
+#: lib/lemmings_os_web/live/departments_live.ex:296
+#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:364
+#: lib/lemmings_os_web/live/departments_live.ex:387
+#: lib/lemmings_os_web/live/departments_live.ex:415
+#: lib/lemmings_os_web/live/world_live.ex:202
+#: lib/lemmings_os_web/live/world_live.ex:234
+#: lib/lemmings_os_web/live/world_live.ex:266
+#: lib/lemmings_os_web/live/world_live.ex:286
+#: lib/lemmings_os_web/live/world_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr "Only local connections can be changed here."
 
-#: lib/lemmings_os_web/live/world_live.ex:184
+#: lib/lemmings_os_web/live/world_live.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr "Scope is unavailable."
 
-#: lib/lemmings_os_web/live/cities_live.ex:411
-#: lib/lemmings_os_web/live/departments_live.ex:406
-#: lib/lemmings_os_web/live/world_live.ex:303
+#: lib/lemmings_os_web/live/cities_live.ex:413
+#: lib/lemmings_os_web/live/departments_live.ex:408
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr "Connection status updated."
@@ -981,16 +981,16 @@ msgstr "Connection status updated."
 msgid ".connections_flash_test_failed"
 msgstr "Connection test failed."
 
-#: lib/lemmings_os_web/live/cities_live.ex:429
-#: lib/lemmings_os_web/live/departments_live.ex:424
-#: lib/lemmings_os_web/live/world_live.ex:316
+#: lib/lemmings_os_web/live/cities_live.ex:431
+#: lib/lemmings_os_web/live/departments_live.ex:426
+#: lib/lemmings_os_web/live/world_live.ex:318
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr "Connection tested."
 
-#: lib/lemmings_os_web/live/cities_live.ex:356
-#: lib/lemmings_os_web/live/departments_live.ex:351
-#: lib/lemmings_os_web/live/world_live.ex:254
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/departments_live.ex:353
+#: lib/lemmings_os_web/live/world_live.ex:256
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr "Connection updated."
@@ -1060,8 +1060,8 @@ msgstr "Unknown"
 msgid ".connections_source_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/world_components.ex:234
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:237
+#: lib/lemmings_os_web/components/world_components.ex:841
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
@@ -1078,3 +1078,89 @@ msgstr "Read-only scope visibility and inheritance."
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
 msgstr "Connections"
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:44
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:18
+#: lib/lemmings_os_web/components/artifacts_components.ex:35
+#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:1072
+#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:851
+#: lib/lemmings_os_web/live/cities_live.html.heex:256
+#, elixir-autogen, elixir-format
+msgid "Artifacts"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:21
+#, elixir-autogen, elixir-format
+msgid "Artifacts available at this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:43
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:116
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:113
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:38
+#, elixir-autogen, elixir-format
+msgid "Filename"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:30
+#, elixir-autogen, elixir-format
+msgid "No artifacts available for this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:39
+#, elixir-autogen, elixir-format
+msgid "Scope"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:42
+#, elixir-autogen, elixir-format
+msgid "Size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:41
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:40
+#, elixir-autogen, elixir-format
+msgid "Type"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:66
+#, elixir-autogen, elixir-format
+msgid "city"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:73
+#, elixir-autogen, elixir-format
+msgid "dept"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:80
+#, elixir-autogen, elixir-format
+msgid "lemming"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "world"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/en/LC_MESSAGES/lemmings.po
@@ -47,19 +47,19 @@ msgstr "All Lemmings"
 msgid ".subtitle_all_lemmings"
 msgstr "Browse persisted lemming definitions across the current world and open the one you want to inspect."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:842
-#: lib/lemmings_os_web/components/lemming_components.ex:898
+#: lib/lemmings_os_web/components/lemming_components.ex:862
+#: lib/lemmings_os_web/components/lemming_components.ex:918
 #, elixir-autogen
 msgid ".title_create_lemming"
 msgstr "Create New Lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:468
-#: lib/lemmings_os_web/components/lemming_components.ex:904
+#: lib/lemmings_os_web/components/lemming_components.ex:482
+#: lib/lemmings_os_web/components/lemming_components.ex:924
 #, elixir-autogen
 msgid ".label_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:909
+#: lib/lemmings_os_web/components/lemming_components.ex:929
 #, elixir-autogen
 msgid ".placeholder_name"
 msgstr "e.g. Turing"
@@ -69,97 +69,97 @@ msgstr "e.g. Turing"
 msgid ".page_title_create_lemming"
 msgstr "Create Lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:236
+#: lib/lemmings_os_web/components/lemming_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_activate"
 msgstr "Activate"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:247
+#: lib/lemmings_os_web/components/lemming_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_archive"
 msgstr "Archive"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:392
+#: lib/lemmings_os_web/components/lemming_components.ex:406
 #, elixir-autogen, elixir-format
 msgid ".copy_inheriting_all_config"
 msgstr "This lemming is inheriting all configuration from its parent scopes."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:623
+#: lib/lemmings_os_web/components/lemming_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".copy_instances_workspace_selected"
 msgstr "%{name} is selected. This area is reserved for running instances and future interaction tools."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:423
+#: lib/lemmings_os_web/components/lemming_components.ex:437
 #, elixir-autogen, elixir-format
 msgid ".detail_allowed_tools"
 msgstr "Allowed Tools"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:437
+#: lib/lemmings_os_web/components/lemming_components.ex:451
 #, elixir-autogen, elixir-format
 msgid ".detail_denied_tools"
 msgstr "Denied Tools"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:410
+#: lib/lemmings_os_web/components/lemming_components.ex:424
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_cross_city"
 msgstr "Cross-City Access"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:415
+#: lib/lemmings_os_web/components/lemming_components.ex:429
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_daily_tokens"
 msgstr "Daily Tokens"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:405
+#: lib/lemmings_os_web/components/lemming_components.ex:419
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_idle_ttl"
 msgstr "Idle TTL"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:398
+#: lib/lemmings_os_web/components/lemming_components.ex:412
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_max_lemmings"
 msgstr "Max Lemmings"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:378
+#: lib/lemmings_os_web/components/lemming_components.ex:392
 #, elixir-autogen, elixir-format
 msgid ".detail_instructions"
 msgstr "Instructions"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:589
+#: lib/lemmings_os_web/components/lemming_components.ex:609
 #, elixir-autogen, elixir-format
 msgid ".detail_spawn_requests"
 msgstr "Spawn Requests"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:268
+#: lib/lemmings_os_web/components/lemming_components.ex:270
 #, elixir-autogen, elixir-format
 msgid ".detail_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:629
+#: lib/lemmings_os_web/components/lemming_components.ex:649
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace"
 msgstr "No lemming selected"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:630
+#: lib/lemmings_os_web/components/lemming_components.ex:650
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace_copy"
 msgstr "Select a lemming type to prepare room for future instances, sessions, and launch actions."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:280
+#: lib/lemmings_os_web/components/lemming_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found"
 msgstr "Lemming not found"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:281
+#: lib/lemmings_os_web/components/lemming_components.ex:283
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found_copy"
 msgstr "The requested lemming does not exist in the current persisted topology."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:430
+#: lib/lemmings_os_web/components/lemming_components.ex:444
 #, elixir-autogen, elixir-format
 msgid ".empty_no_allowed_tools"
 msgstr "No allowed tools"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:444
+#: lib/lemmings_os_web/components/lemming_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".empty_no_denied_tools"
 msgstr "No denied tools"
@@ -181,58 +181,58 @@ msgstr "Adjust the filters or create a new lemming type for this city or departm
 
 #: lib/lemmings_os_web/components/lemming_components.ex:65
 #: lib/lemmings_os_web/components/lemming_components.ex:128
-#: lib/lemmings_os_web/components/lemming_components.ex:258
-#: lib/lemmings_os_web/components/lemming_components.ex:876
-#: lib/lemmings_os_web/components/lemming_components.ex:999
+#: lib/lemmings_os_web/components/lemming_components.ex:260
+#: lib/lemmings_os_web/components/lemming_components.ex:896
+#: lib/lemmings_os_web/components/lemming_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid ".filter_city"
 msgstr "City"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:67
-#: lib/lemmings_os_web/components/lemming_components.ex:878
+#: lib/lemmings_os_web/components/lemming_components.ex:898
 #, elixir-autogen, elixir-format
 msgid ".filter_city_prompt"
 msgstr "All cities"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:74
 #: lib/lemmings_os_web/components/lemming_components.ex:121
-#: lib/lemmings_os_web/components/lemming_components.ex:263
-#: lib/lemmings_os_web/components/lemming_components.ex:885
-#: lib/lemmings_os_web/components/lemming_components.ex:1004
+#: lib/lemmings_os_web/components/lemming_components.ex:265
+#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid ".filter_department"
 msgstr "Department"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:76
-#: lib/lemmings_os_web/components/lemming_components.ex:889
+#: lib/lemmings_os_web/components/lemming_components.ex:909
 #, elixir-autogen, elixir-format
 msgid ".filter_department_prompt"
 msgstr "All departments"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:54
-#: lib/lemmings_os_web/components/lemming_components.ex:865
-#: lib/lemmings_os_web/components/lemming_components.ex:994
+#: lib/lemmings_os_web/components/lemming_components.ex:885
+#: lib/lemmings_os_web/components/lemming_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".filter_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:83
-#: lib/lemmings_os_web/live/lemmings_live.ex:115
+#: lib/lemmings_os_web/live/lemmings_live.ex:86
+#: lib/lemmings_os_web/live/lemmings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_instructions_required"
 msgstr "Instructions are required before activating this lemming."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:530
+#: lib/lemmings_os_web/live/lemmings_live.ex:539
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_activated"
 msgstr "Lemming activated."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:531
+#: lib/lemmings_os_web/live/lemmings_live.ex:540
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_archived"
 msgstr "Lemming archived."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:119
+#: lib/lemmings_os_web/live/lemmings_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_update_failed"
 msgstr "Lemming update failed."
@@ -242,7 +242,7 @@ msgstr "Lemming update failed."
 msgid ".label_open_detail"
 msgstr "Open detail"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:399
 #, elixir-autogen, elixir-format
 msgid ".subtitle_effective_config"
 msgstr "Resolved configuration after world, city, department, and lemming overrides."
@@ -252,7 +252,7 @@ msgstr "Resolved configuration after world, city, department, and lemming overri
 msgid ".subtitle_filters"
 msgstr "Narrow the list by topology scope before opening a lemming type."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:583
+#: lib/lemmings_os_web/components/lemming_components.ex:603
 #, elixir-autogen, elixir-format
 msgid ".subtitle_instances_workspace"
 msgstr "Reserved area for runtime instances, spawn actions, and future interaction surfaces."
@@ -262,13 +262,13 @@ msgstr "Reserved area for runtime instances, spawn actions, and future interacti
 msgid ".subtitle_lemming_types"
 msgstr "Browse lemming types in the current scope and open the one you want to inspect."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:355
-#: lib/lemmings_os_web/components/lemming_components.ex:1052
+#: lib/lemmings_os_web/components/lemming_components.ex:361
+#: lib/lemmings_os_web/components/lemming_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:384
+#: lib/lemmings_os_web/components/lemming_components.ex:398
 #, elixir-autogen, elixir-format
 msgid ".title_effective_config"
 msgstr "Effective Config"
@@ -278,13 +278,13 @@ msgstr "Effective Config"
 msgid ".title_filters"
 msgstr "Filters"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:582
+#: lib/lemmings_os_web/components/lemming_components.ex:602
 #, elixir-autogen, elixir-format
 msgid ".title_instances_workspace"
 msgstr "Instances Workspace"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:177
-#: lib/lemmings_os_web/components/lemming_components.ex:277
+#: lib/lemmings_os_web/components/lemming_components.ex:179
+#: lib/lemmings_os_web/components/lemming_components.ex:279
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_detail"
 msgstr "Lemming Detail"
@@ -294,27 +294,27 @@ msgstr "Lemming Detail"
 msgid ".title_lemming_types"
 msgstr "Lemming Types"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:981
+#: lib/lemmings_os_web/components/lemming_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_create_lemming"
 msgstr "Create Lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:978
+#: lib/lemmings_os_web/components/lemming_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_creating_lemming"
 msgstr "Creating..."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:1008
+#: lib/lemmings_os_web/components/lemming_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid ".copy_create_scope"
 msgstr "This lemming will be created inside the selected department and inherit config from world, city, and department by default."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:854
+#: lib/lemmings_os_web/components/lemming_components.ex:874
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department"
 msgstr "Department context required"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:855
+#: lib/lemmings_os_web/components/lemming_components.ex:875
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department_copy"
 msgstr "Select a city and department to create the new lemming in the right topology scope."
@@ -331,63 +331,63 @@ msgstr "The selected department does not belong to the expected city or world sc
 msgid ".flash_lemming_created"
 msgstr "Lemming created."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:485
-#: lib/lemmings_os_web/components/lemming_components.ex:926
+#: lib/lemmings_os_web/components/lemming_components.ex:499
+#: lib/lemmings_os_web/components/lemming_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".label_description"
 msgstr "Description"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:498
-#: lib/lemmings_os_web/components/lemming_components.ex:939
+#: lib/lemmings_os_web/components/lemming_components.ex:512
+#: lib/lemmings_os_web/components/lemming_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ".label_instructions"
 msgstr "Instructions"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:476
-#: lib/lemmings_os_web/components/lemming_components.ex:915
+#: lib/lemmings_os_web/components/lemming_components.ex:490
+#: lib/lemmings_os_web/components/lemming_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".label_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:511
-#: lib/lemmings_os_web/components/lemming_components.ex:952
+#: lib/lemmings_os_web/components/lemming_components.ex:525
+#: lib/lemmings_os_web/components/lemming_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".label_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:920
+#: lib/lemmings_os_web/components/lemming_components.ex:940
 #, elixir-autogen, elixir-format
 msgid ".placeholder_slug"
 msgstr "e.g. regression-tracker"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:899
+#: lib/lemmings_os_web/components/lemming_components.ex:919
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_form"
 msgstr "Define the core lemming fields and persist the type in the selected department."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:843
+#: lib/lemmings_os_web/components/lemming_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_real"
 msgstr "Create a persisted lemming type with a real changeset-backed form."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:849
-#: lib/lemmings_os_web/components/lemming_components.ex:990
+#: lib/lemmings_os_web/components/lemming_components.ex:869
+#: lib/lemmings_os_web/components/lemming_components.ex:1010
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_scope"
 msgstr "Creation scope is inferred from the selected department. World and city are fixed by that topology."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:848
-#: lib/lemmings_os_web/components/lemming_components.ex:989
+#: lib/lemmings_os_web/components/lemming_components.ex:868
+#: lib/lemmings_os_web/components/lemming_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid ".title_create_scope"
 msgstr "Creation Scope"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:217
+#: lib/lemmings_os_web/components/lemming_components.ex:219
 #, elixir-autogen
 msgid ".button_export_json"
 msgstr "Export JSON"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:133
+#: lib/lemmings_os_web/live/lemmings_live.ex:136
 #, elixir-autogen
 msgid ".flash_export_no_lemming"
 msgstr "No lemming selected for export."
@@ -518,42 +518,42 @@ msgstr "Please select a JSON file to upload."
 msgid ".error_import_file_too_large"
 msgstr "The selected file is too large. Maximum size is 512 KB."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:971
+#: lib/lemmings_os_web/components/lemming_components.ex:991
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_create"
 msgstr "Cancel"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:539
+#: lib/lemmings_os_web/components/lemming_components.ex:553
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_edit"
 msgstr "Cancel"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:530
+#: lib/lemmings_os_web/components/lemming_components.ex:544
 #, elixir-autogen, elixir-format
 msgid ".button_edit_costs"
 msgstr "Edit Cost Config"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:524
+#: lib/lemmings_os_web/components/lemming_components.ex:538
 #, elixir-autogen, elixir-format
 msgid ".button_edit_limit"
 msgstr "Edit Limit Config"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:527
+#: lib/lemmings_os_web/components/lemming_components.ex:541
 #, elixir-autogen, elixir-format
 msgid ".button_edit_runtime"
 msgstr "Edit Runtime Config"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:533
+#: lib/lemmings_os_web/components/lemming_components.ex:547
 #, elixir-autogen, elixir-format
 msgid ".button_edit_tools"
 msgstr "Edit Tools Config"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:547
+#: lib/lemmings_os_web/components/lemming_components.ex:561
 #, elixir-autogen, elixir-format
 msgid ".button_save_lemming"
 msgstr "Save Changes"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:545
+#: lib/lemmings_os_web/components/lemming_components.ex:559
 #, elixir-autogen, elixir-format
 msgid ".button_saving_lemming"
 msgstr "Saving..."
@@ -568,92 +568,92 @@ msgstr "World not found"
 msgid ".empty_world_unavailable_copy"
 msgstr "The lemmings index cannot load because no persisted world is available yet."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:89
+#: lib/lemmings_os_web/live/lemmings_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_saved"
 msgstr "Lemming updated."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:933
+#: lib/lemmings_os_web/components/lemming_components.ex:953
 #, elixir-autogen, elixir-format
 msgid ".placeholder_description"
 msgstr "Explain what this lemming is for, when operators should use it, and the kind of work it should handle."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:946
+#: lib/lemmings_os_web/components/lemming_components.ex:966
 #, elixir-autogen, elixir-format
 msgid ".placeholder_instructions"
 msgstr "You are an expert internet research specialist who knows how to find reliable sources, compare evidence, and produce concise operator-ready summaries."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:455
+#: lib/lemmings_os_web/components/lemming_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".subtitle_lemming_settings"
 msgstr "Edit mutable definition fields and local override buckets for this lemming."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:225
-#: lib/lemmings_os_web/components/lemming_components.ex:363
-#: lib/lemmings_os_web/components/lemming_components.ex:1050
+#: lib/lemmings_os_web/components/lemming_components.ex:227
+#: lib/lemmings_os_web/components/lemming_components.ex:369
+#: lib/lemmings_os_web/components/lemming_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".tab_edit"
 msgstr "Edit"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:454
+#: lib/lemmings_os_web/components/lemming_components.ex:468
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_settings"
 msgstr "Lemming Settings"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:486
-#: lib/lemmings_os_web/components/lemming_components.ex:927
+#: lib/lemmings_os_web/components/lemming_components.ex:500
+#: lib/lemmings_os_web/components/lemming_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_description"
 msgstr "Short explanation of what this lemming type is for."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:499
-#: lib/lemmings_os_web/components/lemming_components.ex:940
+#: lib/lemmings_os_web/components/lemming_components.ex:513
+#: lib/lemmings_os_web/components/lemming_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_instructions"
 msgstr "Detailed instructions that define how this lemming should behave when activated."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:469
-#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:483
+#: lib/lemmings_os_web/components/lemming_components.ex:925
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_name"
 msgstr "Operator-facing name for this lemming type."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:477
-#: lib/lemmings_os_web/components/lemming_components.ex:916
+#: lib/lemmings_os_web/components/lemming_components.ex:491
+#: lib/lemmings_os_web/components/lemming_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_slug"
 msgstr "Stable identifier used in URLs and topology records. It is auto-generated from the name unless you override it."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:512
-#: lib/lemmings_os_web/components/lemming_components.ex:953
+#: lib/lemmings_os_web/components/lemming_components.ex:526
+#: lib/lemmings_os_web/components/lemming_components.ex:973
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_status"
 msgstr "Initial lifecycle state for the new lemming type."
 
-#: lib/lemmings_os_web/components/instance_components.ex:687
-#: lib/lemmings_os_web/live/instance_live.ex:648
+#: lib/lemmings_os_web/components/instance_components.ex:900
+#: lib/lemmings_os_web/live/instance_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:679
-#: lib/lemmings_os_web/live/instance_live.ex:640
+#: lib/lemmings_os_web/components/instance_components.ex:892
+#: lib/lemmings_os_web/live/instance_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:673
-#: lib/lemmings_os_web/live/instance_live.ex:634
+#: lib/lemmings_os_web/components/instance_components.ex:886
+#: lib/lemmings_os_web/live/instance_live.ex:696
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:459
+#: lib/lemmings_os_web/live/instance_live.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:740
+#: lib/lemmings_os_web/components/instance_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -680,12 +680,12 @@ msgstr ""
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:542
+#: lib/lemmings_os_web/live/instance_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:496
+#: lib/lemmings_os_web/live/instance_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -695,13 +695,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:790
-#: lib/lemmings_os_web/live/instance_live.ex:585
+#: lib/lemmings_os_web/components/instance_components.ex:1003
+#: lib/lemmings_os_web/live/instance_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -711,19 +711,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:408
-#: lib/lemmings_os_web/live/instance_live.html.heex:446
+#: lib/lemmings_os_web/live/instance_live.html.heex:412
+#: lib/lemmings_os_web/live/instance_live.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:584
+#: lib/lemmings_os_web/live/instance_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:630
-#: lib/lemmings_os_web/live/instance_live.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:843
+#: lib/lemmings_os_web/live/instance_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -733,29 +733,29 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:464
+#: lib/lemmings_os_web/live/instance_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:24
+#: lib/lemmings_os_web/live/instance_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:693
+#: lib/lemmings_os_web/live/instance_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:690
-#: lib/lemmings_os_web/live/instance_live.ex:723
+#: lib/lemmings_os_web/live/instance_live.ex:752
+#: lib/lemmings_os_web/live/instance_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:689
-#: lib/lemmings_os_web/live/instance_live.ex:722
+#: lib/lemmings_os_web/live/instance_live.ex:751
+#: lib/lemmings_os_web/live/instance_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:470
+#: lib/lemmings_os_web/live/instance_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
@@ -776,7 +776,7 @@ msgstr ""
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:539
+#: lib/lemmings_os_web/live/instance_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
@@ -792,18 +792,18 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:575
+#: lib/lemmings_os_web/live/instance_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:617
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/components/instance_components.ex:830
+#: lib/lemmings_os_web/live/instance_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:719
+#: lib/lemmings_os_web/live/instance_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
@@ -814,15 +814,15 @@ msgstr ""
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:721
+#: lib/lemmings_os_web/live/instance_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:600
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/live/instance_live.ex:565
-#: lib/lemmings_os_web/live/instance_live.ex:601
+#: lib/lemmings_os_web/components/instance_components.ex:813
+#: lib/lemmings_os_web/components/instance_components.ex:836
+#: lib/lemmings_os_web/live/instance_live.ex:627
+#: lib/lemmings_os_web/live/instance_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
@@ -833,12 +833,12 @@ msgstr ""
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:581
+#: lib/lemmings_os_web/live/instance_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:720
+#: lib/lemmings_os_web/live/instance_live.ex:782
 #: lib/lemmings_os_web/live/instance_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
@@ -849,30 +849,30 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:636
-#: lib/lemmings_os_web/live/instance_live.ex:614
+#: lib/lemmings_os_web/components/instance_components.ex:849
+#: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:635
-#: lib/lemmings_os_web/live/instance_live.ex:613
+#: lib/lemmings_os_web/components/instance_components.ex:848
+#: lib/lemmings_os_web/live/instance_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:533
-#: lib/lemmings_os_web/live/instance_live.ex:535
+#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:485
+#: lib/lemmings_os_web/live/instance_live.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:482
+#: lib/lemmings_os_web/live/instance_live.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
@@ -882,14 +882,14 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:611
-#: lib/lemmings_os_web/components/instance_components.ex:637
-#: lib/lemmings_os_web/live/instance_live.ex:573
-#: lib/lemmings_os_web/live/instance_live.ex:587
-#: lib/lemmings_os_web/live/instance_live.ex:589
-#: lib/lemmings_os_web/live/instance_live.ex:615
-#: lib/lemmings_os_web/live/instance_live.ex:717
-#: lib/lemmings_os_web/live/instance_live.ex:724
+#: lib/lemmings_os_web/components/instance_components.ex:824
+#: lib/lemmings_os_web/components/instance_components.ex:850
+#: lib/lemmings_os_web/live/instance_live.ex:635
+#: lib/lemmings_os_web/live/instance_live.ex:649
+#: lib/lemmings_os_web/live/instance_live.ex:651
+#: lib/lemmings_os_web/live/instance_live.ex:677
+#: lib/lemmings_os_web/live/instance_live.ex:779
+#: lib/lemmings_os_web/live/instance_live.ex:786
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
@@ -900,7 +900,7 @@ msgstr ""
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:727
+#: lib/lemmings_os_web/live/instance_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -910,52 +910,53 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:702
-#: lib/lemmings_os_web/live/instance_live.ex:708
+#: lib/lemmings_os_web/live/instance_live.ex:764
+#: lib/lemmings_os_web/live/instance_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:705
+#: lib/lemmings_os_web/live/instance_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:990
+#: lib/lemmings_os_web/components/instance_components.ex:1115
+#: lib/lemmings_os_web/components/instance_components.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:480
+#: lib/lemmings_os_web/live/instance_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:614
-#: lib/lemmings_os_web/live/instance_live.ex:574
-#: lib/lemmings_os_web/live/instance_live.ex:592
-#: lib/lemmings_os_web/live/instance_live.ex:718
+#: lib/lemmings_os_web/components/instance_components.ex:827
+#: lib/lemmings_os_web/live/instance_live.ex:636
+#: lib/lemmings_os_web/live/instance_live.ex:654
+#: lib/lemmings_os_web/live/instance_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:398
+#: lib/lemmings_os_web/live/instance_live.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:457
+#: lib/lemmings_os_web/live/instance_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/live/instance_live.ex:631
+#: lib/lemmings_os_web/components/instance_components.ex:881
+#: lib/lemmings_os_web/live/instance_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -965,7 +966,7 @@ msgstr ""
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:191
+#: lib/lemmings_os_web/live/instance_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -980,7 +981,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:185
+#: lib/lemmings_os_web/live/instance_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -990,18 +991,18 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:195
+#: lib/lemmings_os_web/live/instance_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:178
-#: lib/lemmings_os_web/live/instance_live.ex:202
+#: lib/lemmings_os_web/live/instance_live.ex:181
+#: lib/lemmings_os_web/live/instance_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:996
+#: lib/lemmings_os_web/components/instance_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1016,38 +1017,38 @@ msgstr ""
 msgid "Total tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:681
+#: lib/lemmings_os_web/components/lemming_components.ex:701
 #, elixir-autogen, elixir-format
 msgid ".button_cancel"
 msgstr "Cancel"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:691
+#: lib/lemmings_os_web/components/lemming_components.ex:711
 #, elixir-autogen, elixir-format
 msgid ".button_confirm_spawn"
 msgstr "Confirm spawn"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:606
-#: lib/lemmings_os_web/components/lemming_components.ex:617
+#: lib/lemmings_os_web/components/lemming_components.ex:626
+#: lib/lemmings_os_web/components/lemming_components.ex:637
 #, elixir-autogen, elixir-format
 msgid ".button_spawn"
 msgstr "Spawn"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:689
+#: lib/lemmings_os_web/components/lemming_components.ex:709
 #, elixir-autogen, elixir-format
 msgid ".button_spawning"
 msgstr "Spawning..."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:644
+#: lib/lemmings_os_web/components/lemming_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".copy_spawn_instance"
 msgstr "Enter the first request for this session."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:752
+#: lib/lemmings_os_web/components/lemming_components.ex:772
 #, elixir-autogen, elixir-format
 msgid ".count_shown"
 msgstr "%{count} shown"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:705
+#: lib/lemmings_os_web/components/lemming_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".count_total"
 msgstr "%{count} total"
@@ -1092,12 +1093,12 @@ msgstr "Registered resource pools"
 msgid ".detail_registry_target"
 msgstr "registry target"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:712
+#: lib/lemmings_os_web/components/lemming_components.ex:732
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances"
 msgstr "No active instances"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:713
+#: lib/lemmings_os_web/components/lemming_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances_copy"
 msgstr "Spawn one to start a session."
@@ -1198,7 +1199,7 @@ msgstr "gate"
 msgid ".label_holders"
 msgstr "holders"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:670
+#: lib/lemmings_os_web/components/lemming_components.ex:690
 #, elixir-autogen, elixir-format
 msgid ".label_initial_request"
 msgstr "Initial request"
@@ -1280,8 +1281,8 @@ msgstr "Schedulers"
 msgid ".label_started"
 msgstr "started"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:729
-#: lib/lemmings_os_web/components/lemming_components.ex:768
+#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:788
 #, elixir-autogen, elixir-format
 msgid ".label_unknown"
 msgstr "Unknown"
@@ -1296,7 +1297,7 @@ msgstr "up"
 msgid ".nav_runtime"
 msgstr "Runtime"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:671
+#: lib/lemmings_os_web/components/lemming_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".placeholder_spawn_request"
 msgstr "Tell the lemming what to work on..."
@@ -1396,7 +1397,7 @@ msgstr "Scheduler Registry"
 msgid ".runtime_service_label_scheduler_supervisor"
 msgstr "Scheduler Supervisor"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:593
+#: lib/lemmings_os_web/components/lemming_components.ex:613
 #, elixir-autogen, elixir-format
 msgid ".spawn_enabled_copy"
 msgstr "Create a new runtime session from this lemming."
@@ -1431,7 +1432,7 @@ msgstr "Capacity, gate, and holder pressure per resource key."
 msgid ".subtitle_runtime_dashboard"
 msgstr "Dev-only operational view of runtime modules and live state."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:702
+#: lib/lemmings_os_web/components/lemming_components.ex:722
 #, elixir-autogen, elixir-format
 msgid ".title_active_instances"
 msgstr "Active instances"
@@ -1457,7 +1458,7 @@ msgstr "ETS Runtime Entries"
 msgid ".title_executors"
 msgstr "Executors"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:769
 #, elixir-autogen, elixir-format
 msgid ".title_recent_sessions"
 msgstr "Recent sessions"
@@ -1473,27 +1474,27 @@ msgstr "Resource Pools"
 msgid ".title_runtime_dashboard"
 msgstr "Runtime Dashboard"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:641
+#: lib/lemmings_os_web/components/lemming_components.ex:661
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
 msgstr "Spawn instance"
 
-#: lib/lemmings_os_web/components/instance_components.ex:899
+#: lib/lemmings_os_web/components/instance_components.ex:1137
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:893
+#: lib/lemmings_os_web/components/instance_components.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:902
+#: lib/lemmings_os_web/components/instance_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:295
+#: lib/lemmings_os_web/components/instance_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1508,8 +1509,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:483
-#: lib/lemmings_os_web/components/instance_components.ex:789
+#: lib/lemmings_os_web/components/instance_components.ex:696
+#: lib/lemmings_os_web/components/instance_components.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1524,12 +1525,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:317
+#: lib/lemmings_os_web/components/instance_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
+#: lib/lemmings_os_web/components/instance_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1575,12 +1576,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:306
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:788
+#: lib/lemmings_os_web/components/instance_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1600,37 +1601,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
+#: lib/lemmings_os_web/components/instance_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:799
+#: lib/lemmings_os_web/components/instance_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:805
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:807
+#: lib/lemmings_os_web/components/instance_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:796
+#: lib/lemmings_os_web/components/instance_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:811
+#: lib/lemmings_os_web/components/instance_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:234
+#: lib/lemmings_os_web/components/instance_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1645,22 +1646,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:525
+#: lib/lemmings_os_web/components/instance_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:550
+#: lib/lemmings_os_web/components/instance_components.ex:763
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:435
+#: lib/lemmings_os_web/components/instance_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1675,7 +1676,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:942
+#: lib/lemmings_os_web/components/instance_components.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1685,20 +1686,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:514
+#: lib/lemmings_os_web/components/instance_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:493
+#: lib/lemmings_os_web/components/instance_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:357
-#: lib/lemmings_os_web/components/instance_components.ex:395
-#: lib/lemmings_os_web/components/instance_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/instance_components.ex:570
+#: lib/lemmings_os_web/components/instance_components.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1708,18 +1709,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:859
+#: lib/lemmings_os_web/components/world_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:465
+#: lib/lemmings_os_web/components/instance_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:541
-#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/instance_components.ex:754
+#: lib/lemmings_os_web/components/world_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1729,18 +1730,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:857
-#: lib/lemmings_os_web/components/world_components.ex:1033
+#: lib/lemmings_os_web/components/world_components.ex:886
+#: lib/lemmings_os_web/components/world_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:480
+#: lib/lemmings_os_web/components/instance_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:503
+#: lib/lemmings_os_web/components/instance_components.ex:716
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1755,17 +1756,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:953
+#: lib/lemmings_os_web/components/instance_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:948
+#: lib/lemmings_os_web/components/instance_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/components/instance_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1775,22 +1776,209 @@ msgstr ""
 msgid "Copy workspace path"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:221
+#: lib/lemmings_os_web/live/instance_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Workspace could not be opened."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:209
+#: lib/lemmings_os_web/live/instance_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Workspace is unavailable right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:217
+#: lib/lemmings_os_web/live/instance_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Workspace open requested."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:226
+#: lib/lemmings_os_web/live/instance_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Workspace path copied."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1108
+#, elixir-autogen, elixir-format
+msgid "%{count} bytes"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:344
+#, elixir-autogen, elixir-format
+msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1238
+#, elixir-autogen, elixir-format
+msgid "An Artifact with this filename already exists. Update it after changing the workspace file."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1284
+#, elixir-autogen, elixir-format
+msgid "Artifact checksum calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1278
+#, elixir-autogen, elixir-format
+msgid "Artifact file copy failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Artifact promoted: %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:327
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1294
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed (%{reason})."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1290
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed validation."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1254
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion is missing the runtime instance."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1287
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion request is invalid."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1248
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion scope is invalid for this session."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1281
+#, elixir-autogen, elixir-format
+msgid "Artifact size calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1275
+#, elixir-autogen, elixir-format
+msgid "Artifact storage is unavailable right now."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Choose a valid promotion action for this Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:461
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:477
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:471
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:491
+#, elixir-autogen, elixir-format
+msgid "Notes"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1260
+#, elixir-autogen, elixir-format
+msgid "Only files inside this workspace can be promoted."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1272
+#, elixir-autogen, elixir-format
+msgid "Only regular files can be promoted as Artifacts."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:423
+#, elixir-autogen, elixir-format
+msgid "Promote as New Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:418
+#, elixir-autogen, elixir-format
+msgid "Promote as new Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:393
+#, elixir-autogen, elixir-format
+msgid "Promote to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:388
+#, elixir-autogen, elixir-format
+msgid "Promote workspace file to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:359
+#, elixir-autogen, elixir-format
+msgid "Promoted"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/components/instance_components.ex:417
+#, elixir-autogen, elixir-format
+msgid "Promoting..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1251
+#, elixir-autogen, elixir-format
+msgid "Runtime instance not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Show Artifact help"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1257
+#, elixir-autogen, elixir-format
+msgid "This filename cannot be promoted as an Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Unable to promote this file right now."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1110
+#, elixir-autogen, elixir-format
+msgid "Unknown size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "Update Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#, elixir-autogen, elixir-format
+msgid "Update existing Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:402
+#, elixir-autogen, elixir-format
+msgid "Updating..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1263
+#: lib/lemmings_os_web/live/instance_live.ex:1266
+#, elixir-autogen, elixir-format
+msgid "Workspace file not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/world.po
+++ b/priv/gettext/en/LC_MESSAGES/world.po
@@ -38,13 +38,13 @@ msgstr "Unknown"
 
 #: lib/lemmings_os/helpers.ex:100
 #: lib/lemmings_os/helpers.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:1287
-#: lib/lemmings_os_web/components/world_components.ex:1317
-#: lib/lemmings_os_web/components/world_components.ex:1334
-#: lib/lemmings_os_web/components/world_components.ex:1351
-#: lib/lemmings_os_web/components/world_components.ex:1355
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/components/world_components.ex:1322
+#: lib/lemmings_os_web/components/world_components.ex:1352
+#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1386
+#: lib/lemmings_os_web/components/world_components.ex:1390
+#: lib/lemmings_os_web/components/world_components.ex:1411
+#: lib/lemmings_os_web/live/instance_live.ex:469
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
@@ -75,40 +75,40 @@ msgstr "Department node"
 msgid ".aria_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:769
+#: lib/lemmings_os_web/components/world_components.ex:788
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "All Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:254
-#: lib/lemmings_os_web/components/world_components.ex:539
+#: lib/lemmings_os_web/components/world_components.ex:266
+#: lib/lemmings_os_web/components/world_components.ex:557
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr "Import bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:736
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Open department"
 
-#: lib/lemmings_os_web/components/world_components.ex:102
-#: lib/lemmings_os_web/components/world_components.ex:536
+#: lib/lemmings_os_web/components/world_components.ex:105
+#: lib/lemmings_os_web/components/world_components.ex:554
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr "Refresh world"
 
-#: lib/lemmings_os_web/components/world_components.ex:436
+#: lib/lemmings_os_web/components/world_components.ex:448
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr "The city summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/components/world_components.ex:449
+#: lib/lemmings_os_web/components/world_components.ex:461
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr "The tools summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:126
+#: lib/lemmings_os_web/live/departments_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departments"
@@ -118,178 +118,178 @@ msgstr "%{count} departments"
 msgid ".count_running_of_total"
 msgstr "%{running} of %{total} running"
 
-#: lib/lemmings_os_web/components/world_components.ex:659
-#: lib/lemmings_os_web/live/departments_live.html.heex:54
-#: lib/lemmings_os_web/live/departments_live.html.heex:133
+#: lib/lemmings_os_web/components/world_components.ex:677
+#: lib/lemmings_os_web/live/departments_live.html.heex:55
+#: lib/lemmings_os_web/live/departments_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "No departments yet"
 
-#: lib/lemmings_os_web/components/world_components.ex:660
-#: lib/lemmings_os_web/live/departments_live.html.heex:55
-#: lib/lemmings_os_web/live/departments_live.html.heex:134
+#: lib/lemmings_os_web/components/world_components.ex:678
+#: lib/lemmings_os_web/live/departments_live.html.heex:56
+#: lib/lemmings_os_web/live/departments_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Create or import a department to see it here."
 
-#: lib/lemmings_os_web/components/world_components.ex:544
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr "No world snapshot"
 
-#: lib/lemmings_os_web/components/world_components.ex:545
+#: lib/lemmings_os_web/components/world_components.ex:563
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr "Import bootstrap or refresh state to see the current snapshot."
 
-#: lib/lemmings_os_web/components/world_components.ex:338
+#: lib/lemmings_os_web/components/world_components.ex:350
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr "Bootstrap path"
 
-#: lib/lemmings_os_web/components/world_components.ex:333
+#: lib/lemmings_os_web/components/world_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr "Bootstrap source"
 
-#: lib/lemmings_os_web/components/world_components.ex:410
-#: lib/lemmings_os_web/components/world_components.ex:633
+#: lib/lemmings_os_web/components/world_components.ex:422
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr "Budgets"
 
-#: lib/lemmings_os_web/components/world_components.ex:1310
+#: lib/lemmings_os_web/components/world_components.ex:1345
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1306
+#: lib/lemmings_os_web/components/world_components.ex:1341
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1315
+#: lib/lemmings_os_web/components/world_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declared"
 
-#: lib/lemmings_os_web/components/world_components.ex:1299
+#: lib/lemmings_os_web/components/world_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Depts."
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Empty"
 
-#: lib/lemmings_os_web/components/world_components.ex:123
-#: lib/lemmings_os_web/components/world_components.ex:264
+#: lib/lemmings_os_web/components/world_components.ex:126
+#: lib/lemmings_os_web/components/world_components.ex:276
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr "Immediate import"
 
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:300
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr "Last bootstrap hash"
 
-#: lib/lemmings_os_web/components/world_components.ex:284
+#: lib/lemmings_os_web/components/world_components.ex:296
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr "Last imported at"
 
-#: lib/lemmings_os_web/components/world_components.ex:141
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:144
+#: lib/lemmings_os_web/components/world_components.ex:288
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr "Last sync"
 
-#: lib/lemmings_os_web/components/world_components.ex:1300
+#: lib/lemmings_os_web/components/world_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
 
-#: lib/lemmings_os_web/components/world_components.ex:405
-#: lib/lemmings_os_web/components/world_components.ex:617
+#: lib/lemmings_os_web/components/world_components.ex:417
+#: lib/lemmings_os_web/components/world_components.ex:635
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr "Limits"
 
-#: lib/lemmings_os_web/components/world_components.ex:1289
+#: lib/lemmings_os_web/components/world_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "No fallbacks"
 
-#: lib/lemmings_os_web/components/world_components.ex:302
+#: lib/lemmings_os_web/components/world_components.ex:314
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr "No world issues"
 
-#: lib/lemmings_os_web/components/world_components.ex:433
-#: lib/lemmings_os_web/components/world_components.ex:446
+#: lib/lemmings_os_web/components/world_components.ex:445
+#: lib/lemmings_os_web/components/world_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr "Placeholder only"
 
-#: lib/lemmings_os_web/components/world_components.ex:420
+#: lib/lemmings_os_web/components/world_components.ex:432
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr "Placeholder sections"
 
-#: lib/lemmings_os_web/components/world_components.ex:382
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:394
+#: lib/lemmings_os_web/components/world_components.ex:657
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr "Profiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1362
+#: lib/lemmings_os_web/components/world_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credentials ready"
 
-#: lib/lemmings_os_web/components/world_components.ex:1286
+#: lib/lemmings_os_web/components/world_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Provider disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1285
+#: lib/lemmings_os_web/components/world_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Provider enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:357
+#: lib/lemmings_os_web/components/world_components.ex:369
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr "Providers"
 
-#: lib/lemmings_os_web/components/world_components.ex:732
+#: lib/lemmings_os_web/components/world_components.ex:750
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Queue"
 
-#: lib/lemmings_os_web/components/world_components.ex:415
-#: lib/lemmings_os_web/components/world_components.ex:625
+#: lib/lemmings_os_web/components/world_components.ex:427
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr "Runtime defaults"
 
-#: lib/lemmings_os_web/components/world_components.ex:1371
-#: lib/lemmings_os_web/components/world_components.ex:1372
+#: lib/lemmings_os_web/components/world_components.ex:1406
+#: lib/lemmings_os_web/components/world_components.ex:1407
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Runtime deferred"
 
-#: lib/lemmings_os_web/components/world_components.ex:1328
+#: lib/lemmings_os_web/components/world_components.ex:1363
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "World ID"
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:1329
+#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/world_components.ex:1364
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -329,22 +329,22 @@ msgstr "Online"
 msgid ".metric_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/world_components.ex:1337
+#: lib/lemmings_os_web/components/world_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Bootstrap file"
 
-#: lib/lemmings_os_web/components/world_components.ex:1340
+#: lib/lemmings_os_web/components/world_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Postgres connection"
 
-#: lib/lemmings_os_web/components/world_components.ex:1343
+#: lib/lemmings_os_web/components/world_components.ex:1378
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Provider credentials"
 
-#: lib/lemmings_os_web/components/world_components.ex:1346
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Provider reachability"
@@ -375,23 +375,23 @@ msgstr "Online"
 msgid ".subtitle_all_cities"
 msgstr "Cities registered in this world"
 
-#: lib/lemmings_os_web/components/world_components.ex:207
+#: lib/lemmings_os_web/components/world_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:198
+#: lib/lemmings_os_web/components/world_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr "Import"
 
-#: lib/lemmings_os_web/components/world_components.ex:189
+#: lib/lemmings_os_web/components/world_components.ex:192
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:216
+#: lib/lemmings_os_web/components/world_components.ex:219
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr "Runtime"
@@ -401,45 +401,45 @@ msgstr "Runtime"
 msgid ".title_all_cities"
 msgstr "All Cities"
 
-#: lib/lemmings_os_web/components/world_components.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:327
+#: lib/lemmings_os_web/components/world_components.ex:158
+#: lib/lemmings_os_web/components/world_components.ex:339
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr "Bootstrap config"
 
-#: lib/lemmings_os_web/components/world_components.ex:653
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/components/world_components.ex:671
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:129
+#: lib/lemmings_os_web/components/world_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr "Import state"
 
-#: lib/lemmings_os_web/components/world_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:457
+#: lib/lemmings_os_web/components/world_components.ex:172
+#: lib/lemmings_os_web/components/world_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr "Runtime checks"
 
-#: lib/lemmings_os_web/components/world_components.ex:429
+#: lib/lemmings_os_web/components/world_components.ex:441
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr "World cities"
 
-#: lib/lemmings_os_web/components/world_components.ex:111
-#: lib/lemmings_os_web/components/world_components.ex:349
-#: lib/lemmings_os_web/components/world_components.ex:528
-#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:114
+#: lib/lemmings_os_web/components/world_components.ex:361
+#: lib/lemmings_os_web/components/world_components.ex:546
+#: lib/lemmings_os_web/components/world_components.ex:869
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "World identity"
 
-#: lib/lemmings_os_web/components/world_components.ex:297
+#: lib/lemmings_os_web/components/world_components.ex:309
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr "World issues"
@@ -449,12 +449,12 @@ msgstr "World issues"
 msgid ".title_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:94
+#: lib/lemmings_os_web/components/world_components.ex:97
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr "World status"
 
-#: lib/lemmings_os_web/components/world_components.ex:442
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr "World tools"
@@ -469,13 +469,13 @@ msgstr "Department"
 msgid ".tooltip_running"
 msgstr "Running"
 
-#: lib/lemmings_os_web/components/world_components.ex:612
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr "Resolved from the persisted World and City layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:835
-#: lib/lemmings_os_web/live/departments_live.html.heex:49
+#: lib/lemmings_os_web/components/world_components.ex:864
+#: lib/lemmings_os_web/live/departments_live.html.heex:50
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr "Cities"
@@ -501,40 +501,40 @@ msgstr "No cities yet"
 msgid ".empty_no_cities_copy"
 msgstr "This page now reads the real city table. Create or bootstrap a city to see it listed here."
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:272
+#: lib/lemmings_os_web/live/cities_live.html.heex:281
 #, elixir-autogen
 msgid ".label_city_distribution_port"
 msgstr "Distribution port"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:277
+#: lib/lemmings_os_web/live/cities_live.html.heex:286
 #, elixir-autogen
 msgid ".label_city_epmd_port"
 msgstr "EPMD port"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:267
+#: lib/lemmings_os_web/live/cities_live.html.heex:276
 #, elixir-autogen
 msgid ".label_city_host"
 msgstr "Host"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:282
+#: lib/lemmings_os_web/live/cities_live.html.heex:291
 #: lib/lemmings_os_web/live/settings_live.html.heex:111
 #, elixir-autogen
 msgid ".label_city_last_seen_at"
 msgstr "Last heartbeat"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:262
+#: lib/lemmings_os_web/live/cities_live.html.heex:271
 #: lib/lemmings_os_web/live/settings_live.html.heex:106
 #, elixir-autogen
 msgid ".label_city_node_name"
 msgstr "BEAM node"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:257
+#: lib/lemmings_os_web/live/cities_live.html.heex:266
 #: lib/lemmings_os_web/live/settings_live.html.heex:101
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:629
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr "Effective city config"
@@ -604,7 +604,7 @@ msgstr "BEAM node name"
 msgid ".city_form_node_name_placeholder"
 msgstr "e.g. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:830
+#: lib/lemmings_os_web/components/world_components.ex:859
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -645,268 +645,268 @@ msgstr "Create city"
 msgid ".city_form_submit_update"
 msgstr "Save changes"
 
-#: lib/lemmings_os_web/live/cities_live.ex:504
+#: lib/lemmings_os_web/live/cities_live.ex:508
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "City created."
 
-#: lib/lemmings_os_web/live/cities_live.ex:529
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "City updated."
 
-#: lib/lemmings_os_web/live/cities_live.ex:144
+#: lib/lemmings_os_web/live/cities_live.ex:146
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr "City deleted."
 
-#: lib/lemmings_os_web/live/cities_live.ex:100
-#: lib/lemmings_os_web/live/cities_live.ex:153
+#: lib/lemmings_os_web/live/cities_live.ex:102
+#: lib/lemmings_os_web/live/cities_live.ex:155
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr "City not found."
 
-#: lib/lemmings_os_web/live/cities_live.ex:514
-#: lib/lemmings_os_web/live/cities_live.ex:539
+#: lib/lemmings_os_web/live/cities_live.ex:518
+#: lib/lemmings_os_web/live/cities_live.ex:543
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "Could not save city. Check the form for errors."
 
-#: lib/lemmings_os_web/live/cities_live.ex:150
+#: lib/lemmings_os_web/live/cities_live.ex:152
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr "Could not delete city."
 
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:717
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Open Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:666
+#: lib/lemmings_os_web/components/world_components.ex:684
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr "%{city} has %{count} departments."
 
-#: lib/lemmings_os_web/components/world_components.ex:654
+#: lib/lemmings_os_web/components/world_components.ex:672
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr "Compact summary of persisted departments for this city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Change the city scope for the map and department list."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:96
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "Selected City"
 
-#: lib/lemmings_os_web/components/world_components.ex:925
+#: lib/lemmings_os_web/components/world_components.ex:954
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activate"
 
-#: lib/lemmings_os_web/components/world_components.ex:953
+#: lib/lemmings_os_web/components/world_components.ex:982
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Delete"
 
-#: lib/lemmings_os_web/components/world_components.ex:943
+#: lib/lemmings_os_web/components/world_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Disable"
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:963
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drain"
 
-#: lib/lemmings_os_web/components/world_components.ex:1177
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Save settings"
 
-#: lib/lemmings_os_web/components/world_components.ex:950
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "Are you sure you want to delete this department?"
 
-#: lib/lemmings_os_web/components/world_components.ex:897
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notes"
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:931
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:987
+#: lib/lemmings_os_web/components/world_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No lemmings available"
 
-#: lib/lemmings_os_web/components/world_components.ex:988
+#: lib/lemmings_os_web/components/world_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "No runtime-backed or mock preview lemmings are available for this department yet."
 
-#: lib/lemmings_os_web/components/world_components.ex:963
+#: lib/lemmings_os_web/components/world_components.ex:992
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Lifecycle actions"
 
-#: lib/lemmings_os_web/components/world_components.ex:915
+#: lib/lemmings_os_web/components/world_components.ex:944
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Use the persisted department lifecycle controls. Delete remains guarded by safety checks."
 
-#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:922
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadata"
 
-#: lib/lemmings_os_web/components/world_components.ex:1072
-#: lib/lemmings_os_web/components/world_components.ex:1105
-#: lib/lemmings_os_web/components/world_components.ex:1154
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1134
+#: lib/lemmings_os_web/components/world_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1077
-#: lib/lemmings_os_web/components/world_components.ex:1114
-#: lib/lemmings_os_web/components/world_components.ex:1169
+#: lib/lemmings_os_web/components/world_components.ex:1106
+#: lib/lemmings_os_web/components/world_components.ex:1143
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1158
+#: lib/lemmings_os_web/components/world_components.ex:1187
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1157
+#: lib/lemmings_os_web/components/world_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1067
-#: lib/lemmings_os_web/components/world_components.ex:1098
-#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Idle TTL seconds"
 
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Inherit"
 
-#: lib/lemmings_os_web/components/world_components.ex:1062
-#: lib/lemmings_os_web/components/world_components.ex:1089
-#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1091
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1168
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Max lemmings per department"
 
-#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Effective values after resolving World, City, and Department layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:1057
+#: lib/lemmings_os_web/components/world_components.ex:1086
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Effective config"
 
-#: lib/lemmings_os_web/components/world_components.ex:1085
+#: lib/lemmings_os_web/components/world_components.ex:1114
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Only Department-local overrides persisted on this row. Empty values inherit from City or World."
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Local overrides"
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "V1 editor. This safely updates a narrow subset of Department-local overrides."
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Settings editor"
 
-#: lib/lemmings_os_web/components/world_components.ex:792
+#: lib/lemmings_os_web/components/world_components.ex:811
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:782
+#: lib/lemmings_os_web/components/world_components.ex:801
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:821
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Settings"
 
-#: lib/lemmings_os_web/live/departments_live.ex:665
+#: lib/lemmings_os_web/live/departments_live.ex:670
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Department activated."
 
-#: lib/lemmings_os_web/live/departments_live.ex:116
+#: lib/lemmings_os_web/live/departments_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Department deleted."
 
-#: lib/lemmings_os_web/live/departments_live.ex:667
+#: lib/lemmings_os_web/live/departments_live.ex:672
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Department disabled."
 
-#: lib/lemmings_os_web/live/departments_live.ex:666
+#: lib/lemmings_os_web/live/departments_live.ex:671
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Department set to draining."
 
-#: lib/lemmings_os_web/live/departments_live.ex:130
+#: lib/lemmings_os_web/live/departments_live.ex:132
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "Could not update the department lifecycle."
 
-#: lib/lemmings_os_web/live/departments_live.ex:100
+#: lib/lemmings_os_web/live/departments_live.ex:102
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Department settings saved."
 
-#: lib/lemmings_os_web/live/departments_live.ex:668
+#: lib/lemmings_os_web/live/departments_live.ex:673
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Department updated."
 
-#: lib/lemmings_os_web/components/world_components.ex:972
+#: lib/lemmings_os_web/components/world_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:964
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr "allowlisted"
 msgid ".secret_blocked_by_allowlist"
 msgstr "blocked by allowlist"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:297
+#: lib/lemmings_os_web/live/cities_live.html.heex:306
 #, elixir-autogen, elixir-format
 msgid ".secret_city_subtitle"
 msgstr "Write-only Secret Bank values scoped to this city."
@@ -992,15 +992,15 @@ msgstr "Delete this local secret value?"
 msgid ".secret_delete_label"
 msgstr "Delete local secret %{key}"
 
-#: lib/lemmings_os_web/live/cities_live.ex:204
-#: lib/lemmings_os_web/live/departments_live.ex:189
-#: lib/lemmings_os_web/live/lemmings_live.ex:184
-#: lib/lemmings_os_web/live/world_live.ex:101
+#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/lemmings_live.ex:187
+#: lib/lemmings_os_web/live/world_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr "Local secret deleted"
 
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1223
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr "Write-only Secret Bank values scoped to this department."
@@ -1085,7 +1085,7 @@ msgstr "Use the configured Secret Bank key name, without exposing a value."
 msgid ".secret_key_label"
 msgstr "Secret key"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:565
+#: lib/lemmings_os_web/components/lemming_components.ex:579
 #, elixir-autogen, elixir-format
 msgid ".secret_lemming_subtitle"
 msgstr "Write-only Secret Bank values scoped to this lemming."
@@ -1110,10 +1110,10 @@ msgstr "Save secret"
 msgid ".secret_save_pending"
 msgstr "Saving secret..."
 
-#: lib/lemmings_os_web/live/cities_live.ex:164
-#: lib/lemmings_os_web/live/departments_live.ex:146
-#: lib/lemmings_os_web/live/lemmings_live.ex:144
-#: lib/lemmings_os_web/live/world_live.ex:63
+#: lib/lemmings_os_web/live/cities_live.ex:166
+#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/lemmings_live.ex:147
+#: lib/lemmings_os_web/live/world_live.ex:65
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr "Secret saved"
@@ -1128,11 +1128,11 @@ msgstr "The value is write-only and will not be displayed after saving."
 msgid ".secret_value_label"
 msgstr "Secret value"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:371
-#: lib/lemmings_os_web/components/lemming_components.ex:1051
+#: lib/lemmings_os_web/components/lemming_components.ex:377
+#: lib/lemmings_os_web/components/lemming_components.ex:1071
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:225
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:228
+#: lib/lemmings_os_web/components/world_components.ex:831
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -133,10 +133,10 @@ msgstr ""
 msgid ".error_something_went_wrong"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:177
-#: lib/lemmings_os_web/live/departments_live.ex:159
-#: lib/lemmings_os_web/live/lemmings_live.ex:157
-#: lib/lemmings_os_web/live/world_live.ex:76
+#: lib/lemmings_os_web/live/cities_live.ex:179
+#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/lemmings_live.ex:160
+#: lib/lemmings_os_web/live/world_live.ex:78
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr ""
@@ -275,6 +275,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:105
+#: lib/lemmings_os/artifacts/artifact.ex:106
+#: lib/lemmings_os/artifacts/artifact.ex:211
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -290,6 +293,7 @@ msgstr ""
 msgid ".invalid_choice"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:179
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -298,6 +302,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:104
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -309,11 +314,14 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os/secret_bank/secret.ex:64
-#: lib/lemmings_os_web/live/instance_live.ex:685
+#: lib/lemmings_os_web/live/instance_live.ex:747
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:109
+#: lib/lemmings_os/artifacts/artifact.ex:151
+#: lib/lemmings_os/artifacts/artifact.ex:203
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139
@@ -447,76 +455,76 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:170
-#: lib/lemmings_os_web/live/cities_live.ex:209
-#: lib/lemmings_os_web/live/cities_live.ex:274
-#: lib/lemmings_os_web/live/cities_live.ex:360
-#: lib/lemmings_os_web/live/cities_live.ex:387
-#: lib/lemmings_os_web/live/cities_live.ex:415
-#: lib/lemmings_os_web/live/cities_live.ex:433
+#: lib/lemmings_os_web/live/cities_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:211
+#: lib/lemmings_os_web/live/cities_live.ex:276
+#: lib/lemmings_os_web/live/cities_live.ex:362
+#: lib/lemmings_os_web/live/cities_live.ex:389
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:435
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:152
-#: lib/lemmings_os_web/live/departments_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:261
-#: lib/lemmings_os_web/live/departments_live.ex:355
-#: lib/lemmings_os_web/live/departments_live.ex:382
-#: lib/lemmings_os_web/live/departments_live.ex:410
-#: lib/lemmings_os_web/live/departments_live.ex:428
+#: lib/lemmings_os_web/live/departments_live.ex:154
+#: lib/lemmings_os_web/live/departments_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:263
+#: lib/lemmings_os_web/live/departments_live.ex:357
+#: lib/lemmings_os_web/live/departments_live.ex:384
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:430
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:150
-#: lib/lemmings_os_web/live/lemmings_live.ex:189
+#: lib/lemmings_os_web/live/lemmings_live.ex:153
+#: lib/lemmings_os_web/live/lemmings_live.ex:192
 #, elixir-autogen, elixir-format
 msgid ".error_lemming_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:223
-#: lib/lemmings_os_web/live/departments_live.ex:208
-#: lib/lemmings_os_web/live/lemmings_live.ex:203
-#: lib/lemmings_os_web/live/world_live.ex:120
+#: lib/lemmings_os_web/live/cities_live.ex:225
+#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/lemmings_live.ex:206
+#: lib/lemmings_os_web/live/world_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:216
-#: lib/lemmings_os_web/live/departments_live.ex:201
-#: lib/lemmings_os_web/live/lemmings_live.ex:196
-#: lib/lemmings_os_web/live/world_live.ex:113
+#: lib/lemmings_os_web/live/cities_live.ex:218
+#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/lemmings_live.ex:199
+#: lib/lemmings_os_web/live/world_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:220
-#: lib/lemmings_os_web/live/departments_live.ex:205
-#: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:117
+#: lib/lemmings_os_web/live/cities_live.ex:222
+#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/lemmings_live.ex:203
+#: lib/lemmings_os_web/live/world_live.ex:119
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:192
-#: lib/lemmings_os_web/live/departments_live.ex:177
-#: lib/lemmings_os_web/live/lemmings_live.ex:172
-#: lib/lemmings_os_web/live/world_live.ex:91
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/lemmings_live.ex:175
+#: lib/lemmings_os_web/live/world_live.ex:93
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:185
-#: lib/lemmings_os_web/live/departments_live.ex:170
-#: lib/lemmings_os_web/live/lemmings_live.ex:165
-#: lib/lemmings_os_web/live/world_live.ex:84
+#: lib/lemmings_os_web/live/cities_live.ex:187
+#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/lemmings_live.ex:168
+#: lib/lemmings_os_web/live/world_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:69
-#: lib/lemmings_os_web/live/world_live.ex:106
+#: lib/lemmings_os_web/live/world_live.ex:71
+#: lib/lemmings_os_web/live/world_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -136,10 +136,10 @@ msgstr "Intentando reconectar"
 msgid ".error_something_went_wrong"
 msgstr "Algo salio mal!"
 
-#: lib/lemmings_os_web/live/cities_live.ex:177
-#: lib/lemmings_os_web/live/departments_live.ex:159
-#: lib/lemmings_os_web/live/lemmings_live.ex:157
-#: lib/lemmings_os_web/live/world_live.ex:76
+#: lib/lemmings_os_web/live/cities_live.ex:179
+#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/lemmings_live.ex:160
+#: lib/lemmings_os_web/live/world_live.ex:78
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr "Formato de clave secreta invalido. Usa letras MAYUSCULAS, numeros y _."
@@ -278,6 +278,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "La eliminacion del lemming no esta disponible porque todavia no se puede demostrar que sea segura."
 
+#: lib/lemmings_os/artifacts/artifact.ex:105
+#: lib/lemmings_os/artifacts/artifact.ex:106
+#: lib/lemmings_os/artifacts/artifact.ex:211
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -293,6 +296,7 @@ msgstr "La eliminacion del lemming no esta disponible porque todavia no se puede
 msgid ".invalid_choice"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:179
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -301,6 +305,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:104
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -312,11 +317,14 @@ msgstr ""
 #: lib/lemmings_os/lemming_instances/message.ex:61
 #: lib/lemmings_os/lemming_instances/tool_execution.ex:83
 #: lib/lemmings_os/secret_bank/secret.ex:64
-#: lib/lemmings_os_web/live/instance_live.ex:685
+#: lib/lemmings_os_web/live/instance_live.ex:747
 #, elixir-autogen, elixir-format
 msgid ".required"
 msgstr ""
 
+#: lib/lemmings_os/artifacts/artifact.ex:109
+#: lib/lemmings_os/artifacts/artifact.ex:151
+#: lib/lemmings_os/artifacts/artifact.ex:203
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139
@@ -450,76 +458,76 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:170
-#: lib/lemmings_os_web/live/cities_live.ex:209
-#: lib/lemmings_os_web/live/cities_live.ex:274
-#: lib/lemmings_os_web/live/cities_live.ex:360
-#: lib/lemmings_os_web/live/cities_live.ex:387
-#: lib/lemmings_os_web/live/cities_live.ex:415
-#: lib/lemmings_os_web/live/cities_live.ex:433
+#: lib/lemmings_os_web/live/cities_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:211
+#: lib/lemmings_os_web/live/cities_live.ex:276
+#: lib/lemmings_os_web/live/cities_live.ex:362
+#: lib/lemmings_os_web/live/cities_live.ex:389
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:435
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr "La ciudad no está disponible"
 
-#: lib/lemmings_os_web/live/departments_live.ex:152
-#: lib/lemmings_os_web/live/departments_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:261
-#: lib/lemmings_os_web/live/departments_live.ex:355
-#: lib/lemmings_os_web/live/departments_live.ex:382
-#: lib/lemmings_os_web/live/departments_live.ex:410
-#: lib/lemmings_os_web/live/departments_live.ex:428
+#: lib/lemmings_os_web/live/departments_live.ex:154
+#: lib/lemmings_os_web/live/departments_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:263
+#: lib/lemmings_os_web/live/departments_live.ex:357
+#: lib/lemmings_os_web/live/departments_live.ex:384
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:430
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr "El departamento no está disponible"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:150
-#: lib/lemmings_os_web/live/lemmings_live.ex:189
+#: lib/lemmings_os_web/live/lemmings_live.ex:153
+#: lib/lemmings_os_web/live/lemmings_live.ex:192
 #, elixir-autogen, elixir-format
 msgid ".error_lemming_unavailable"
 msgstr "El lemming no está disponible"
 
-#: lib/lemmings_os_web/live/cities_live.ex:223
-#: lib/lemmings_os_web/live/departments_live.ex:208
-#: lib/lemmings_os_web/live/lemmings_live.ex:203
-#: lib/lemmings_os_web/live/world_live.ex:120
+#: lib/lemmings_os_web/live/cities_live.ex:225
+#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/lemmings_live.ex:206
+#: lib/lemmings_os_web/live/world_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr "No se pudo eliminar el secreto"
 
-#: lib/lemmings_os_web/live/cities_live.ex:216
-#: lib/lemmings_os_web/live/departments_live.ex:201
-#: lib/lemmings_os_web/live/lemmings_live.ex:196
-#: lib/lemmings_os_web/live/world_live.ex:113
+#: lib/lemmings_os_web/live/cities_live.ex:218
+#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/lemmings_live.ex:199
+#: lib/lemmings_os_web/live/world_live.ex:115
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr "Solo los valores locales pueden eliminarse en este alcance"
 
-#: lib/lemmings_os_web/live/cities_live.ex:220
-#: lib/lemmings_os_web/live/departments_live.ex:205
-#: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:117
+#: lib/lemmings_os_web/live/cities_live.ex:222
+#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/lemmings_live.ex:203
+#: lib/lemmings_os_web/live/world_live.ex:119
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr "Clave secreta no encontrada"
 
-#: lib/lemmings_os_web/live/cities_live.ex:192
-#: lib/lemmings_os_web/live/departments_live.ex:177
-#: lib/lemmings_os_web/live/lemmings_live.ex:172
-#: lib/lemmings_os_web/live/world_live.ex:91
+#: lib/lemmings_os_web/live/cities_live.ex:194
+#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/lemmings_live.ex:175
+#: lib/lemmings_os_web/live/world_live.ex:93
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr "No se pudo guardar el secreto"
 
-#: lib/lemmings_os_web/live/cities_live.ex:185
-#: lib/lemmings_os_web/live/departments_live.ex:170
-#: lib/lemmings_os_web/live/lemmings_live.ex:165
-#: lib/lemmings_os_web/live/world_live.ex:84
+#: lib/lemmings_os_web/live/cities_live.ex:187
+#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/lemmings_live.ex:168
+#: lib/lemmings_os_web/live/world_live.ex:86
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr "El valor secreto es obligatorio"
 
-#: lib/lemmings_os_web/live/world_live.ex:69
-#: lib/lemmings_os_web/live/world_live.ex:106
+#: lib/lemmings_os_web/live/world_live.ex:71
+#: lib/lemmings_os_web/live/world_live.ex:108
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr "El mundo no está disponible"

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -79,7 +79,7 @@ msgid ".nav_departments"
 msgstr "Departamentos"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:681
+#: lib/lemmings_os_web/components/world_components.ex:699
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -107,7 +107,7 @@ msgid ".nav_settings"
 msgstr "Ajustes"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:996
+#: lib/lemmings_os_web/components/world_components.ex:1025
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "Nuevo lemming"
@@ -204,22 +204,22 @@ msgstr "Notas del entorno"
 msgid ".page_title_home"
 msgstr "Inicio"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:26
+#: lib/lemmings_os_web/live/lemmings_live.ex:27
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/live/cities_live.ex:46
+#: lib/lemmings_os_web/live/cities_live.ex:47
 #, elixir-autogen
 msgid ".page_title_cities"
 msgstr "Ciudades"
 
-#: lib/lemmings_os_web/live/departments_live.ex:27
+#: lib/lemmings_os_web/live/departments_live.ex:28
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/live/world_live.ex:23
+#: lib/lemmings_os_web/live/world_live.ex:24
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr "Mundo"
@@ -919,60 +919,60 @@ msgstr "Nombre"
 msgid ".connections_empty"
 msgstr "No hay conexiones visibles para este alcance."
 
-#: lib/lemmings_os_web/live/cities_live.ex:269
-#: lib/lemmings_os_web/live/departments_live.ex:256
-#: lib/lemmings_os_web/live/world_live.ex:164
+#: lib/lemmings_os_web/live/cities_live.ex:271
+#: lib/lemmings_os_web/live/departments_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:166
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr "Conexion creada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:383
-#: lib/lemmings_os_web/live/departments_live.ex:378
-#: lib/lemmings_os_web/live/world_live.ex:278
+#: lib/lemmings_os_web/live/cities_live.ex:385
+#: lib/lemmings_os_web/live/departments_live.ex:380
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr "Conexion eliminada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:284
-#: lib/lemmings_os_web/live/cities_live.ex:338
-#: lib/lemmings_os_web/live/cities_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:274
-#: lib/lemmings_os_web/live/departments_live.ex:333
-#: lib/lemmings_os_web/live/departments_live.ex:359
-#: lib/lemmings_os_web/live/world_live.ex:180
-#: lib/lemmings_os_web/live/world_live.ex:238
-#: lib/lemmings_os_web/live/world_live.ex:261
+#: lib/lemmings_os_web/live/cities_live.ex:286
+#: lib/lemmings_os_web/live/cities_live.ex:340
+#: lib/lemmings_os_web/live/cities_live.ex:366
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:335
+#: lib/lemmings_os_web/live/departments_live.ex:361
+#: lib/lemmings_os_web/live/world_live.ex:182
+#: lib/lemmings_os_web/live/world_live.ex:240
+#: lib/lemmings_os_web/live/world_live.ex:263
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr "Payload de conexion invalido. Usa YAML o JSON valido."
 
-#: lib/lemmings_os_web/live/cities_live.ex:300
-#: lib/lemmings_os_web/live/cities_live.ex:332
-#: lib/lemmings_os_web/live/cities_live.ex:367
-#: lib/lemmings_os_web/live/cities_live.ex:390
-#: lib/lemmings_os_web/live/cities_live.ex:418
-#: lib/lemmings_os_web/live/departments_live.ex:294
-#: lib/lemmings_os_web/live/departments_live.ex:327
-#: lib/lemmings_os_web/live/departments_live.ex:362
-#: lib/lemmings_os_web/live/departments_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:413
-#: lib/lemmings_os_web/live/world_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:232
-#: lib/lemmings_os_web/live/world_live.ex:264
-#: lib/lemmings_os_web/live/world_live.ex:284
-#: lib/lemmings_os_web/live/world_live.ex:307
+#: lib/lemmings_os_web/live/cities_live.ex:302
+#: lib/lemmings_os_web/live/cities_live.ex:334
+#: lib/lemmings_os_web/live/cities_live.ex:369
+#: lib/lemmings_os_web/live/cities_live.ex:392
+#: lib/lemmings_os_web/live/cities_live.ex:420
+#: lib/lemmings_os_web/live/departments_live.ex:296
+#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:364
+#: lib/lemmings_os_web/live/departments_live.ex:387
+#: lib/lemmings_os_web/live/departments_live.ex:415
+#: lib/lemmings_os_web/live/world_live.ex:202
+#: lib/lemmings_os_web/live/world_live.ex:234
+#: lib/lemmings_os_web/live/world_live.ex:266
+#: lib/lemmings_os_web/live/world_live.ex:286
+#: lib/lemmings_os_web/live/world_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr "Solo se pueden cambiar conexiones locales aqui."
 
-#: lib/lemmings_os_web/live/world_live.ex:184
+#: lib/lemmings_os_web/live/world_live.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr "El alcance no esta disponible."
 
-#: lib/lemmings_os_web/live/cities_live.ex:411
-#: lib/lemmings_os_web/live/departments_live.ex:406
-#: lib/lemmings_os_web/live/world_live.ex:303
+#: lib/lemmings_os_web/live/cities_live.ex:413
+#: lib/lemmings_os_web/live/departments_live.ex:408
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr "Estado de conexion actualizado."
@@ -982,16 +982,16 @@ msgstr "Estado de conexion actualizado."
 msgid ".connections_flash_test_failed"
 msgstr "Fallo la prueba de conexion."
 
-#: lib/lemmings_os_web/live/cities_live.ex:429
-#: lib/lemmings_os_web/live/departments_live.ex:424
-#: lib/lemmings_os_web/live/world_live.ex:316
+#: lib/lemmings_os_web/live/cities_live.ex:431
+#: lib/lemmings_os_web/live/departments_live.ex:426
+#: lib/lemmings_os_web/live/world_live.ex:318
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr "Conexion probada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:356
-#: lib/lemmings_os_web/live/departments_live.ex:351
-#: lib/lemmings_os_web/live/world_live.ex:254
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/departments_live.ex:353
+#: lib/lemmings_os_web/live/world_live.ex:256
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr "Conexion actualizada."
@@ -1061,8 +1061,8 @@ msgstr "Desconocido"
 msgid ".connections_source_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/world_components.ex:234
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:237
+#: lib/lemmings_os_web/components/world_components.ex:841
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
@@ -1079,3 +1079,89 @@ msgstr "Visibilidad de alcance y herencia en modo solo lectura."
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
 msgstr "Conexiones"
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:44
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:18
+#: lib/lemmings_os_web/components/artifacts_components.ex:35
+#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:1072
+#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:851
+#: lib/lemmings_os_web/live/cities_live.html.heex:256
+#, elixir-autogen, elixir-format
+msgid "Artifacts"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:21
+#, elixir-autogen, elixir-format
+msgid "Artifacts available at this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:43
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:116
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:113
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:38
+#, elixir-autogen, elixir-format
+msgid "Filename"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:30
+#, elixir-autogen, elixir-format
+msgid "No artifacts available for this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:39
+#, elixir-autogen, elixir-format
+msgid "Scope"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:42
+#, elixir-autogen, elixir-format
+msgid "Size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:41
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:40
+#, elixir-autogen, elixir-format
+msgid "Type"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:66
+#, elixir-autogen, elixir-format
+msgid "city"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:73
+#, elixir-autogen, elixir-format
+msgid "dept"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:80
+#, elixir-autogen, elixir-format
+msgid "lemming"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "world"
+msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/es/LC_MESSAGES/lemmings.po
@@ -48,19 +48,19 @@ msgstr "Todos los lemmings"
 msgid ".subtitle_all_lemmings"
 msgstr "Explora las definiciones persistidas de lemmings en el mundo actual y abre la que quieras inspeccionar."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:842
-#: lib/lemmings_os_web/components/lemming_components.ex:898
+#: lib/lemmings_os_web/components/lemming_components.ex:862
+#: lib/lemmings_os_web/components/lemming_components.ex:918
 #, elixir-autogen
 msgid ".title_create_lemming"
 msgstr "Crear lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:468
-#: lib/lemmings_os_web/components/lemming_components.ex:904
+#: lib/lemmings_os_web/components/lemming_components.ex:482
+#: lib/lemmings_os_web/components/lemming_components.ex:924
 #, elixir-autogen
 msgid ".label_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:909
+#: lib/lemmings_os_web/components/lemming_components.ex:929
 #, elixir-autogen
 msgid ".placeholder_name"
 msgstr "Ej. Aurora"
@@ -70,97 +70,97 @@ msgstr "Ej. Aurora"
 msgid ".page_title_create_lemming"
 msgstr "Crear lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:236
+#: lib/lemmings_os_web/components/lemming_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_activate"
 msgstr "Activar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:247
+#: lib/lemmings_os_web/components/lemming_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_archive"
 msgstr "Archivar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:392
+#: lib/lemmings_os_web/components/lemming_components.ex:406
 #, elixir-autogen, elixir-format
 msgid ".copy_inheriting_all_config"
 msgstr "Este lemming hereda toda la configuración desde sus scopes padre."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:623
+#: lib/lemmings_os_web/components/lemming_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".copy_instances_workspace_selected"
 msgstr "%{name} está seleccionado. Esta área queda reservada para instancias en ejecución y herramientas futuras de interacción."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:423
+#: lib/lemmings_os_web/components/lemming_components.ex:437
 #, elixir-autogen, elixir-format
 msgid ".detail_allowed_tools"
 msgstr "Herramientas permitidas"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:437
+#: lib/lemmings_os_web/components/lemming_components.ex:451
 #, elixir-autogen, elixir-format
 msgid ".detail_denied_tools"
 msgstr "Herramientas denegadas"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:410
+#: lib/lemmings_os_web/components/lemming_components.ex:424
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_cross_city"
 msgstr "Acceso entre ciudades"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:415
+#: lib/lemmings_os_web/components/lemming_components.ex:429
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:405
+#: lib/lemmings_os_web/components/lemming_components.ex:419
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_idle_ttl"
 msgstr "TTL inactivo"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:398
+#: lib/lemmings_os_web/components/lemming_components.ex:412
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_max_lemmings"
 msgstr "Máx. lemmings"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:378
+#: lib/lemmings_os_web/components/lemming_components.ex:392
 #, elixir-autogen, elixir-format
 msgid ".detail_instructions"
 msgstr "Instrucciones"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:589
+#: lib/lemmings_os_web/components/lemming_components.ex:609
 #, elixir-autogen, elixir-format
 msgid ".detail_spawn_requests"
 msgstr "Solicitudes de spawn"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:268
+#: lib/lemmings_os_web/components/lemming_components.ex:270
 #, elixir-autogen, elixir-format
 msgid ".detail_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:629
+#: lib/lemmings_os_web/components/lemming_components.ex:649
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace"
 msgstr "No hay lemming seleccionado"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:630
+#: lib/lemmings_os_web/components/lemming_components.ex:650
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace_copy"
 msgstr "Selecciona un tipo de lemming para preparar espacio para futuras instancias, sesiones y acciones de lanzamiento."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:280
+#: lib/lemmings_os_web/components/lemming_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found"
 msgstr "Lemming no encontrado"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:281
+#: lib/lemmings_os_web/components/lemming_components.ex:283
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found_copy"
 msgstr "El lemming solicitado no existe en la topología persistida actual."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:430
+#: lib/lemmings_os_web/components/lemming_components.ex:444
 #, elixir-autogen, elixir-format
 msgid ".empty_no_allowed_tools"
 msgstr "Sin herramientas permitidas"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:444
+#: lib/lemmings_os_web/components/lemming_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".empty_no_denied_tools"
 msgstr "Sin herramientas denegadas"
@@ -182,58 +182,58 @@ msgstr "Ajusta los filtros o crea un nuevo tipo de lemming para esta ciudad o de
 
 #: lib/lemmings_os_web/components/lemming_components.ex:65
 #: lib/lemmings_os_web/components/lemming_components.ex:128
-#: lib/lemmings_os_web/components/lemming_components.ex:258
-#: lib/lemmings_os_web/components/lemming_components.ex:876
-#: lib/lemmings_os_web/components/lemming_components.ex:999
+#: lib/lemmings_os_web/components/lemming_components.ex:260
+#: lib/lemmings_os_web/components/lemming_components.ex:896
+#: lib/lemmings_os_web/components/lemming_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid ".filter_city"
 msgstr "Ciudad"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:67
-#: lib/lemmings_os_web/components/lemming_components.ex:878
+#: lib/lemmings_os_web/components/lemming_components.ex:898
 #, elixir-autogen, elixir-format
 msgid ".filter_city_prompt"
 msgstr "Todas las ciudades"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:74
 #: lib/lemmings_os_web/components/lemming_components.ex:121
-#: lib/lemmings_os_web/components/lemming_components.ex:263
-#: lib/lemmings_os_web/components/lemming_components.ex:885
-#: lib/lemmings_os_web/components/lemming_components.ex:1004
+#: lib/lemmings_os_web/components/lemming_components.ex:265
+#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid ".filter_department"
 msgstr "Departamento"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:76
-#: lib/lemmings_os_web/components/lemming_components.ex:889
+#: lib/lemmings_os_web/components/lemming_components.ex:909
 #, elixir-autogen, elixir-format
 msgid ".filter_department_prompt"
 msgstr "Todos los departamentos"
 
 #: lib/lemmings_os_web/components/lemming_components.ex:54
-#: lib/lemmings_os_web/components/lemming_components.ex:865
-#: lib/lemmings_os_web/components/lemming_components.ex:994
+#: lib/lemmings_os_web/components/lemming_components.ex:885
+#: lib/lemmings_os_web/components/lemming_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".filter_world"
 msgstr "Mundo"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:83
-#: lib/lemmings_os_web/live/lemmings_live.ex:115
+#: lib/lemmings_os_web/live/lemmings_live.ex:86
+#: lib/lemmings_os_web/live/lemmings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_instructions_required"
 msgstr "Las instrucciones son obligatorias antes de activar este lemming."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:530
+#: lib/lemmings_os_web/live/lemmings_live.ex:539
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_activated"
 msgstr "Lemming activado."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:531
+#: lib/lemmings_os_web/live/lemmings_live.ex:540
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_archived"
 msgstr "Lemming archivado."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:119
+#: lib/lemmings_os_web/live/lemmings_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_update_failed"
 msgstr "No se pudo actualizar el lemming."
@@ -243,7 +243,7 @@ msgstr "No se pudo actualizar el lemming."
 msgid ".label_open_detail"
 msgstr "Abrir detalle"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:399
 #, elixir-autogen, elixir-format
 msgid ".subtitle_effective_config"
 msgstr "Configuración resuelta después de aplicar overrides de mundo, ciudad, departamento y lemming."
@@ -253,7 +253,7 @@ msgstr "Configuración resuelta después de aplicar overrides de mundo, ciudad, 
 msgid ".subtitle_filters"
 msgstr "Acota la lista por scope de topología antes de abrir un tipo de lemming."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:583
+#: lib/lemmings_os_web/components/lemming_components.ex:603
 #, elixir-autogen, elixir-format
 msgid ".subtitle_instances_workspace"
 msgstr "Área reservada para instancias runtime, acciones de spawn y futuras superficies de interacción."
@@ -263,13 +263,13 @@ msgstr "Área reservada para instancias runtime, acciones de spawn y futuras sup
 msgid ".subtitle_lemming_types"
 msgstr "Explora los tipos de lemming del scope actual y abre el que quieras inspeccionar."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:355
-#: lib/lemmings_os_web/components/lemming_components.ex:1052
+#: lib/lemmings_os_web/components/lemming_components.ex:361
+#: lib/lemmings_os_web/components/lemming_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:384
+#: lib/lemmings_os_web/components/lemming_components.ex:398
 #, elixir-autogen, elixir-format
 msgid ".title_effective_config"
 msgstr "Configuración efectiva"
@@ -279,13 +279,13 @@ msgstr "Configuración efectiva"
 msgid ".title_filters"
 msgstr "Filtros"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:582
+#: lib/lemmings_os_web/components/lemming_components.ex:602
 #, elixir-autogen, elixir-format
 msgid ".title_instances_workspace"
 msgstr "Workspace de instancias"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:177
-#: lib/lemmings_os_web/components/lemming_components.ex:277
+#: lib/lemmings_os_web/components/lemming_components.ex:179
+#: lib/lemmings_os_web/components/lemming_components.ex:279
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_detail"
 msgstr "Detalle del lemming"
@@ -295,27 +295,27 @@ msgstr "Detalle del lemming"
 msgid ".title_lemming_types"
 msgstr "Tipos de lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:981
+#: lib/lemmings_os_web/components/lemming_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_create_lemming"
 msgstr "Crear lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:978
+#: lib/lemmings_os_web/components/lemming_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_creating_lemming"
 msgstr "Creando..."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:1008
+#: lib/lemmings_os_web/components/lemming_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid ".copy_create_scope"
 msgstr "Este lemming se creará dentro del departamento seleccionado y heredará la configuración de mundo, ciudad y departamento por defecto."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:854
+#: lib/lemmings_os_web/components/lemming_components.ex:874
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department"
 msgstr "Hace falta contexto de departamento"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:855
+#: lib/lemmings_os_web/components/lemming_components.ex:875
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department_copy"
 msgstr "Selecciona una ciudad y un departamento para crear el nuevo lemming en el scope correcto."
@@ -332,63 +332,63 @@ msgstr "El departamento seleccionado no pertenece al scope esperado de ciudad o 
 msgid ".flash_lemming_created"
 msgstr "Lemming creado."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:485
-#: lib/lemmings_os_web/components/lemming_components.ex:926
+#: lib/lemmings_os_web/components/lemming_components.ex:499
+#: lib/lemmings_os_web/components/lemming_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".label_description"
 msgstr "Descripción"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:498
-#: lib/lemmings_os_web/components/lemming_components.ex:939
+#: lib/lemmings_os_web/components/lemming_components.ex:512
+#: lib/lemmings_os_web/components/lemming_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ".label_instructions"
 msgstr "Instrucciones"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:476
-#: lib/lemmings_os_web/components/lemming_components.ex:915
+#: lib/lemmings_os_web/components/lemming_components.ex:490
+#: lib/lemmings_os_web/components/lemming_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".label_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:511
-#: lib/lemmings_os_web/components/lemming_components.ex:952
+#: lib/lemmings_os_web/components/lemming_components.ex:525
+#: lib/lemmings_os_web/components/lemming_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".label_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:920
+#: lib/lemmings_os_web/components/lemming_components.ex:940
 #, elixir-autogen, elixir-format
 msgid ".placeholder_slug"
 msgstr "ej. regression-tracker"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:899
+#: lib/lemmings_os_web/components/lemming_components.ex:919
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_form"
 msgstr "Define los campos centrales del lemming y persiste el tipo en el departamento seleccionado."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:843
+#: lib/lemmings_os_web/components/lemming_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_real"
 msgstr "Crea un tipo de lemming persistido con un formulario real respaldado por changeset."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:849
-#: lib/lemmings_os_web/components/lemming_components.ex:990
+#: lib/lemmings_os_web/components/lemming_components.ex:869
+#: lib/lemmings_os_web/components/lemming_components.ex:1010
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_scope"
 msgstr "El scope de creación se infiere desde el departamento seleccionado. Mundo y ciudad quedan fijados por esa topología."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:848
-#: lib/lemmings_os_web/components/lemming_components.ex:989
+#: lib/lemmings_os_web/components/lemming_components.ex:868
+#: lib/lemmings_os_web/components/lemming_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid ".title_create_scope"
 msgstr "Scope de creación"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:217
+#: lib/lemmings_os_web/components/lemming_components.ex:219
 #, elixir-autogen
 msgid ".button_export_json"
 msgstr "Exportar JSON"
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:133
+#: lib/lemmings_os_web/live/lemmings_live.ex:136
 #, elixir-autogen
 msgid ".flash_export_no_lemming"
 msgstr "No hay lemming seleccionado para exportar."
@@ -519,42 +519,42 @@ msgstr "Por favor selecciona un archivo JSON para subir."
 msgid ".error_import_file_too_large"
 msgstr "El archivo seleccionado es demasiado grande. El tamanio maximo es 512 KB."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:971
+#: lib/lemmings_os_web/components/lemming_components.ex:991
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_create"
 msgstr "Cancelar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:539
+#: lib/lemmings_os_web/components/lemming_components.ex:553
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_edit"
 msgstr "Cancelar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:530
+#: lib/lemmings_os_web/components/lemming_components.ex:544
 #, elixir-autogen, elixir-format
 msgid ".button_edit_costs"
 msgstr "Editar costos"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:524
+#: lib/lemmings_os_web/components/lemming_components.ex:538
 #, elixir-autogen, elixir-format
 msgid ".button_edit_limit"
 msgstr "Editar límites"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:527
+#: lib/lemmings_os_web/components/lemming_components.ex:541
 #, elixir-autogen, elixir-format
 msgid ".button_edit_runtime"
 msgstr "Editar runtime"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:533
+#: lib/lemmings_os_web/components/lemming_components.ex:547
 #, elixir-autogen, elixir-format
 msgid ".button_edit_tools"
 msgstr "Editar tools"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:547
+#: lib/lemmings_os_web/components/lemming_components.ex:561
 #, elixir-autogen, elixir-format
 msgid ".button_save_lemming"
 msgstr "Guardar cambios"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:545
+#: lib/lemmings_os_web/components/lemming_components.ex:559
 #, elixir-autogen, elixir-format
 msgid ".button_saving_lemming"
 msgstr "Guardando..."
@@ -569,92 +569,92 @@ msgstr "Mundo no encontrado"
 msgid ".empty_world_unavailable_copy"
 msgstr "El indice de lemmings no puede cargar porque todavia no hay ningun mundo persistido disponible."
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:89
+#: lib/lemmings_os_web/live/lemmings_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_saved"
 msgstr "Lemming actualizado."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:933
+#: lib/lemmings_os_web/components/lemming_components.ex:953
 #, elixir-autogen, elixir-format
 msgid ".placeholder_description"
 msgstr "Explica para qué sirve este tipo de lemming, cuándo deberían usarlo los operadores y qué clase de trabajo debe manejar."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:946
+#: lib/lemmings_os_web/components/lemming_components.ex:966
 #, elixir-autogen, elixir-format
 msgid ".placeholder_instructions"
 msgstr "Eres un especialista experto en busquedas por internet que sabe encontrar fuentes confiables, contrastar evidencia y producir resumentes concisos listos para operadores."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:455
+#: lib/lemmings_os_web/components/lemming_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".subtitle_lemming_settings"
 msgstr "Edita los campos mutables de la definicion y los overrides locales de este lemming."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:225
-#: lib/lemmings_os_web/components/lemming_components.ex:363
-#: lib/lemmings_os_web/components/lemming_components.ex:1050
+#: lib/lemmings_os_web/components/lemming_components.ex:227
+#: lib/lemmings_os_web/components/lemming_components.ex:369
+#: lib/lemmings_os_web/components/lemming_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".tab_edit"
 msgstr "Editar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:454
+#: lib/lemmings_os_web/components/lemming_components.ex:468
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_settings"
 msgstr "Configuracion del lemming"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:486
-#: lib/lemmings_os_web/components/lemming_components.ex:927
+#: lib/lemmings_os_web/components/lemming_components.ex:500
+#: lib/lemmings_os_web/components/lemming_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_description"
 msgstr "Explicación corta de para qué sirve este tipo de lemming."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:499
-#: lib/lemmings_os_web/components/lemming_components.ex:940
+#: lib/lemmings_os_web/components/lemming_components.ex:513
+#: lib/lemmings_os_web/components/lemming_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_instructions"
 msgstr "Instrucciones detalladas que definen cómo debe comportarse este lemming cuando se active."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:469
-#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:483
+#: lib/lemmings_os_web/components/lemming_components.ex:925
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_name"
 msgstr "Nombre visible para operadores de este tipo de lemming."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:477
-#: lib/lemmings_os_web/components/lemming_components.ex:916
+#: lib/lemmings_os_web/components/lemming_components.ex:491
+#: lib/lemmings_os_web/components/lemming_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_slug"
 msgstr "Identificador estable usado en URLs y registros de topología. Se genera automáticamente desde el nombre salvo que lo sobrescribas."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:512
-#: lib/lemmings_os_web/components/lemming_components.ex:953
+#: lib/lemmings_os_web/components/lemming_components.ex:526
+#: lib/lemmings_os_web/components/lemming_components.ex:973
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_status"
 msgstr "Estado inicial del ciclo de vida para el nuevo tipo de lemming."
 
-#: lib/lemmings_os_web/components/instance_components.ex:687
-#: lib/lemmings_os_web/live/instance_live.ex:648
+#: lib/lemmings_os_web/components/instance_components.ex:900
+#: lib/lemmings_os_web/live/instance_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:679
-#: lib/lemmings_os_web/live/instance_live.ex:640
+#: lib/lemmings_os_web/components/instance_components.ex:892
+#: lib/lemmings_os_web/live/instance_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:673
-#: lib/lemmings_os_web/live/instance_live.ex:634
+#: lib/lemmings_os_web/components/instance_components.ex:886
+#: lib/lemmings_os_web/live/instance_live.ex:696
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:459
+#: lib/lemmings_os_web/live/instance_live.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:740
+#: lib/lemmings_os_web/components/instance_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -681,12 +681,12 @@ msgstr ""
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:542
+#: lib/lemmings_os_web/live/instance_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:496
+#: lib/lemmings_os_web/live/instance_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -696,13 +696,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:790
-#: lib/lemmings_os_web/live/instance_live.ex:585
+#: lib/lemmings_os_web/components/instance_components.ex:1003
+#: lib/lemmings_os_web/live/instance_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -712,19 +712,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:408
-#: lib/lemmings_os_web/live/instance_live.html.heex:446
+#: lib/lemmings_os_web/live/instance_live.html.heex:412
+#: lib/lemmings_os_web/live/instance_live.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:584
+#: lib/lemmings_os_web/live/instance_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:630
-#: lib/lemmings_os_web/live/instance_live.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:843
+#: lib/lemmings_os_web/live/instance_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -734,29 +734,29 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:464
+#: lib/lemmings_os_web/live/instance_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:24
+#: lib/lemmings_os_web/live/instance_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:693
+#: lib/lemmings_os_web/live/instance_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:690
-#: lib/lemmings_os_web/live/instance_live.ex:723
+#: lib/lemmings_os_web/live/instance_live.ex:752
+#: lib/lemmings_os_web/live/instance_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:689
-#: lib/lemmings_os_web/live/instance_live.ex:722
+#: lib/lemmings_os_web/live/instance_live.ex:751
+#: lib/lemmings_os_web/live/instance_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
@@ -767,7 +767,7 @@ msgstr ""
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:470
+#: lib/lemmings_os_web/live/instance_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:539
+#: lib/lemmings_os_web/live/instance_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
@@ -793,18 +793,18 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:575
+#: lib/lemmings_os_web/live/instance_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:617
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/components/instance_components.ex:830
+#: lib/lemmings_os_web/live/instance_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:719
+#: lib/lemmings_os_web/live/instance_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
@@ -815,15 +815,15 @@ msgstr ""
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:721
+#: lib/lemmings_os_web/live/instance_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:600
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/live/instance_live.ex:565
-#: lib/lemmings_os_web/live/instance_live.ex:601
+#: lib/lemmings_os_web/components/instance_components.ex:813
+#: lib/lemmings_os_web/components/instance_components.ex:836
+#: lib/lemmings_os_web/live/instance_live.ex:627
+#: lib/lemmings_os_web/live/instance_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
@@ -834,12 +834,12 @@ msgstr ""
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:581
+#: lib/lemmings_os_web/live/instance_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:720
+#: lib/lemmings_os_web/live/instance_live.ex:782
 #: lib/lemmings_os_web/live/instance_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
@@ -850,30 +850,30 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:636
-#: lib/lemmings_os_web/live/instance_live.ex:614
+#: lib/lemmings_os_web/components/instance_components.ex:849
+#: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:635
-#: lib/lemmings_os_web/live/instance_live.ex:613
+#: lib/lemmings_os_web/components/instance_components.ex:848
+#: lib/lemmings_os_web/live/instance_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:533
-#: lib/lemmings_os_web/live/instance_live.ex:535
+#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:485
+#: lib/lemmings_os_web/live/instance_live.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:482
+#: lib/lemmings_os_web/live/instance_live.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
@@ -883,14 +883,14 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:611
-#: lib/lemmings_os_web/components/instance_components.ex:637
-#: lib/lemmings_os_web/live/instance_live.ex:573
-#: lib/lemmings_os_web/live/instance_live.ex:587
-#: lib/lemmings_os_web/live/instance_live.ex:589
-#: lib/lemmings_os_web/live/instance_live.ex:615
-#: lib/lemmings_os_web/live/instance_live.ex:717
-#: lib/lemmings_os_web/live/instance_live.ex:724
+#: lib/lemmings_os_web/components/instance_components.ex:824
+#: lib/lemmings_os_web/components/instance_components.ex:850
+#: lib/lemmings_os_web/live/instance_live.ex:635
+#: lib/lemmings_os_web/live/instance_live.ex:649
+#: lib/lemmings_os_web/live/instance_live.ex:651
+#: lib/lemmings_os_web/live/instance_live.ex:677
+#: lib/lemmings_os_web/live/instance_live.ex:779
+#: lib/lemmings_os_web/live/instance_live.ex:786
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
@@ -901,7 +901,7 @@ msgstr ""
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:727
+#: lib/lemmings_os_web/live/instance_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -911,52 +911,53 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:702
-#: lib/lemmings_os_web/live/instance_live.ex:708
+#: lib/lemmings_os_web/live/instance_live.ex:764
+#: lib/lemmings_os_web/live/instance_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:705
+#: lib/lemmings_os_web/live/instance_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:990
+#: lib/lemmings_os_web/components/instance_components.ex:1115
+#: lib/lemmings_os_web/components/instance_components.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:480
+#: lib/lemmings_os_web/live/instance_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:614
-#: lib/lemmings_os_web/live/instance_live.ex:574
-#: lib/lemmings_os_web/live/instance_live.ex:592
-#: lib/lemmings_os_web/live/instance_live.ex:718
+#: lib/lemmings_os_web/components/instance_components.ex:827
+#: lib/lemmings_os_web/live/instance_live.ex:636
+#: lib/lemmings_os_web/live/instance_live.ex:654
+#: lib/lemmings_os_web/live/instance_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:398
+#: lib/lemmings_os_web/live/instance_live.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:457
+#: lib/lemmings_os_web/live/instance_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/live/instance_live.ex:631
+#: lib/lemmings_os_web/components/instance_components.ex:881
+#: lib/lemmings_os_web/live/instance_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -966,7 +967,7 @@ msgstr ""
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:191
+#: lib/lemmings_os_web/live/instance_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -981,7 +982,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:185
+#: lib/lemmings_os_web/live/instance_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -991,18 +992,18 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:195
+#: lib/lemmings_os_web/live/instance_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:178
-#: lib/lemmings_os_web/live/instance_live.ex:202
+#: lib/lemmings_os_web/live/instance_live.ex:181
+#: lib/lemmings_os_web/live/instance_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:996
+#: lib/lemmings_os_web/components/instance_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1017,38 +1018,38 @@ msgstr ""
 msgid "Total tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:681
+#: lib/lemmings_os_web/components/lemming_components.ex:701
 #, elixir-autogen, elixir-format
 msgid ".button_cancel"
 msgstr "Cancelar"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:691
+#: lib/lemmings_os_web/components/lemming_components.ex:711
 #, elixir-autogen, elixir-format
 msgid ".button_confirm_spawn"
 msgstr "Confirmar spawn"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:606
-#: lib/lemmings_os_web/components/lemming_components.ex:617
+#: lib/lemmings_os_web/components/lemming_components.ex:626
+#: lib/lemmings_os_web/components/lemming_components.ex:637
 #, elixir-autogen, elixir-format
 msgid ".button_spawn"
 msgstr "Spawn"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:689
+#: lib/lemmings_os_web/components/lemming_components.ex:709
 #, elixir-autogen, elixir-format
 msgid ".button_spawning"
 msgstr "Lanzando..."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:644
+#: lib/lemmings_os_web/components/lemming_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".copy_spawn_instance"
 msgstr "Ingresa la primera solicitud para esta sesión."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:752
+#: lib/lemmings_os_web/components/lemming_components.ex:772
 #, elixir-autogen, elixir-format
 msgid ".count_shown"
 msgstr "%{count} mostradas"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:705
+#: lib/lemmings_os_web/components/lemming_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".count_total"
 msgstr "%{count} total"
@@ -1093,12 +1094,12 @@ msgstr "Pools de recursos registrados"
 msgid ".detail_registry_target"
 msgstr "target del registry"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:712
+#: lib/lemmings_os_web/components/lemming_components.ex:732
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances"
 msgstr "No hay instancias activas"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:713
+#: lib/lemmings_os_web/components/lemming_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances_copy"
 msgstr "Lanza una para iniciar una sesión."
@@ -1199,7 +1200,7 @@ msgstr "gate"
 msgid ".label_holders"
 msgstr "holders"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:670
+#: lib/lemmings_os_web/components/lemming_components.ex:690
 #, elixir-autogen, elixir-format
 msgid ".label_initial_request"
 msgstr "Solicitud inicial"
@@ -1281,8 +1282,8 @@ msgstr "Schedulers"
 msgid ".label_started"
 msgstr "iniciado"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:729
-#: lib/lemmings_os_web/components/lemming_components.ex:768
+#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:788
 #, elixir-autogen, elixir-format
 msgid ".label_unknown"
 msgstr "Desconocido"
@@ -1297,7 +1298,7 @@ msgstr "activo"
 msgid ".nav_runtime"
 msgstr "Runtime"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:671
+#: lib/lemmings_os_web/components/lemming_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".placeholder_spawn_request"
 msgstr "Dile al lemming en qué trabajar..."
@@ -1397,7 +1398,7 @@ msgstr "Scheduler Registry"
 msgid ".runtime_service_label_scheduler_supervisor"
 msgstr "Scheduler Supervisor"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:593
+#: lib/lemmings_os_web/components/lemming_components.ex:613
 #, elixir-autogen, elixir-format
 msgid ".spawn_enabled_copy"
 msgstr "Crea una nueva sesión runtime desde este lemming."
@@ -1432,7 +1433,7 @@ msgstr "Capacidad, gate y presión de holders por resource key."
 msgid ".subtitle_runtime_dashboard"
 msgstr "Vista operativa solo para desarrollo de módulos runtime y estado vivo."
 
-#: lib/lemmings_os_web/components/lemming_components.ex:702
+#: lib/lemmings_os_web/components/lemming_components.ex:722
 #, elixir-autogen, elixir-format
 msgid ".title_active_instances"
 msgstr "Instancias activas"
@@ -1458,7 +1459,7 @@ msgstr "Entradas runtime en ETS"
 msgid ".title_executors"
 msgstr "Executors"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:769
 #, elixir-autogen, elixir-format
 msgid ".title_recent_sessions"
 msgstr "Sesiones recientes"
@@ -1474,27 +1475,27 @@ msgstr "Pools de recursos"
 msgid ".title_runtime_dashboard"
 msgstr "Dashboard runtime"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:641
+#: lib/lemmings_os_web/components/lemming_components.ex:661
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
 msgstr "Lanzar instancia"
 
-#: lib/lemmings_os_web/components/instance_components.ex:899
+#: lib/lemmings_os_web/components/instance_components.ex:1137
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:893
+#: lib/lemmings_os_web/components/instance_components.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:902
+#: lib/lemmings_os_web/components/instance_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:295
+#: lib/lemmings_os_web/components/instance_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1509,8 +1510,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:483
-#: lib/lemmings_os_web/components/instance_components.ex:789
+#: lib/lemmings_os_web/components/instance_components.ex:696
+#: lib/lemmings_os_web/components/instance_components.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1525,12 +1526,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:317
+#: lib/lemmings_os_web/components/instance_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
+#: lib/lemmings_os_web/components/instance_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1576,12 +1577,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:306
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:788
+#: lib/lemmings_os_web/components/instance_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1601,37 +1602,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
+#: lib/lemmings_os_web/components/instance_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:799
+#: lib/lemmings_os_web/components/instance_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:805
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:807
+#: lib/lemmings_os_web/components/instance_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:796
+#: lib/lemmings_os_web/components/instance_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:811
+#: lib/lemmings_os_web/components/instance_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:234
+#: lib/lemmings_os_web/components/instance_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1646,22 +1647,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:525
+#: lib/lemmings_os_web/components/instance_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:550
+#: lib/lemmings_os_web/components/instance_components.ex:763
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:435
+#: lib/lemmings_os_web/components/instance_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1676,7 +1677,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:942
+#: lib/lemmings_os_web/components/instance_components.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1686,20 +1687,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:514
+#: lib/lemmings_os_web/components/instance_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:493
+#: lib/lemmings_os_web/components/instance_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:357
-#: lib/lemmings_os_web/components/instance_components.ex:395
-#: lib/lemmings_os_web/components/instance_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/instance_components.ex:570
+#: lib/lemmings_os_web/components/instance_components.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1709,18 +1710,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:859
+#: lib/lemmings_os_web/components/world_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:465
+#: lib/lemmings_os_web/components/instance_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:541
-#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/instance_components.ex:754
+#: lib/lemmings_os_web/components/world_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1730,18 +1731,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:857
-#: lib/lemmings_os_web/components/world_components.ex:1033
+#: lib/lemmings_os_web/components/world_components.ex:886
+#: lib/lemmings_os_web/components/world_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:480
+#: lib/lemmings_os_web/components/instance_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:503
+#: lib/lemmings_os_web/components/instance_components.ex:716
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1756,17 +1757,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:953
+#: lib/lemmings_os_web/components/instance_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:948
+#: lib/lemmings_os_web/components/instance_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/components/instance_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1776,22 +1777,209 @@ msgstr ""
 msgid "Copy workspace path"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:221
+#: lib/lemmings_os_web/live/instance_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Workspace could not be opened."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:209
+#: lib/lemmings_os_web/live/instance_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Workspace is unavailable right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:217
+#: lib/lemmings_os_web/live/instance_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Workspace open requested."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:226
+#: lib/lemmings_os_web/live/instance_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Workspace path copied."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1108
+#, elixir-autogen, elixir-format
+msgid "%{count} bytes"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:344
+#, elixir-autogen, elixir-format
+msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1238
+#, elixir-autogen, elixir-format
+msgid "An Artifact with this filename already exists. Update it after changing the workspace file."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1284
+#, elixir-autogen, elixir-format
+msgid "Artifact checksum calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1278
+#, elixir-autogen, elixir-format
+msgid "Artifact file copy failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Artifact promoted: %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:327
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1294
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed (%{reason})."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1290
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed validation."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1254
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion is missing the runtime instance."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1287
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion request is invalid."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1248
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion scope is invalid for this session."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1281
+#, elixir-autogen, elixir-format
+msgid "Artifact size calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1275
+#, elixir-autogen, elixir-format
+msgid "Artifact storage is unavailable right now."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Choose a valid promotion action for this Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:461
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:477
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:471
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:491
+#, elixir-autogen, elixir-format
+msgid "Notes"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1260
+#, elixir-autogen, elixir-format
+msgid "Only files inside this workspace can be promoted."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1272
+#, elixir-autogen, elixir-format
+msgid "Only regular files can be promoted as Artifacts."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:423
+#, elixir-autogen, elixir-format
+msgid "Promote as New Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:418
+#, elixir-autogen, elixir-format
+msgid "Promote as new Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:393
+#, elixir-autogen, elixir-format
+msgid "Promote to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:388
+#, elixir-autogen, elixir-format
+msgid "Promote workspace file to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:359
+#, elixir-autogen, elixir-format
+msgid "Promoted"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/components/instance_components.ex:417
+#, elixir-autogen, elixir-format
+msgid "Promoting..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1251
+#, elixir-autogen, elixir-format
+msgid "Runtime instance not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Show Artifact help"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1257
+#, elixir-autogen, elixir-format
+msgid "This filename cannot be promoted as an Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Unable to promote this file right now."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1110
+#, elixir-autogen, elixir-format
+msgid "Unknown size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "Update Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#, elixir-autogen, elixir-format
+msgid "Update existing Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:402
+#, elixir-autogen, elixir-format
+msgid "Updating..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1263
+#: lib/lemmings_os_web/live/instance_live.ex:1266
+#, elixir-autogen, elixir-format
+msgid "Workspace file not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/world.po
+++ b/priv/gettext/es/LC_MESSAGES/world.po
@@ -38,13 +38,13 @@ msgstr "Desconocido"
 
 #: lib/lemmings_os/helpers.ex:100
 #: lib/lemmings_os/helpers.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:1287
-#: lib/lemmings_os_web/components/world_components.ex:1317
-#: lib/lemmings_os_web/components/world_components.ex:1334
-#: lib/lemmings_os_web/components/world_components.ex:1351
-#: lib/lemmings_os_web/components/world_components.ex:1355
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/components/world_components.ex:1322
+#: lib/lemmings_os_web/components/world_components.ex:1352
+#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1386
+#: lib/lemmings_os_web/components/world_components.ex:1390
+#: lib/lemmings_os_web/components/world_components.ex:1411
+#: lib/lemmings_os_web/live/instance_live.ex:469
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
@@ -75,40 +75,40 @@ msgstr "Nodo de departamento"
 msgid ".aria_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:769
+#: lib/lemmings_os_web/components/world_components.ex:788
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "Todos los departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:254
-#: lib/lemmings_os_web/components/world_components.ex:539
+#: lib/lemmings_os_web/components/world_components.ex:266
+#: lib/lemmings_os_web/components/world_components.ex:557
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr "Importar bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:736
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Abrir departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:102
-#: lib/lemmings_os_web/components/world_components.ex:536
+#: lib/lemmings_os_web/components/world_components.ex:105
+#: lib/lemmings_os_web/components/world_components.ex:554
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr "Actualizar mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:436
+#: lib/lemmings_os_web/components/world_components.ex:448
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr "Aquí aparecerá el resumen de ciudades cuando exista una fuente real."
 
-#: lib/lemmings_os_web/components/world_components.ex:449
+#: lib/lemmings_os_web/components/world_components.ex:461
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr "Aquí aparecerá el resumen de herramientas cuando exista una fuente real."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:126
+#: lib/lemmings_os_web/live/departments_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departamentos"
@@ -118,178 +118,178 @@ msgstr "%{count} departamentos"
 msgid ".count_running_of_total"
 msgstr "%{running} de %{total} en ejecución"
 
-#: lib/lemmings_os_web/components/world_components.ex:659
-#: lib/lemmings_os_web/live/departments_live.html.heex:54
-#: lib/lemmings_os_web/live/departments_live.html.heex:133
+#: lib/lemmings_os_web/components/world_components.ex:677
+#: lib/lemmings_os_web/live/departments_live.html.heex:55
+#: lib/lemmings_os_web/live/departments_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "Aún no hay departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:660
-#: lib/lemmings_os_web/live/departments_live.html.heex:55
-#: lib/lemmings_os_web/live/departments_live.html.heex:134
+#: lib/lemmings_os_web/components/world_components.ex:678
+#: lib/lemmings_os_web/live/departments_live.html.heex:56
+#: lib/lemmings_os_web/live/departments_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Crea o importa un departamento para verlo aquí."
 
-#: lib/lemmings_os_web/components/world_components.ex:544
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr "No hay snapshot del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:545
+#: lib/lemmings_os_web/components/world_components.ex:563
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr "Importa el bootstrap o actualiza el estado para ver el snapshot actual."
 
-#: lib/lemmings_os_web/components/world_components.ex:338
+#: lib/lemmings_os_web/components/world_components.ex:350
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr "Ruta del bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:333
+#: lib/lemmings_os_web/components/world_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr "Fuente del bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:410
-#: lib/lemmings_os_web/components/world_components.ex:633
+#: lib/lemmings_os_web/components/world_components.ex:422
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr "Presupuestos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1310
+#: lib/lemmings_os_web/components/world_components.ex:1345
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1306
+#: lib/lemmings_os_web/components/world_components.ex:1341
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1315
+#: lib/lemmings_os_web/components/world_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declarado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1299
+#: lib/lemmings_os_web/components/world_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Deps."
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Vacío"
 
-#: lib/lemmings_os_web/components/world_components.ex:123
-#: lib/lemmings_os_web/components/world_components.ex:264
+#: lib/lemmings_os_web/components/world_components.ex:126
+#: lib/lemmings_os_web/components/world_components.ex:276
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr "Importación inmediata"
 
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:300
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr "Hash del último bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:284
+#: lib/lemmings_os_web/components/world_components.ex:296
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr "Última importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:141
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:144
+#: lib/lemmings_os_web/components/world_components.ex:288
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr "Última sincronización"
 
-#: lib/lemmings_os_web/components/world_components.ex:1300
+#: lib/lemmings_os_web/components/world_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
 
-#: lib/lemmings_os_web/components/world_components.ex:405
-#: lib/lemmings_os_web/components/world_components.ex:617
+#: lib/lemmings_os_web/components/world_components.ex:417
+#: lib/lemmings_os_web/components/world_components.ex:635
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr "Límites"
 
-#: lib/lemmings_os_web/components/world_components.ex:1289
+#: lib/lemmings_os_web/components/world_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "Sin fallback"
 
-#: lib/lemmings_os_web/components/world_components.ex:302
+#: lib/lemmings_os_web/components/world_components.ex:314
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr "No hay incidencias del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:433
-#: lib/lemmings_os_web/components/world_components.ex:446
+#: lib/lemmings_os_web/components/world_components.ex:445
+#: lib/lemmings_os_web/components/world_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr "Solo marcador"
 
-#: lib/lemmings_os_web/components/world_components.ex:420
+#: lib/lemmings_os_web/components/world_components.ex:432
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr "Secciones de marcador"
 
-#: lib/lemmings_os_web/components/world_components.ex:382
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:394
+#: lib/lemmings_os_web/components/world_components.ex:657
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr "Perfiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1362
+#: lib/lemmings_os_web/components/world_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credenciales listas"
 
-#: lib/lemmings_os_web/components/world_components.ex:1286
+#: lib/lemmings_os_web/components/world_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Proveedor deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1285
+#: lib/lemmings_os_web/components/world_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Proveedor habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:357
+#: lib/lemmings_os_web/components/world_components.ex:369
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr "Proveedores"
 
-#: lib/lemmings_os_web/components/world_components.ex:732
+#: lib/lemmings_os_web/components/world_components.ex:750
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Cola"
 
-#: lib/lemmings_os_web/components/world_components.ex:415
-#: lib/lemmings_os_web/components/world_components.ex:625
+#: lib/lemmings_os_web/components/world_components.ex:427
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr "Valores por defecto del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1371
-#: lib/lemmings_os_web/components/world_components.ex:1372
+#: lib/lemmings_os_web/components/world_components.ex:1406
+#: lib/lemmings_os_web/components/world_components.ex:1407
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Diferido por el entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1328
+#: lib/lemmings_os_web/components/world_components.ex:1363
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "ID del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:1329
+#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/world_components.ex:1364
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -329,22 +329,22 @@ msgstr "En línea"
 msgid ".metric_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1337
+#: lib/lemmings_os_web/components/world_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Archivo bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:1340
+#: lib/lemmings_os_web/components/world_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Conexión a Postgres"
 
-#: lib/lemmings_os_web/components/world_components.ex:1343
+#: lib/lemmings_os_web/components/world_components.ex:1378
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Credenciales del proveedor"
 
-#: lib/lemmings_os_web/components/world_components.ex:1346
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Alcance del proveedor"
@@ -375,23 +375,23 @@ msgstr "En línea"
 msgid ".subtitle_all_cities"
 msgstr "Ciudades registradas en este mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:207
+#: lib/lemmings_os_web/components/world_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:198
+#: lib/lemmings_os_web/components/world_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr "Importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:189
+#: lib/lemmings_os_web/components/world_components.ex:192
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:216
+#: lib/lemmings_os_web/components/world_components.ex:219
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr "Entorno"
@@ -401,45 +401,45 @@ msgstr "Entorno"
 msgid ".title_all_cities"
 msgstr "Todas las ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:327
+#: lib/lemmings_os_web/components/world_components.ex:158
+#: lib/lemmings_os_web/components/world_components.ex:339
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr "Configuración bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:653
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/components/world_components.ex:671
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:129
+#: lib/lemmings_os_web/components/world_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr "Estado de importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:457
+#: lib/lemmings_os_web/components/world_components.ex:172
+#: lib/lemmings_os_web/components/world_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr "Verificaciones del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:429
+#: lib/lemmings_os_web/components/world_components.ex:441
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr "Ciudades del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:111
-#: lib/lemmings_os_web/components/world_components.ex:349
-#: lib/lemmings_os_web/components/world_components.ex:528
-#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:114
+#: lib/lemmings_os_web/components/world_components.ex:361
+#: lib/lemmings_os_web/components/world_components.ex:546
+#: lib/lemmings_os_web/components/world_components.ex:869
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "Identidad del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:297
+#: lib/lemmings_os_web/components/world_components.ex:309
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr "Incidencias del mundo"
@@ -449,12 +449,12 @@ msgstr "Incidencias del mundo"
 msgid ".title_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:94
+#: lib/lemmings_os_web/components/world_components.ex:97
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr "Estado del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:442
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr "Herramientas del mundo"
@@ -469,13 +469,13 @@ msgstr "Departamento"
 msgid ".tooltip_running"
 msgstr "En ejecución"
 
-#: lib/lemmings_os_web/components/world_components.ex:612
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr "Se resuelve a partir de las capas persistidas World y City."
 
-#: lib/lemmings_os_web/components/world_components.ex:835
-#: lib/lemmings_os_web/live/departments_live.html.heex:49
+#: lib/lemmings_os_web/components/world_components.ex:864
+#: lib/lemmings_os_web/live/departments_live.html.heex:50
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr "Ciudades"
@@ -501,40 +501,40 @@ msgstr "Aún no hay ciudades"
 msgid ".empty_no_cities_copy"
 msgstr "Esta página ahora lee la tabla real de ciudades. Creá o bootstrappeá una ciudad para verla acá."
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:272
+#: lib/lemmings_os_web/live/cities_live.html.heex:281
 #, elixir-autogen
 msgid ".label_city_distribution_port"
 msgstr "Puerto de distribución"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:277
+#: lib/lemmings_os_web/live/cities_live.html.heex:286
 #, elixir-autogen
 msgid ".label_city_epmd_port"
 msgstr "Puerto EPMD"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:267
+#: lib/lemmings_os_web/live/cities_live.html.heex:276
 #, elixir-autogen
 msgid ".label_city_host"
 msgstr "Host"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:282
+#: lib/lemmings_os_web/live/cities_live.html.heex:291
 #: lib/lemmings_os_web/live/settings_live.html.heex:111
 #, elixir-autogen
 msgid ".label_city_last_seen_at"
 msgstr "Último heartbeat"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:262
+#: lib/lemmings_os_web/live/cities_live.html.heex:271
 #: lib/lemmings_os_web/live/settings_live.html.heex:106
 #, elixir-autogen
 msgid ".label_city_node_name"
 msgstr "Nodo BEAM"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:257
+#: lib/lemmings_os_web/live/cities_live.html.heex:266
 #: lib/lemmings_os_web/live/settings_live.html.heex:101
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:629
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr "Configuración efectiva de la ciudad"
@@ -604,7 +604,7 @@ msgstr "Nombre del nodo BEAM"
 msgid ".city_form_node_name_placeholder"
 msgstr "ej. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:830
+#: lib/lemmings_os_web/components/world_components.ex:859
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -645,268 +645,268 @@ msgstr "Crear ciudad"
 msgid ".city_form_submit_update"
 msgstr "Guardar cambios"
 
-#: lib/lemmings_os_web/live/cities_live.ex:504
+#: lib/lemmings_os_web/live/cities_live.ex:508
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "Ciudad creada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:529
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "Ciudad actualizada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:144
+#: lib/lemmings_os_web/live/cities_live.ex:146
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr "Ciudad eliminada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:100
-#: lib/lemmings_os_web/live/cities_live.ex:153
+#: lib/lemmings_os_web/live/cities_live.ex:102
+#: lib/lemmings_os_web/live/cities_live.ex:155
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr "Ciudad no encontrada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:514
-#: lib/lemmings_os_web/live/cities_live.ex:539
+#: lib/lemmings_os_web/live/cities_live.ex:518
+#: lib/lemmings_os_web/live/cities_live.ex:543
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "No se pudo guardar la ciudad. Revisá el formulario."
 
-#: lib/lemmings_os_web/live/cities_live.ex:150
+#: lib/lemmings_os_web/live/cities_live.ex:152
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr "No se pudo eliminar la ciudad."
 
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:717
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Abrir departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:666
+#: lib/lemmings_os_web/components/world_components.ex:684
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr "%{city} tiene %{count} departamentos."
 
-#: lib/lemmings_os_web/components/world_components.ex:654
+#: lib/lemmings_os_web/components/world_components.ex:672
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr "Resumen compacto de los departamentos persistidos para esta city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Cambiá la city activa para el mapa y la lista de departamentos."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:96
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "City seleccionada"
 
-#: lib/lemmings_os_web/components/world_components.ex:925
+#: lib/lemmings_os_web/components/world_components.ex:954
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activar"
 
-#: lib/lemmings_os_web/components/world_components.ex:953
+#: lib/lemmings_os_web/components/world_components.ex:982
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Borrar"
 
-#: lib/lemmings_os_web/components/world_components.ex:943
+#: lib/lemmings_os_web/components/world_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Deshabilitar"
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:963
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drenar"
 
-#: lib/lemmings_os_web/components/world_components.ex:1177
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Guardar ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:950
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "¿Seguro que quieres borrar este departamento?"
 
-#: lib/lemmings_os_web/components/world_components.ex:897
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notas"
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:931
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:987
+#: lib/lemmings_os_web/components/world_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No hay lemmings disponibles"
 
-#: lib/lemmings_os_web/components/world_components.ex:988
+#: lib/lemmings_os_web/components/world_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "Todavía no hay lemmings con respaldo de runtime ni vista mock para este departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:963
+#: lib/lemmings_os_web/components/world_components.ex:992
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Acciones de ciclo de vida"
 
-#: lib/lemmings_os_web/components/world_components.ex:915
+#: lib/lemmings_os_web/components/world_components.ex:944
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Usa los controles persistidos del ciclo de vida del departamento. El borrado sigue protegido por checks de seguridad."
 
-#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:922
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadatos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1072
-#: lib/lemmings_os_web/components/world_components.ex:1105
-#: lib/lemmings_os_web/components/world_components.ex:1154
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1134
+#: lib/lemmings_os_web/components/world_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1077
-#: lib/lemmings_os_web/components/world_components.ex:1114
-#: lib/lemmings_os_web/components/world_components.ex:1169
+#: lib/lemmings_os_web/components/world_components.ex:1106
+#: lib/lemmings_os_web/components/world_components.ex:1143
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1158
+#: lib/lemmings_os_web/components/world_components.ex:1187
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1157
+#: lib/lemmings_os_web/components/world_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1067
-#: lib/lemmings_os_web/components/world_components.ex:1098
-#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Segundos TTL inactivo"
 
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Heredar"
 
-#: lib/lemmings_os_web/components/world_components.ex:1062
-#: lib/lemmings_os_web/components/world_components.ex:1089
-#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1091
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1168
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Máximo de lemmings por departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Valores efectivos después de resolver las capas de Mundo, Ciudad y Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:1057
+#: lib/lemmings_os_web/components/world_components.ex:1086
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Configuración efectiva"
 
-#: lib/lemmings_os_web/components/world_components.ex:1085
+#: lib/lemmings_os_web/components/world_components.ex:1114
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Solo los overrides locales del Departamento persistidos en esta fila. Los valores vacíos heredan desde Ciudad o Mundo."
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Overrides locales"
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "Editor V1. Actualiza de forma segura un subconjunto pequeño de overrides locales del Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Editor de ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:792
+#: lib/lemmings_os_web/components/world_components.ex:811
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:782
+#: lib/lemmings_os_web/components/world_components.ex:801
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:821
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Ajustes"
 
-#: lib/lemmings_os_web/live/departments_live.ex:665
+#: lib/lemmings_os_web/live/departments_live.ex:670
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Departamento activado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:116
+#: lib/lemmings_os_web/live/departments_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Departamento borrado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:667
+#: lib/lemmings_os_web/live/departments_live.ex:672
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Departamento deshabilitado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:666
+#: lib/lemmings_os_web/live/departments_live.ex:671
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Departamento puesto en drenaje."
 
-#: lib/lemmings_os_web/live/departments_live.ex:130
+#: lib/lemmings_os_web/live/departments_live.ex:132
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "No se pudo actualizar el ciclo de vida del departamento."
 
-#: lib/lemmings_os_web/live/departments_live.ex:100
+#: lib/lemmings_os_web/live/departments_live.ex:102
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Ajustes del departamento guardados."
 
-#: lib/lemmings_os_web/live/departments_live.ex:668
+#: lib/lemmings_os_web/live/departments_live.ex:673
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Departamento actualizado."
 
-#: lib/lemmings_os_web/components/world_components.ex:972
+#: lib/lemmings_os_web/components/world_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:964
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr "permitido"
 msgid ".secret_blocked_by_allowlist"
 msgstr "bloqueado por la lista de permitidos"
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:297
+#: lib/lemmings_os_web/live/cities_live.html.heex:306
 #, elixir-autogen, elixir-format
 msgid ".secret_city_subtitle"
 msgstr "Valores write-only del Secret Bank con alcance a esta ciudad."
@@ -992,15 +992,15 @@ msgstr "¿Eliminar este valor secreto local?"
 msgid ".secret_delete_label"
 msgstr "Eliminar secreto local %{key}"
 
-#: lib/lemmings_os_web/live/cities_live.ex:204
-#: lib/lemmings_os_web/live/departments_live.ex:189
-#: lib/lemmings_os_web/live/lemmings_live.ex:184
-#: lib/lemmings_os_web/live/world_live.ex:101
+#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/lemmings_live.ex:187
+#: lib/lemmings_os_web/live/world_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr "Secreto local eliminado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1223
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr "Valores write-only del Secret Bank con alcance a este departamento."
@@ -1085,7 +1085,7 @@ msgstr "Usa el nombre de clave configurado en Secret Bank, sin exponer un valor.
 msgid ".secret_key_label"
 msgstr "Clave secreta"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:565
+#: lib/lemmings_os_web/components/lemming_components.ex:579
 #, elixir-autogen, elixir-format
 msgid ".secret_lemming_subtitle"
 msgstr "Valores write-only del Secret Bank con alcance a este lemming."
@@ -1110,10 +1110,10 @@ msgstr "Guardar secreto"
 msgid ".secret_save_pending"
 msgstr "Guardando secreto..."
 
-#: lib/lemmings_os_web/live/cities_live.ex:164
-#: lib/lemmings_os_web/live/departments_live.ex:146
-#: lib/lemmings_os_web/live/lemmings_live.ex:144
-#: lib/lemmings_os_web/live/world_live.ex:63
+#: lib/lemmings_os_web/live/cities_live.ex:166
+#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/lemmings_live.ex:147
+#: lib/lemmings_os_web/live/world_live.ex:65
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr "Secreto guardado"
@@ -1128,11 +1128,11 @@ msgstr "El valor es write-only y no se mostrará después de guardarlo."
 msgid ".secret_value_label"
 msgstr "Valor secreto"
 
-#: lib/lemmings_os_web/components/lemming_components.ex:371
-#: lib/lemmings_os_web/components/lemming_components.ex:1051
+#: lib/lemmings_os_web/components/lemming_components.ex:377
+#: lib/lemmings_os_web/components/lemming_components.ex:1071
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:225
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:228
+#: lib/lemmings_os_web/components/world_components.ex:831
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/priv/gettext/layout.pot
+++ b/priv/gettext/layout.pot
@@ -74,7 +74,7 @@ msgid ".nav_departments"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:681
+#: lib/lemmings_os_web/components/world_components.ex:699
 #: lib/lemmings_os_web/live/mock_shell.ex:48
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -102,7 +102,7 @@ msgid ".nav_settings"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:996
+#: lib/lemmings_os_web/components/world_components.ex:1025
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr ""
@@ -199,22 +199,22 @@ msgstr ""
 msgid ".page_title_home"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:26
+#: lib/lemmings_os_web/live/lemmings_live.ex:27
 #, elixir-autogen
 msgid ".page_title_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:46
+#: lib/lemmings_os_web/live/cities_live.ex:47
 #, elixir-autogen
 msgid ".page_title_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:27
+#: lib/lemmings_os_web/live/departments_live.ex:28
 #, elixir-autogen
 msgid ".page_title_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:23
+#: lib/lemmings_os_web/live/world_live.ex:24
 #, elixir-autogen
 msgid ".page_title_world"
 msgstr ""
@@ -914,60 +914,60 @@ msgstr ""
 msgid ".connections_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:269
-#: lib/lemmings_os_web/live/departments_live.ex:256
-#: lib/lemmings_os_web/live/world_live.ex:164
+#: lib/lemmings_os_web/live/cities_live.ex:271
+#: lib/lemmings_os_web/live/departments_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:166
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:383
-#: lib/lemmings_os_web/live/departments_live.ex:378
-#: lib/lemmings_os_web/live/world_live.ex:278
+#: lib/lemmings_os_web/live/cities_live.ex:385
+#: lib/lemmings_os_web/live/departments_live.ex:380
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:284
-#: lib/lemmings_os_web/live/cities_live.ex:338
-#: lib/lemmings_os_web/live/cities_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:274
-#: lib/lemmings_os_web/live/departments_live.ex:333
-#: lib/lemmings_os_web/live/departments_live.ex:359
-#: lib/lemmings_os_web/live/world_live.ex:180
-#: lib/lemmings_os_web/live/world_live.ex:238
-#: lib/lemmings_os_web/live/world_live.ex:261
+#: lib/lemmings_os_web/live/cities_live.ex:286
+#: lib/lemmings_os_web/live/cities_live.ex:340
+#: lib/lemmings_os_web/live/cities_live.ex:366
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:335
+#: lib/lemmings_os_web/live/departments_live.ex:361
+#: lib/lemmings_os_web/live/world_live.ex:182
+#: lib/lemmings_os_web/live/world_live.ex:240
+#: lib/lemmings_os_web/live/world_live.ex:263
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:300
-#: lib/lemmings_os_web/live/cities_live.ex:332
-#: lib/lemmings_os_web/live/cities_live.ex:367
-#: lib/lemmings_os_web/live/cities_live.ex:390
-#: lib/lemmings_os_web/live/cities_live.ex:418
-#: lib/lemmings_os_web/live/departments_live.ex:294
-#: lib/lemmings_os_web/live/departments_live.ex:327
-#: lib/lemmings_os_web/live/departments_live.ex:362
-#: lib/lemmings_os_web/live/departments_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:413
-#: lib/lemmings_os_web/live/world_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:232
-#: lib/lemmings_os_web/live/world_live.ex:264
-#: lib/lemmings_os_web/live/world_live.ex:284
-#: lib/lemmings_os_web/live/world_live.ex:307
+#: lib/lemmings_os_web/live/cities_live.ex:302
+#: lib/lemmings_os_web/live/cities_live.ex:334
+#: lib/lemmings_os_web/live/cities_live.ex:369
+#: lib/lemmings_os_web/live/cities_live.ex:392
+#: lib/lemmings_os_web/live/cities_live.ex:420
+#: lib/lemmings_os_web/live/departments_live.ex:296
+#: lib/lemmings_os_web/live/departments_live.ex:329
+#: lib/lemmings_os_web/live/departments_live.ex:364
+#: lib/lemmings_os_web/live/departments_live.ex:387
+#: lib/lemmings_os_web/live/departments_live.ex:415
+#: lib/lemmings_os_web/live/world_live.ex:202
+#: lib/lemmings_os_web/live/world_live.ex:234
+#: lib/lemmings_os_web/live/world_live.ex:266
+#: lib/lemmings_os_web/live/world_live.ex:286
+#: lib/lemmings_os_web/live/world_live.ex:309
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:184
+#: lib/lemmings_os_web/live/world_live.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:411
-#: lib/lemmings_os_web/live/departments_live.ex:406
-#: lib/lemmings_os_web/live/world_live.ex:303
+#: lib/lemmings_os_web/live/cities_live.ex:413
+#: lib/lemmings_os_web/live/departments_live.ex:408
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr ""
@@ -977,16 +977,16 @@ msgstr ""
 msgid ".connections_flash_test_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:429
-#: lib/lemmings_os_web/live/departments_live.ex:424
-#: lib/lemmings_os_web/live/world_live.ex:316
+#: lib/lemmings_os_web/live/cities_live.ex:431
+#: lib/lemmings_os_web/live/departments_live.ex:426
+#: lib/lemmings_os_web/live/world_live.ex:318
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:356
-#: lib/lemmings_os_web/live/departments_live.ex:351
-#: lib/lemmings_os_web/live/world_live.ex:254
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/departments_live.ex:353
+#: lib/lemmings_os_web/live/world_live.ex:256
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr ""
@@ -1056,8 +1056,8 @@ msgstr ""
 msgid ".connections_source_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:234
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:237
+#: lib/lemmings_os_web/components/world_components.ex:841
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
@@ -1073,4 +1073,90 @@ msgstr ""
 #: lib/lemmings_os_web/components/connections_components.ex:135
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:44
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:18
+#: lib/lemmings_os_web/components/artifacts_components.ex:35
+#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:1072
+#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:851
+#: lib/lemmings_os_web/live/cities_live.html.heex:256
+#, elixir-autogen, elixir-format
+msgid "Artifacts"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:21
+#, elixir-autogen, elixir-format
+msgid "Artifacts available at this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:43
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:116
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:113
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:38
+#, elixir-autogen, elixir-format
+msgid "Filename"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:30
+#, elixir-autogen, elixir-format
+msgid "No artifacts available for this scope."
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:39
+#, elixir-autogen, elixir-format
+msgid "Scope"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:42
+#, elixir-autogen, elixir-format
+msgid "Size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:41
+#, elixir-autogen, elixir-format
+msgid "Status"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:40
+#, elixir-autogen, elixir-format
+msgid "Type"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:66
+#, elixir-autogen, elixir-format
+msgid "city"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:73
+#, elixir-autogen, elixir-format
+msgid "dept"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:80
+#, elixir-autogen, elixir-format
+msgid "lemming"
+msgstr ""
+
+#: lib/lemmings_os_web/components/artifacts_components.ex:90
+#, elixir-autogen, elixir-format
+msgid "world"
 msgstr ""

--- a/priv/gettext/lemmings.pot
+++ b/priv/gettext/lemmings.pot
@@ -35,19 +35,19 @@ msgstr ""
 msgid ".subtitle_all_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:842
-#: lib/lemmings_os_web/components/lemming_components.ex:898
+#: lib/lemmings_os_web/components/lemming_components.ex:862
+#: lib/lemmings_os_web/components/lemming_components.ex:918
 #, elixir-autogen
 msgid ".title_create_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:468
-#: lib/lemmings_os_web/components/lemming_components.ex:904
+#: lib/lemmings_os_web/components/lemming_components.ex:482
+#: lib/lemmings_os_web/components/lemming_components.ex:924
 #, elixir-autogen
 msgid ".label_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:909
+#: lib/lemmings_os_web/components/lemming_components.ex:929
 #, elixir-autogen
 msgid ".placeholder_name"
 msgstr ""
@@ -57,97 +57,97 @@ msgstr ""
 msgid ".page_title_create_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:236
+#: lib/lemmings_os_web/components/lemming_components.ex:238
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_activate"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:247
+#: lib/lemmings_os_web/components/lemming_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".button_lemming_archive"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:392
+#: lib/lemmings_os_web/components/lemming_components.ex:406
 #, elixir-autogen, elixir-format
 msgid ".copy_inheriting_all_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:623
+#: lib/lemmings_os_web/components/lemming_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".copy_instances_workspace_selected"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:423
+#: lib/lemmings_os_web/components/lemming_components.ex:437
 #, elixir-autogen, elixir-format
 msgid ".detail_allowed_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:437
+#: lib/lemmings_os_web/components/lemming_components.ex:451
 #, elixir-autogen, elixir-format
 msgid ".detail_denied_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:410
+#: lib/lemmings_os_web/components/lemming_components.ex:424
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_cross_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:415
+#: lib/lemmings_os_web/components/lemming_components.ex:429
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:405
+#: lib/lemmings_os_web/components/lemming_components.ex:419
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_idle_ttl"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:398
+#: lib/lemmings_os_web/components/lemming_components.ex:412
 #, elixir-autogen, elixir-format
 msgid ".detail_effective_max_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:378
+#: lib/lemmings_os_web/components/lemming_components.ex:392
 #, elixir-autogen, elixir-format
 msgid ".detail_instructions"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:589
+#: lib/lemmings_os_web/components/lemming_components.ex:609
 #, elixir-autogen, elixir-format
 msgid ".detail_spawn_requests"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:268
+#: lib/lemmings_os_web/components/lemming_components.ex:270
 #, elixir-autogen, elixir-format
 msgid ".detail_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:629
+#: lib/lemmings_os_web/components/lemming_components.ex:649
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:630
+#: lib/lemmings_os_web/components/lemming_components.ex:650
 #, elixir-autogen, elixir-format
 msgid ".empty_instances_workspace_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:280
+#: lib/lemmings_os_web/components/lemming_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:281
+#: lib/lemmings_os_web/components/lemming_components.ex:283
 #, elixir-autogen, elixir-format
 msgid ".empty_lemming_not_found_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:430
+#: lib/lemmings_os_web/components/lemming_components.ex:444
 #, elixir-autogen, elixir-format
 msgid ".empty_no_allowed_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:444
+#: lib/lemmings_os_web/components/lemming_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".empty_no_denied_tools"
 msgstr ""
@@ -169,58 +169,58 @@ msgstr ""
 
 #: lib/lemmings_os_web/components/lemming_components.ex:65
 #: lib/lemmings_os_web/components/lemming_components.ex:128
-#: lib/lemmings_os_web/components/lemming_components.ex:258
-#: lib/lemmings_os_web/components/lemming_components.ex:876
-#: lib/lemmings_os_web/components/lemming_components.ex:999
+#: lib/lemmings_os_web/components/lemming_components.ex:260
+#: lib/lemmings_os_web/components/lemming_components.ex:896
+#: lib/lemmings_os_web/components/lemming_components.ex:1019
 #, elixir-autogen, elixir-format
 msgid ".filter_city"
 msgstr ""
 
 #: lib/lemmings_os_web/components/lemming_components.ex:67
-#: lib/lemmings_os_web/components/lemming_components.ex:878
+#: lib/lemmings_os_web/components/lemming_components.ex:898
 #, elixir-autogen, elixir-format
 msgid ".filter_city_prompt"
 msgstr ""
 
 #: lib/lemmings_os_web/components/lemming_components.ex:74
 #: lib/lemmings_os_web/components/lemming_components.ex:121
-#: lib/lemmings_os_web/components/lemming_components.ex:263
-#: lib/lemmings_os_web/components/lemming_components.ex:885
-#: lib/lemmings_os_web/components/lemming_components.ex:1004
+#: lib/lemmings_os_web/components/lemming_components.ex:265
+#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid ".filter_department"
 msgstr ""
 
 #: lib/lemmings_os_web/components/lemming_components.ex:76
-#: lib/lemmings_os_web/components/lemming_components.ex:889
+#: lib/lemmings_os_web/components/lemming_components.ex:909
 #, elixir-autogen, elixir-format
 msgid ".filter_department_prompt"
 msgstr ""
 
 #: lib/lemmings_os_web/components/lemming_components.ex:54
-#: lib/lemmings_os_web/components/lemming_components.ex:865
-#: lib/lemmings_os_web/components/lemming_components.ex:994
+#: lib/lemmings_os_web/components/lemming_components.ex:885
+#: lib/lemmings_os_web/components/lemming_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".filter_world"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:83
-#: lib/lemmings_os_web/live/lemmings_live.ex:115
+#: lib/lemmings_os_web/live/lemmings_live.ex:86
+#: lib/lemmings_os_web/live/lemmings_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_instructions_required"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:530
+#: lib/lemmings_os_web/live/lemmings_live.ex:539
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_activated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:531
+#: lib/lemmings_os_web/live/lemmings_live.ex:540
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_archived"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:119
+#: lib/lemmings_os_web/live/lemmings_live.ex:122
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_update_failed"
 msgstr ""
@@ -230,7 +230,7 @@ msgstr ""
 msgid ".label_open_detail"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:385
+#: lib/lemmings_os_web/components/lemming_components.ex:399
 #, elixir-autogen, elixir-format
 msgid ".subtitle_effective_config"
 msgstr ""
@@ -240,7 +240,7 @@ msgstr ""
 msgid ".subtitle_filters"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:583
+#: lib/lemmings_os_web/components/lemming_components.ex:603
 #, elixir-autogen, elixir-format
 msgid ".subtitle_instances_workspace"
 msgstr ""
@@ -250,13 +250,13 @@ msgstr ""
 msgid ".subtitle_lemming_types"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:355
-#: lib/lemmings_os_web/components/lemming_components.ex:1052
+#: lib/lemmings_os_web/components/lemming_components.ex:361
+#: lib/lemmings_os_web/components/lemming_components.ex:1073
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:384
+#: lib/lemmings_os_web/components/lemming_components.ex:398
 #, elixir-autogen, elixir-format
 msgid ".title_effective_config"
 msgstr ""
@@ -266,13 +266,13 @@ msgstr ""
 msgid ".title_filters"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:582
+#: lib/lemmings_os_web/components/lemming_components.ex:602
 #, elixir-autogen, elixir-format
 msgid ".title_instances_workspace"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:177
-#: lib/lemmings_os_web/components/lemming_components.ex:277
+#: lib/lemmings_os_web/components/lemming_components.ex:179
+#: lib/lemmings_os_web/components/lemming_components.ex:279
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_detail"
 msgstr ""
@@ -282,27 +282,27 @@ msgstr ""
 msgid ".title_lemming_types"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:981
+#: lib/lemmings_os_web/components/lemming_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_create_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:978
+#: lib/lemmings_os_web/components/lemming_components.ex:998
 #, elixir-autogen, elixir-format
 msgid ".button_creating_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:1008
+#: lib/lemmings_os_web/components/lemming_components.ex:1028
 #, elixir-autogen, elixir-format
 msgid ".copy_create_scope"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:854
+#: lib/lemmings_os_web/components/lemming_components.ex:874
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:855
+#: lib/lemmings_os_web/components/lemming_components.ex:875
 #, elixir-autogen, elixir-format
 msgid ".empty_create_missing_department_copy"
 msgstr ""
@@ -319,63 +319,63 @@ msgstr ""
 msgid ".flash_lemming_created"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:485
-#: lib/lemmings_os_web/components/lemming_components.ex:926
+#: lib/lemmings_os_web/components/lemming_components.ex:499
+#: lib/lemmings_os_web/components/lemming_components.ex:946
 #, elixir-autogen, elixir-format
 msgid ".label_description"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:498
-#: lib/lemmings_os_web/components/lemming_components.ex:939
+#: lib/lemmings_os_web/components/lemming_components.ex:512
+#: lib/lemmings_os_web/components/lemming_components.ex:959
 #, elixir-autogen, elixir-format
 msgid ".label_instructions"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:476
-#: lib/lemmings_os_web/components/lemming_components.ex:915
+#: lib/lemmings_os_web/components/lemming_components.ex:490
+#: lib/lemmings_os_web/components/lemming_components.ex:935
 #, elixir-autogen, elixir-format
 msgid ".label_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:511
-#: lib/lemmings_os_web/components/lemming_components.ex:952
+#: lib/lemmings_os_web/components/lemming_components.ex:525
+#: lib/lemmings_os_web/components/lemming_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".label_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:920
+#: lib/lemmings_os_web/components/lemming_components.ex:940
 #, elixir-autogen, elixir-format
 msgid ".placeholder_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:899
+#: lib/lemmings_os_web/components/lemming_components.ex:919
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_form"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:843
+#: lib/lemmings_os_web/components/lemming_components.ex:863
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_lemming_real"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:849
-#: lib/lemmings_os_web/components/lemming_components.ex:990
+#: lib/lemmings_os_web/components/lemming_components.ex:869
+#: lib/lemmings_os_web/components/lemming_components.ex:1010
 #, elixir-autogen, elixir-format
 msgid ".subtitle_create_scope"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:848
-#: lib/lemmings_os_web/components/lemming_components.ex:989
+#: lib/lemmings_os_web/components/lemming_components.ex:868
+#: lib/lemmings_os_web/components/lemming_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid ".title_create_scope"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:217
+#: lib/lemmings_os_web/components/lemming_components.ex:219
 #, elixir-autogen
 msgid ".button_export_json"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:133
+#: lib/lemmings_os_web/live/lemmings_live.ex:136
 #, elixir-autogen
 msgid ".flash_export_no_lemming"
 msgstr ""
@@ -506,42 +506,42 @@ msgstr ""
 msgid ".error_import_file_too_large"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:971
+#: lib/lemmings_os_web/components/lemming_components.ex:991
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_create"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:539
+#: lib/lemmings_os_web/components/lemming_components.ex:553
 #, elixir-autogen, elixir-format
 msgid ".button_cancel_edit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:530
+#: lib/lemmings_os_web/components/lemming_components.ex:544
 #, elixir-autogen, elixir-format
 msgid ".button_edit_costs"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:524
+#: lib/lemmings_os_web/components/lemming_components.ex:538
 #, elixir-autogen, elixir-format
 msgid ".button_edit_limit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:527
+#: lib/lemmings_os_web/components/lemming_components.ex:541
 #, elixir-autogen, elixir-format
 msgid ".button_edit_runtime"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:533
+#: lib/lemmings_os_web/components/lemming_components.ex:547
 #, elixir-autogen, elixir-format
 msgid ".button_edit_tools"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:547
+#: lib/lemmings_os_web/components/lemming_components.ex:561
 #, elixir-autogen, elixir-format
 msgid ".button_save_lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:545
+#: lib/lemmings_os_web/components/lemming_components.ex:559
 #, elixir-autogen, elixir-format
 msgid ".button_saving_lemming"
 msgstr ""
@@ -556,92 +556,92 @@ msgstr ""
 msgid ".empty_world_unavailable_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/live/lemmings_live.ex:89
+#: lib/lemmings_os_web/live/lemmings_live.ex:92
 #, elixir-autogen, elixir-format
 msgid ".flash_lemming_saved"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:933
+#: lib/lemmings_os_web/components/lemming_components.ex:953
 #, elixir-autogen, elixir-format
 msgid ".placeholder_description"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:946
+#: lib/lemmings_os_web/components/lemming_components.ex:966
 #, elixir-autogen, elixir-format
 msgid ".placeholder_instructions"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:455
+#: lib/lemmings_os_web/components/lemming_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".subtitle_lemming_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:225
-#: lib/lemmings_os_web/components/lemming_components.ex:363
-#: lib/lemmings_os_web/components/lemming_components.ex:1050
+#: lib/lemmings_os_web/components/lemming_components.ex:227
+#: lib/lemmings_os_web/components/lemming_components.ex:369
+#: lib/lemmings_os_web/components/lemming_components.ex:1070
 #, elixir-autogen, elixir-format
 msgid ".tab_edit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:454
+#: lib/lemmings_os_web/components/lemming_components.ex:468
 #, elixir-autogen, elixir-format
 msgid ".title_lemming_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:486
-#: lib/lemmings_os_web/components/lemming_components.ex:927
+#: lib/lemmings_os_web/components/lemming_components.ex:500
+#: lib/lemmings_os_web/components/lemming_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_description"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:499
-#: lib/lemmings_os_web/components/lemming_components.ex:940
+#: lib/lemmings_os_web/components/lemming_components.ex:513
+#: lib/lemmings_os_web/components/lemming_components.ex:960
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_instructions"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:469
-#: lib/lemmings_os_web/components/lemming_components.ex:905
+#: lib/lemmings_os_web/components/lemming_components.ex:483
+#: lib/lemmings_os_web/components/lemming_components.ex:925
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:477
-#: lib/lemmings_os_web/components/lemming_components.ex:916
+#: lib/lemmings_os_web/components/lemming_components.ex:491
+#: lib/lemmings_os_web/components/lemming_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:512
-#: lib/lemmings_os_web/components/lemming_components.ex:953
+#: lib/lemmings_os_web/components/lemming_components.ex:526
+#: lib/lemmings_os_web/components/lemming_components.ex:973
 #, elixir-autogen, elixir-format
 msgid ".tooltip_create_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:687
-#: lib/lemmings_os_web/live/instance_live.ex:648
+#: lib/lemmings_os_web/components/instance_components.ex:900
+#: lib/lemmings_os_web/live/instance_live.ex:710
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:679
-#: lib/lemmings_os_web/live/instance_live.ex:640
+#: lib/lemmings_os_web/components/instance_components.ex:892
+#: lib/lemmings_os_web/live/instance_live.ex:702
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:673
-#: lib/lemmings_os_web/live/instance_live.ex:634
+#: lib/lemmings_os_web/components/instance_components.ex:886
+#: lib/lemmings_os_web/live/instance_live.ex:696
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:459
+#: lib/lemmings_os_web/live/instance_live.html.heex:463
 #, elixir-autogen, elixir-format
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:740
+#: lib/lemmings_os_web/components/instance_components.ex:953
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -668,12 +668,12 @@ msgstr ""
 msgid "Current item"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:542
+#: lib/lemmings_os_web/live/instance_live.ex:604
 #, elixir-autogen, elixir-format
 msgid "Current item: %{item}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:496
+#: lib/lemmings_os_web/live/instance_live.ex:558
 #, elixir-autogen, elixir-format
 msgid "Current status: %{status}"
 msgstr ""
@@ -683,13 +683,13 @@ msgstr ""
 msgid "Elapsed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:586
+#: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:790
-#: lib/lemmings_os_web/live/instance_live.ex:585
+#: lib/lemmings_os_web/components/instance_components.ex:1003
+#: lib/lemmings_os_web/live/instance_live.ex:647
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
@@ -699,19 +699,19 @@ msgstr ""
 msgid "Failure detail"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:408
-#: lib/lemmings_os_web/live/instance_live.html.heex:446
+#: lib/lemmings_os_web/live/instance_live.html.heex:412
+#: lib/lemmings_os_web/live/instance_live.html.heex:450
 #, elixir-autogen, elixir-format
 msgid "Follow-up request"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:584
+#: lib/lemmings_os_web/live/instance_live.ex:646
 #, elixir-autogen, elixir-format
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:630
-#: lib/lemmings_os_web/live/instance_live.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:843
+#: lib/lemmings_os_web/live/instance_live.ex:670
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
@@ -721,29 +721,29 @@ msgstr ""
 msgid "Input %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:464
+#: lib/lemmings_os_web/live/instance_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Instance"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:24
+#: lib/lemmings_os_web/live/instance_live.ex:26
 #, elixir-autogen, elixir-format
 msgid "Instance Session"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:693
+#: lib/lemmings_os_web/live/instance_live.ex:755
 #, elixir-autogen, elixir-format
 msgid "Instance cannot accept follow-up requests"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:690
-#: lib/lemmings_os_web/live/instance_live.ex:723
+#: lib/lemmings_os_web/live/instance_live.ex:752
+#: lib/lemmings_os_web/live/instance_live.ex:785
 #, elixir-autogen, elixir-format
 msgid "Instance has expired"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:689
-#: lib/lemmings_os_web/live/instance_live.ex:722
+#: lib/lemmings_os_web/live/instance_live.ex:751
+#: lib/lemmings_os_web/live/instance_live.ex:784
 #, elixir-autogen, elixir-format
 msgid "Instance has failed"
 msgstr ""
@@ -754,7 +754,7 @@ msgstr ""
 msgid "Instance not found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:470
+#: lib/lemmings_os_web/live/instance_live.ex:532
 #, elixir-autogen, elixir-format
 msgid "Instance session"
 msgstr ""
@@ -764,7 +764,7 @@ msgstr ""
 msgid "Last activity at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:539
+#: lib/lemmings_os_web/live/instance_live.ex:601
 #, elixir-autogen, elixir-format
 msgid "Latest runtime move"
 msgstr ""
@@ -780,18 +780,18 @@ msgstr ""
 msgid "Output %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:575
+#: lib/lemmings_os_web/live/instance_live.ex:637
 #, elixir-autogen, elixir-format
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:617
-#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/components/instance_components.ex:830
+#: lib/lemmings_os_web/live/instance_live.ex:657
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:719
+#: lib/lemmings_os_web/live/instance_live.ex:781
 #, elixir-autogen, elixir-format
 msgid "Processing..."
 msgstr ""
@@ -802,15 +802,15 @@ msgstr ""
 msgid "Queue depth"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:721
+#: lib/lemmings_os_web/live/instance_live.ex:783
 #, elixir-autogen, elixir-format
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:600
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/live/instance_live.ex:565
-#: lib/lemmings_os_web/live/instance_live.ex:601
+#: lib/lemmings_os_web/components/instance_components.ex:813
+#: lib/lemmings_os_web/components/instance_components.ex:836
+#: lib/lemmings_os_web/live/instance_live.ex:627
+#: lib/lemmings_os_web/live/instance_live.ex:663
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
@@ -821,12 +821,12 @@ msgstr ""
 msgid "Retry state"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:581
+#: lib/lemmings_os_web/live/instance_live.ex:643
 #, elixir-autogen, elixir-format
 msgid "Retrying (%{count}/%{max})"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:720
+#: lib/lemmings_os_web/live/instance_live.ex:782
 #: lib/lemmings_os_web/live/instance_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid "Retrying..."
@@ -837,30 +837,30 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:636
-#: lib/lemmings_os_web/live/instance_live.ex:614
+#: lib/lemmings_os_web/components/instance_components.ex:849
+#: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:635
-#: lib/lemmings_os_web/live/instance_live.ex:613
+#: lib/lemmings_os_web/components/instance_components.ex:848
+#: lib/lemmings_os_web/live/instance_live.ex:675
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:533
-#: lib/lemmings_os_web/live/instance_live.ex:535
+#: lib/lemmings_os_web/live/instance_live.ex:595
+#: lib/lemmings_os_web/live/instance_live.ex:597
 #, elixir-autogen, elixir-format
 msgid "Runtime status"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:485
+#: lib/lemmings_os_web/live/instance_live.html.heex:489
 #, elixir-autogen, elixir-format
 msgid "Send follow-up"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:482
+#: lib/lemmings_os_web/live/instance_live.html.heex:486
 #, elixir-autogen, elixir-format
 msgid "Sending..."
 msgstr ""
@@ -870,14 +870,14 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:611
-#: lib/lemmings_os_web/components/instance_components.ex:637
-#: lib/lemmings_os_web/live/instance_live.ex:573
-#: lib/lemmings_os_web/live/instance_live.ex:587
-#: lib/lemmings_os_web/live/instance_live.ex:589
-#: lib/lemmings_os_web/live/instance_live.ex:615
-#: lib/lemmings_os_web/live/instance_live.ex:717
-#: lib/lemmings_os_web/live/instance_live.ex:724
+#: lib/lemmings_os_web/components/instance_components.ex:824
+#: lib/lemmings_os_web/components/instance_components.ex:850
+#: lib/lemmings_os_web/live/instance_live.ex:635
+#: lib/lemmings_os_web/live/instance_live.ex:649
+#: lib/lemmings_os_web/live/instance_live.ex:651
+#: lib/lemmings_os_web/live/instance_live.ex:677
+#: lib/lemmings_os_web/live/instance_live.ex:779
+#: lib/lemmings_os_web/live/instance_live.ex:786
 #, elixir-autogen, elixir-format
 msgid "Starting..."
 msgstr ""
@@ -888,7 +888,7 @@ msgstr ""
 msgid "The requested runtime session could not be loaded for this world scope."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:727
+#: lib/lemmings_os_web/live/instance_live.ex:789
 #, elixir-autogen, elixir-format
 msgid "This request will reuse the current transcript context."
 msgstr ""
@@ -898,52 +898,53 @@ msgstr ""
 msgid "Total %{count} tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:702
-#: lib/lemmings_os_web/live/instance_live.ex:708
+#: lib/lemmings_os_web/live/instance_live.ex:764
+#: lib/lemmings_os_web/live/instance_live.ex:770
 #, elixir-autogen, elixir-format
 msgid "Unable to queue the follow-up request right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:705
+#: lib/lemmings_os_web/live/instance_live.ex:767
 #, elixir-autogen, elixir-format
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:990
+#: lib/lemmings_os_web/components/instance_components.ex:1115
+#: lib/lemmings_os_web/components/instance_components.ex:1228
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:480
+#: lib/lemmings_os_web/live/instance_live.ex:542
 #, elixir-autogen, elixir-format
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:955
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:614
-#: lib/lemmings_os_web/live/instance_live.ex:574
-#: lib/lemmings_os_web/live/instance_live.ex:592
-#: lib/lemmings_os_web/live/instance_live.ex:718
+#: lib/lemmings_os_web/components/instance_components.ex:827
+#: lib/lemmings_os_web/live/instance_live.ex:636
+#: lib/lemmings_os_web/live/instance_live.ex:654
+#: lib/lemmings_os_web/live/instance_live.ex:780
 #, elixir-autogen, elixir-format
 msgid "Waiting for capacity..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.html.heex:398
+#: lib/lemmings_os_web/live/instance_live.html.heex:402
 #, elixir-autogen, elixir-format
 msgid "Waiting for first response..."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:457
+#: lib/lemmings_os_web/live/instance_live.ex:519
 #, elixir-autogen, elixir-format
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/live/instance_live.ex:631
+#: lib/lemmings_os_web/components/instance_components.ex:881
+#: lib/lemmings_os_web/live/instance_live.ex:693
 #, elixir-autogen, elixir-format
 msgid "unknown"
 msgstr ""
@@ -953,7 +954,7 @@ msgstr ""
 msgid "Active work backlog"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:191
+#: lib/lemmings_os_web/live/instance_live.ex:194
 #, elixir-autogen, elixir-format
 msgid "Only failed instances can be retried."
 msgstr ""
@@ -968,7 +969,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:185
+#: lib/lemmings_os_web/live/instance_live.ex:188
 #, elixir-autogen, elixir-format
 msgid "Retry requested for this instance."
 msgstr ""
@@ -978,18 +979,18 @@ msgstr ""
 msgid "Retry the latest failed request."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:195
+#: lib/lemmings_os_web/live/instance_live.ex:198
 #, elixir-autogen, elixir-format
 msgid "There is no failed request to retry."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:178
-#: lib/lemmings_os_web/live/instance_live.ex:202
+#: lib/lemmings_os_web/live/instance_live.ex:181
+#: lib/lemmings_os_web/live/instance_live.ex:205
 #, elixir-autogen, elixir-format
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:996
+#: lib/lemmings_os_web/components/instance_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1004,38 +1005,38 @@ msgstr ""
 msgid "Total tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:681
+#: lib/lemmings_os_web/components/lemming_components.ex:701
 #, elixir-autogen, elixir-format
 msgid ".button_cancel"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:691
+#: lib/lemmings_os_web/components/lemming_components.ex:711
 #, elixir-autogen, elixir-format
 msgid ".button_confirm_spawn"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:606
-#: lib/lemmings_os_web/components/lemming_components.ex:617
+#: lib/lemmings_os_web/components/lemming_components.ex:626
+#: lib/lemmings_os_web/components/lemming_components.ex:637
 #, elixir-autogen, elixir-format
 msgid ".button_spawn"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:689
+#: lib/lemmings_os_web/components/lemming_components.ex:709
 #, elixir-autogen, elixir-format
 msgid ".button_spawning"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:644
+#: lib/lemmings_os_web/components/lemming_components.ex:664
 #, elixir-autogen, elixir-format
 msgid ".copy_spawn_instance"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:752
+#: lib/lemmings_os_web/components/lemming_components.ex:772
 #, elixir-autogen, elixir-format
 msgid ".count_shown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:705
+#: lib/lemmings_os_web/components/lemming_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".count_total"
 msgstr ""
@@ -1080,12 +1081,12 @@ msgstr ""
 msgid ".detail_registry_target"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:712
+#: lib/lemmings_os_web/components/lemming_components.ex:732
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:713
+#: lib/lemmings_os_web/components/lemming_components.ex:733
 #, elixir-autogen, elixir-format
 msgid ".empty_no_active_instances_copy"
 msgstr ""
@@ -1186,7 +1187,7 @@ msgstr ""
 msgid ".label_holders"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:670
+#: lib/lemmings_os_web/components/lemming_components.ex:690
 #, elixir-autogen, elixir-format
 msgid ".label_initial_request"
 msgstr ""
@@ -1268,8 +1269,8 @@ msgstr ""
 msgid ".label_started"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:729
-#: lib/lemmings_os_web/components/lemming_components.ex:768
+#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:788
 #, elixir-autogen, elixir-format
 msgid ".label_unknown"
 msgstr ""
@@ -1284,7 +1285,7 @@ msgstr ""
 msgid ".nav_runtime"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:671
+#: lib/lemmings_os_web/components/lemming_components.ex:691
 #, elixir-autogen, elixir-format
 msgid ".placeholder_spawn_request"
 msgstr ""
@@ -1384,7 +1385,7 @@ msgstr ""
 msgid ".runtime_service_label_scheduler_supervisor"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:593
+#: lib/lemmings_os_web/components/lemming_components.ex:613
 #, elixir-autogen, elixir-format
 msgid ".spawn_enabled_copy"
 msgstr ""
@@ -1419,7 +1420,7 @@ msgstr ""
 msgid ".subtitle_runtime_dashboard"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:702
+#: lib/lemmings_os_web/components/lemming_components.ex:722
 #, elixir-autogen, elixir-format
 msgid ".title_active_instances"
 msgstr ""
@@ -1445,7 +1446,7 @@ msgstr ""
 msgid ".title_executors"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:749
+#: lib/lemmings_os_web/components/lemming_components.ex:769
 #, elixir-autogen, elixir-format
 msgid ".title_recent_sessions"
 msgstr ""
@@ -1461,27 +1462,27 @@ msgstr ""
 msgid ".title_runtime_dashboard"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:641
+#: lib/lemmings_os_web/components/lemming_components.ex:661
 #, elixir-autogen, elixir-format
 msgid ".title_spawn_instance"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:899
+#: lib/lemmings_os_web/components/instance_components.ex:1137
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:893
+#: lib/lemmings_os_web/components/instance_components.ex:1131
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:902
+#: lib/lemmings_os_web/components/instance_components.ex:1140
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:295
+#: lib/lemmings_os_web/components/instance_components.ex:511
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1496,8 +1497,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:483
-#: lib/lemmings_os_web/components/instance_components.ex:789
+#: lib/lemmings_os_web/components/instance_components.ex:696
+#: lib/lemmings_os_web/components/instance_components.ex:1002
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1512,12 +1513,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:317
+#: lib/lemmings_os_web/components/instance_components.ex:531
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:289
+#: lib/lemmings_os_web/components/instance_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1563,12 +1564,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:306
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:788
+#: lib/lemmings_os_web/components/instance_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1588,37 +1589,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:232
+#: lib/lemmings_os_web/components/instance_components.ex:258
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:799
+#: lib/lemmings_os_web/components/instance_components.ex:1012
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:805
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:807
+#: lib/lemmings_os_web/components/instance_components.ex:1020
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:796
+#: lib/lemmings_os_web/components/instance_components.ex:1009
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:811
+#: lib/lemmings_os_web/components/instance_components.ex:1024
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:234
+#: lib/lemmings_os_web/components/instance_components.ex:260
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1633,22 +1634,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:525
+#: lib/lemmings_os_web/components/instance_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:879
+#: lib/lemmings_os_web/components/world_components.ex:908
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:550
+#: lib/lemmings_os_web/components/instance_components.ex:763
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:435
+#: lib/lemmings_os_web/components/instance_components.ex:648
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1663,7 +1664,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:942
+#: lib/lemmings_os_web/components/instance_components.ex:1180
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1673,20 +1674,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:514
+#: lib/lemmings_os_web/components/instance_components.ex:727
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:493
+#: lib/lemmings_os_web/components/instance_components.ex:706
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:357
-#: lib/lemmings_os_web/components/instance_components.ex:395
-#: lib/lemmings_os_web/components/instance_components.ex:440
-#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/instance_components.ex:570
+#: lib/lemmings_os_web/components/instance_components.ex:608
+#: lib/lemmings_os_web/components/instance_components.ex:653
+#: lib/lemmings_os_web/components/world_components.ex:903
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1696,18 +1697,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:859
+#: lib/lemmings_os_web/components/world_components.ex:888
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:465
+#: lib/lemmings_os_web/components/instance_components.ex:678
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:541
-#: lib/lemmings_os_web/components/world_components.ex:867
+#: lib/lemmings_os_web/components/instance_components.ex:754
+#: lib/lemmings_os_web/components/world_components.ex:896
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1717,18 +1718,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:857
-#: lib/lemmings_os_web/components/world_components.ex:1033
+#: lib/lemmings_os_web/components/world_components.ex:886
+#: lib/lemmings_os_web/components/world_components.ex:1062
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:480
+#: lib/lemmings_os_web/components/instance_components.ex:693
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:503
+#: lib/lemmings_os_web/components/instance_components.ex:716
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1743,17 +1744,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:953
+#: lib/lemmings_os_web/components/instance_components.ex:1191
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:948
+#: lib/lemmings_os_web/components/instance_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:443
+#: lib/lemmings_os_web/components/instance_components.ex:656
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1763,22 +1764,209 @@ msgstr ""
 msgid "Copy workspace path"
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:221
+#: lib/lemmings_os_web/live/instance_live.ex:224
 #, elixir-autogen, elixir-format
 msgid "Workspace could not be opened."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:209
+#: lib/lemmings_os_web/live/instance_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "Workspace is unavailable right now."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:217
+#: lib/lemmings_os_web/live/instance_live.ex:220
 #, elixir-autogen, elixir-format
 msgid "Workspace open requested."
 msgstr ""
 
-#: lib/lemmings_os_web/live/instance_live.ex:226
+#: lib/lemmings_os_web/live/instance_live.ex:229
 #, elixir-autogen, elixir-format
 msgid "Workspace path copied."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1108
+#, elixir-autogen, elixir-format
+msgid "%{count} bytes"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:344
+#, elixir-autogen, elixir-format
+msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1238
+#, elixir-autogen, elixir-format
+msgid "An Artifact with this filename already exists. Update it after changing the workspace file."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1284
+#, elixir-autogen, elixir-format
+msgid "Artifact checksum calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1278
+#, elixir-autogen, elixir-format
+msgid "Artifact file copy failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:257
+#, elixir-autogen, elixir-format
+msgid "Artifact promoted: %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:327
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1294
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed (%{reason})."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1290
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion failed validation."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1254
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion is missing the runtime instance."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1287
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion request is invalid."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1248
+#, elixir-autogen, elixir-format
+msgid "Artifact promotion scope is invalid for this session."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1281
+#, elixir-autogen, elixir-format
+msgid "Artifact size calculation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1275
+#, elixir-autogen, elixir-format
+msgid "Artifact storage is unavailable right now."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1245
+#, elixir-autogen, elixir-format
+msgid "Choose a valid promotion action for this Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:461
+#, elixir-autogen, elixir-format
+msgid "Created"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:477
+#, elixir-autogen, elixir-format
+msgid "Download"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:471
+#, elixir-autogen, elixir-format
+msgid "Download Artifact %{filename}"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:491
+#, elixir-autogen, elixir-format
+msgid "Notes"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1260
+#, elixir-autogen, elixir-format
+msgid "Only files inside this workspace can be promoted."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1272
+#, elixir-autogen, elixir-format
+msgid "Only regular files can be promoted as Artifacts."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:423
+#, elixir-autogen, elixir-format
+msgid "Promote as New Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:418
+#, elixir-autogen, elixir-format
+msgid "Promote as new Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:393
+#, elixir-autogen, elixir-format
+msgid "Promote to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:388
+#, elixir-autogen, elixir-format
+msgid "Promote workspace file to Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:359
+#, elixir-autogen, elixir-format
+msgid "Promoted"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:387
+#: lib/lemmings_os_web/components/instance_components.ex:417
+#, elixir-autogen, elixir-format
+msgid "Promoting..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1251
+#, elixir-autogen, elixir-format
+msgid "Runtime instance not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:337
+#, elixir-autogen, elixir-format
+msgid "Show Artifact help"
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1257
+#, elixir-autogen, elixir-format
+msgid "This filename cannot be promoted as an Artifact."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:238
+#, elixir-autogen, elixir-format
+msgid "Unable to promote this file right now."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1110
+#, elixir-autogen, elixir-format
+msgid "Unknown size"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:408
+#, elixir-autogen, elixir-format
+msgid "Update Artifact"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#, elixir-autogen, elixir-format
+msgid "Update existing Artifact from workspace file"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:402
+#, elixir-autogen, elixir-format
+msgid "Updating..."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1263
+#: lib/lemmings_os_web/live/instance_live.ex:1266
+#, elixir-autogen, elixir-format
+msgid "Workspace file not found for Artifact promotion."
+msgstr ""
+
+#: lib/lemmings_os_web/live/instance_live.ex:1269
+#, elixir-autogen, elixir-format
+msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""

--- a/priv/gettext/world.pot
+++ b/priv/gettext/world.pot
@@ -34,13 +34,13 @@ msgstr ""
 
 #: lib/lemmings_os/helpers.ex:100
 #: lib/lemmings_os/helpers.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:1287
-#: lib/lemmings_os_web/components/world_components.ex:1317
-#: lib/lemmings_os_web/components/world_components.ex:1334
-#: lib/lemmings_os_web/components/world_components.ex:1351
-#: lib/lemmings_os_web/components/world_components.ex:1355
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/live/instance_live.ex:407
+#: lib/lemmings_os_web/components/world_components.ex:1322
+#: lib/lemmings_os_web/components/world_components.ex:1352
+#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1386
+#: lib/lemmings_os_web/components/world_components.ex:1390
+#: lib/lemmings_os_web/components/world_components.ex:1411
+#: lib/lemmings_os_web/live/instance_live.ex:469
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".label_not_available"
@@ -71,40 +71,40 @@ msgstr ""
 msgid ".aria_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:769
+#: lib/lemmings_os_web/components/world_components.ex:788
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:254
-#: lib/lemmings_os_web/components/world_components.ex:539
+#: lib/lemmings_os_web/components/world_components.ex:266
+#: lib/lemmings_os_web/components/world_components.ex:557
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:718
+#: lib/lemmings_os_web/components/world_components.ex:736
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:102
-#: lib/lemmings_os_web/components/world_components.ex:536
+#: lib/lemmings_os_web/components/world_components.ex:105
+#: lib/lemmings_os_web/components/world_components.ex:554
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:436
+#: lib/lemmings_os_web/components/world_components.ex:448
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:449
+#: lib/lemmings_os_web/components/world_components.ex:461
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:126
+#: lib/lemmings_os_web/live/departments_live.html.heex:127
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr ""
@@ -114,178 +114,178 @@ msgstr ""
 msgid ".count_running_of_total"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:659
-#: lib/lemmings_os_web/live/departments_live.html.heex:54
-#: lib/lemmings_os_web/live/departments_live.html.heex:133
+#: lib/lemmings_os_web/components/world_components.ex:677
+#: lib/lemmings_os_web/live/departments_live.html.heex:55
+#: lib/lemmings_os_web/live/departments_live.html.heex:134
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:660
-#: lib/lemmings_os_web/live/departments_live.html.heex:55
-#: lib/lemmings_os_web/live/departments_live.html.heex:134
+#: lib/lemmings_os_web/components/world_components.ex:678
+#: lib/lemmings_os_web/live/departments_live.html.heex:56
+#: lib/lemmings_os_web/live/departments_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:544
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:545
+#: lib/lemmings_os_web/components/world_components.ex:563
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:338
+#: lib/lemmings_os_web/components/world_components.ex:350
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:333
+#: lib/lemmings_os_web/components/world_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:410
-#: lib/lemmings_os_web/components/world_components.ex:633
+#: lib/lemmings_os_web/components/world_components.ex:422
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1310
+#: lib/lemmings_os_web/components/world_components.ex:1345
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1306
+#: lib/lemmings_os_web/components/world_components.ex:1341
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1315
+#: lib/lemmings_os_web/components/world_components.ex:1350
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1299
+#: lib/lemmings_os_web/components/world_components.ex:1334
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:733
+#: lib/lemmings_os_web/components/world_components.ex:751
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:123
-#: lib/lemmings_os_web/components/world_components.ex:264
+#: lib/lemmings_os_web/components/world_components.ex:126
+#: lib/lemmings_os_web/components/world_components.ex:276
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:300
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:284
+#: lib/lemmings_os_web/components/world_components.ex:296
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:141
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:144
+#: lib/lemmings_os_web/components/world_components.ex:288
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1300
+#: lib/lemmings_os_web/components/world_components.ex:1335
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:405
-#: lib/lemmings_os_web/components/world_components.ex:617
+#: lib/lemmings_os_web/components/world_components.ex:417
+#: lib/lemmings_os_web/components/world_components.ex:635
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1289
+#: lib/lemmings_os_web/components/world_components.ex:1324
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:302
+#: lib/lemmings_os_web/components/world_components.ex:314
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:433
-#: lib/lemmings_os_web/components/world_components.ex:446
+#: lib/lemmings_os_web/components/world_components.ex:445
+#: lib/lemmings_os_web/components/world_components.ex:458
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:420
+#: lib/lemmings_os_web/components/world_components.ex:432
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:382
-#: lib/lemmings_os_web/components/world_components.ex:639
+#: lib/lemmings_os_web/components/world_components.ex:394
+#: lib/lemmings_os_web/components/world_components.ex:657
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1362
+#: lib/lemmings_os_web/components/world_components.ex:1397
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1286
+#: lib/lemmings_os_web/components/world_components.ex:1321
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1285
+#: lib/lemmings_os_web/components/world_components.ex:1320
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:357
+#: lib/lemmings_os_web/components/world_components.ex:369
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:732
+#: lib/lemmings_os_web/components/world_components.ex:750
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:415
-#: lib/lemmings_os_web/components/world_components.ex:625
+#: lib/lemmings_os_web/components/world_components.ex:427
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1371
-#: lib/lemmings_os_web/components/world_components.ex:1372
+#: lib/lemmings_os_web/components/world_components.ex:1406
+#: lib/lemmings_os_web/components/world_components.ex:1407
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1328
+#: lib/lemmings_os_web/components/world_components.ex:1363
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:845
-#: lib/lemmings_os_web/components/world_components.ex:1329
+#: lib/lemmings_os_web/components/world_components.ex:874
+#: lib/lemmings_os_web/components/world_components.ex:1364
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -325,22 +325,22 @@ msgstr ""
 msgid ".metric_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1337
+#: lib/lemmings_os_web/components/world_components.ex:1372
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1340
+#: lib/lemmings_os_web/components/world_components.ex:1375
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1343
+#: lib/lemmings_os_web/components/world_components.ex:1378
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1346
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr ""
@@ -371,23 +371,23 @@ msgstr ""
 msgid ".subtitle_all_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:207
+#: lib/lemmings_os_web/components/world_components.ex:210
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:198
+#: lib/lemmings_os_web/components/world_components.ex:201
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:189
+#: lib/lemmings_os_web/components/world_components.ex:192
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:216
+#: lib/lemmings_os_web/components/world_components.ex:219
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr ""
@@ -397,45 +397,45 @@ msgstr ""
 msgid ".title_all_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:327
+#: lib/lemmings_os_web/components/world_components.ex:158
+#: lib/lemmings_os_web/components/world_components.ex:339
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:653
-#: lib/lemmings_os_web/live/departments_live.html.heex:122
+#: lib/lemmings_os_web/components/world_components.ex:671
+#: lib/lemmings_os_web/live/departments_live.html.heex:123
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:246
+#: lib/lemmings_os_web/components/world_components.ex:129
+#: lib/lemmings_os_web/components/world_components.ex:258
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:169
-#: lib/lemmings_os_web/components/world_components.ex:457
+#: lib/lemmings_os_web/components/world_components.ex:172
+#: lib/lemmings_os_web/components/world_components.ex:469
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:429
+#: lib/lemmings_os_web/components/world_components.ex:441
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:111
-#: lib/lemmings_os_web/components/world_components.ex:349
-#: lib/lemmings_os_web/components/world_components.ex:528
-#: lib/lemmings_os_web/components/world_components.ex:840
+#: lib/lemmings_os_web/components/world_components.ex:114
+#: lib/lemmings_os_web/components/world_components.ex:361
+#: lib/lemmings_os_web/components/world_components.ex:546
+#: lib/lemmings_os_web/components/world_components.ex:869
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:297
+#: lib/lemmings_os_web/components/world_components.ex:309
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr ""
@@ -445,12 +445,12 @@ msgstr ""
 msgid ".title_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:94
+#: lib/lemmings_os_web/components/world_components.ex:97
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:442
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr ""
@@ -465,13 +465,13 @@ msgstr ""
 msgid ".tooltip_running"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:612
+#: lib/lemmings_os_web/components/world_components.ex:630
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:835
-#: lib/lemmings_os_web/live/departments_live.html.heex:49
+#: lib/lemmings_os_web/components/world_components.ex:864
+#: lib/lemmings_os_web/live/departments_live.html.heex:50
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr ""
@@ -497,40 +497,40 @@ msgstr ""
 msgid ".empty_no_cities_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:272
+#: lib/lemmings_os_web/live/cities_live.html.heex:281
 #, elixir-autogen
 msgid ".label_city_distribution_port"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:277
+#: lib/lemmings_os_web/live/cities_live.html.heex:286
 #, elixir-autogen
 msgid ".label_city_epmd_port"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:267
+#: lib/lemmings_os_web/live/cities_live.html.heex:276
 #, elixir-autogen
 msgid ".label_city_host"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:282
+#: lib/lemmings_os_web/live/cities_live.html.heex:291
 #: lib/lemmings_os_web/live/settings_live.html.heex:111
 #, elixir-autogen
 msgid ".label_city_last_seen_at"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:262
+#: lib/lemmings_os_web/live/cities_live.html.heex:271
 #: lib/lemmings_os_web/live/settings_live.html.heex:106
 #, elixir-autogen
 msgid ".label_city_node_name"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:257
+#: lib/lemmings_os_web/live/cities_live.html.heex:266
 #: lib/lemmings_os_web/live/settings_live.html.heex:101
 #, elixir-autogen
 msgid ".label_city_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:611
+#: lib/lemmings_os_web/components/world_components.ex:629
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr ""
@@ -600,7 +600,7 @@ msgstr ""
 msgid ".city_form_node_name_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:830
+#: lib/lemmings_os_web/components/world_components.ex:859
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -641,268 +641,268 @@ msgstr ""
 msgid ".city_form_submit_update"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:504
+#: lib/lemmings_os_web/live/cities_live.ex:508
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:529
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:144
+#: lib/lemmings_os_web/live/cities_live.ex:146
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:100
-#: lib/lemmings_os_web/live/cities_live.ex:153
+#: lib/lemmings_os_web/live/cities_live.ex:102
+#: lib/lemmings_os_web/live/cities_live.ex:155
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:514
-#: lib/lemmings_os_web/live/cities_live.ex:539
+#: lib/lemmings_os_web/live/cities_live.ex:518
+#: lib/lemmings_os_web/live/cities_live.ex:543
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:150
+#: lib/lemmings_os_web/live/cities_live.ex:152
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:717
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:666
+#: lib/lemmings_os_web/components/world_components.ex:684
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:654
+#: lib/lemmings_os_web/components/world_components.ex:672
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:98
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:96
-#: lib/lemmings_os_web/live/departments_live.html.heex:115
+#: lib/lemmings_os_web/live/departments_live.html.heex:97
+#: lib/lemmings_os_web/live/departments_live.html.heex:116
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:925
+#: lib/lemmings_os_web/components/world_components.ex:954
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:953
+#: lib/lemmings_os_web/components/world_components.ex:982
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:943
+#: lib/lemmings_os_web/components/world_components.ex:972
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:934
+#: lib/lemmings_os_web/components/world_components.ex:963
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1177
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:950
+#: lib/lemmings_os_web/components/world_components.ex:979
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:897
+#: lib/lemmings_os_web/components/world_components.ex:926
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:936
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:902
+#: lib/lemmings_os_web/components/world_components.ex:931
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:987
+#: lib/lemmings_os_web/components/world_components.ex:1016
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:988
+#: lib/lemmings_os_web/components/world_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:963
+#: lib/lemmings_os_web/components/world_components.ex:992
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:915
+#: lib/lemmings_os_web/components/world_components.ex:944
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:893
+#: lib/lemmings_os_web/components/world_components.ex:922
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1072
-#: lib/lemmings_os_web/components/world_components.ex:1105
-#: lib/lemmings_os_web/components/world_components.ex:1154
+#: lib/lemmings_os_web/components/world_components.ex:1101
+#: lib/lemmings_os_web/components/world_components.ex:1134
+#: lib/lemmings_os_web/components/world_components.ex:1183
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1077
-#: lib/lemmings_os_web/components/world_components.ex:1114
-#: lib/lemmings_os_web/components/world_components.ex:1169
+#: lib/lemmings_os_web/components/world_components.ex:1106
+#: lib/lemmings_os_web/components/world_components.ex:1143
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1158
+#: lib/lemmings_os_web/components/world_components.ex:1187
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1157
+#: lib/lemmings_os_web/components/world_components.ex:1186
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1067
-#: lib/lemmings_os_web/components/world_components.ex:1098
-#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1096
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1177
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1156
+#: lib/lemmings_os_web/components/world_components.ex:1185
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1062
-#: lib/lemmings_os_web/components/world_components.ex:1089
-#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1091
+#: lib/lemmings_os_web/components/world_components.ex:1118
+#: lib/lemmings_os_web/components/world_components.ex:1168
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1058
+#: lib/lemmings_os_web/components/world_components.ex:1087
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1057
+#: lib/lemmings_os_web/components/world_components.ex:1086
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1085
+#: lib/lemmings_os_web/components/world_components.ex:1114
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1084
+#: lib/lemmings_os_web/components/world_components.ex:1113
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1154
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1153
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:792
+#: lib/lemmings_os_web/components/world_components.ex:811
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:782
+#: lib/lemmings_os_web/components/world_components.ex:801
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:821
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:665
+#: lib/lemmings_os_web/live/departments_live.ex:670
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:116
+#: lib/lemmings_os_web/live/departments_live.ex:118
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:667
+#: lib/lemmings_os_web/live/departments_live.ex:672
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:666
+#: lib/lemmings_os_web/live/departments_live.ex:671
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:130
+#: lib/lemmings_os_web/live/departments_live.ex:132
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:100
+#: lib/lemmings_os_web/live/departments_live.ex:102
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:668
+#: lib/lemmings_os_web/live/departments_live.ex:673
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:972
+#: lib/lemmings_os_web/components/world_components.ex:1001
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:964
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -968,7 +968,7 @@ msgstr ""
 msgid ".secret_blocked_by_allowlist"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.html.heex:297
+#: lib/lemmings_os_web/live/cities_live.html.heex:306
 #, elixir-autogen, elixir-format
 msgid ".secret_city_subtitle"
 msgstr ""
@@ -988,15 +988,15 @@ msgstr ""
 msgid ".secret_delete_label"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:204
-#: lib/lemmings_os_web/live/departments_live.ex:189
-#: lib/lemmings_os_web/live/lemmings_live.ex:184
-#: lib/lemmings_os_web/live/world_live.ex:101
+#: lib/lemmings_os_web/live/cities_live.ex:206
+#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/lemmings_live.ex:187
+#: lib/lemmings_os_web/live/world_live.ex:103
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1223
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr ""
@@ -1081,7 +1081,7 @@ msgstr ""
 msgid ".secret_key_label"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:565
+#: lib/lemmings_os_web/components/lemming_components.ex:579
 #, elixir-autogen, elixir-format
 msgid ".secret_lemming_subtitle"
 msgstr ""
@@ -1106,10 +1106,10 @@ msgstr ""
 msgid ".secret_save_pending"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:164
-#: lib/lemmings_os_web/live/departments_live.ex:146
-#: lib/lemmings_os_web/live/lemmings_live.ex:144
-#: lib/lemmings_os_web/live/world_live.ex:63
+#: lib/lemmings_os_web/live/cities_live.ex:166
+#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/lemmings_live.ex:147
+#: lib/lemmings_os_web/live/world_live.ex:65
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr ""
@@ -1124,11 +1124,11 @@ msgstr ""
 msgid ".secret_value_label"
 msgstr ""
 
-#: lib/lemmings_os_web/components/lemming_components.ex:371
-#: lib/lemmings_os_web/components/lemming_components.ex:1051
+#: lib/lemmings_os_web/components/lemming_components.ex:377
+#: lib/lemmings_os_web/components/lemming_components.ex:1071
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:225
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:228
+#: lib/lemmings_os_web/components/world_components.ex:831
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/priv/repo/migrations/20260501120000_create_artifacts.exs
+++ b/priv/repo/migrations/20260501120000_create_artifacts.exs
@@ -1,0 +1,46 @@
+defmodule LemmingsOs.Repo.Migrations.CreateArtifacts do
+  use Ecto.Migration
+
+  def change do
+    create table(:artifacts, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+
+      add :world_id, references(:worlds, type: :binary_id, on_delete: :delete_all), null: false
+      add :city_id, references(:cities, type: :binary_id, on_delete: :delete_all)
+
+      add :department_id,
+          references(:departments, type: :binary_id, on_delete: :delete_all)
+
+      add :lemming_id, references(:lemmings, type: :binary_id, on_delete: :delete_all)
+
+      add :lemming_instance_id,
+          references(:lemming_instances, type: :binary_id, on_delete: :nilify_all)
+
+      add :created_by_tool_execution_id,
+          references(:lemming_instance_tool_executions, type: :binary_id, on_delete: :nilify_all)
+
+      add :type, :string, null: false
+      add :filename, :string, null: false
+      add :content_type, :string, null: false
+      add :storage_ref, :text, null: false
+      add :size_bytes, :bigint, null: false
+      add :checksum, :string, null: false
+      add :status, :string, null: false
+      add :notes, :text
+      add :metadata, :map, null: false, default: %{}
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:artifacts, [:world_id])
+    create index(:artifacts, [:world_id, :city_id, :department_id])
+    create index(:artifacts, [:lemming_instance_id])
+    create index(:artifacts, [:created_by_tool_execution_id])
+
+    create index(
+             :artifacts,
+             [:world_id, :city_id, :department_id, :lemming_id, :filename],
+             name: :artifacts_scope_filename_lookup_index
+           )
+  end
+end

--- a/test/lemmings_os/artifacts/artifact_test.exs
+++ b/test/lemmings_os/artifacts/artifact_test.exs
@@ -1,0 +1,215 @@
+defmodule LemmingsOs.Artifacts.ArtifactTest do
+  use LemmingsOs.DataCase, async: true
+
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Repo
+
+  doctest Artifact
+
+  describe "changeset/2" do
+    test "validates required fields" do
+      changeset = Artifact.changeset(%Artifact{}, %{})
+
+      refute changeset.valid?
+
+      errors = errors_on(changeset)
+
+      assert ".required" in errors.world_id
+      assert ".required" in errors.filename
+      assert ".required" in errors.type
+      assert ".required" in errors.content_type
+      assert ".required" in errors.storage_ref
+      assert ".required" in errors.size_bytes
+      assert ".required" in errors.checksum
+      assert ".required" in errors.status
+      refute Map.has_key?(errors, :metadata)
+    end
+
+    test "accepts allowed type and status values" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          city_id: Ecto.UUID.generate(),
+          department_id: Ecto.UUID.generate(),
+          lemming_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/city/department/lemming/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{"source" => "manual_promotion"}
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects unknown type values" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "docx",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{}
+        })
+
+      refute changeset.valid?
+      assert ".invalid_choice" in errors_on(changeset).type
+    end
+
+    test "rejects unknown status values" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "pending",
+          metadata: %{}
+        })
+
+      refute changeset.valid?
+      assert ".invalid_choice" in errors_on(changeset).status
+    end
+
+    test "defaults metadata to empty map when omitted" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready"
+        })
+
+      assert changeset.valid?
+      assert Ecto.Changeset.get_field(changeset, :metadata) == %{}
+    end
+
+    test "rejects metadata that is not a map" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: "bad"
+        })
+
+      refute changeset.valid?
+      assert "is invalid" in errors_on(changeset).metadata
+    end
+
+    test "rejects metadata keys outside source contract" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{"prompt" => "leak"}
+        })
+
+      refute changeset.valid?
+      assert ".invalid_value" in errors_on(changeset).metadata
+    end
+
+    test "rejects unsupported metadata source value" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{"source" => "tool_output"}
+        })
+
+      refute changeset.valid?
+      assert ".invalid_choice" in errors_on(changeset).metadata
+    end
+
+    test "rejects invalid scope shape when lemming_id is set without department_id" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          city_id: Ecto.UUID.generate(),
+          lemming_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/city/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{}
+        })
+
+      refute changeset.valid?
+      assert ".invalid_value" in errors_on(changeset).city_id
+    end
+
+    test "accepts world, city, department, and lemming scope shape" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          city_id: Ecto.UUID.generate(),
+          department_id: Ecto.UUID.generate(),
+          lemming_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/city/department/lemming/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{"source" => "manual_promotion"}
+        })
+
+      assert changeset.valid?
+    end
+  end
+
+  describe "database constraints" do
+    test "enforces associated world existence" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 10,
+          checksum: String.duplicate("a", 64),
+          status: "ready",
+          metadata: %{}
+        })
+
+      assert {:error, changeset} = Repo.insert(changeset)
+      assert "does not exist" in errors_on(changeset).world
+    end
+  end
+end

--- a/test/lemmings_os/artifacts/artifact_test.exs
+++ b/test/lemmings_os/artifacts/artifact_test.exs
@@ -1,6 +1,8 @@
 defmodule LemmingsOs.Artifacts.ArtifactTest do
   use LemmingsOs.DataCase, async: true
 
+  import LemmingsOs.Factory
+
   alias LemmingsOs.Artifacts.Artifact
   alias LemmingsOs.Repo
 
@@ -210,6 +212,44 @@ defmodule LemmingsOs.Artifacts.ArtifactTest do
 
       assert {:error, changeset} = Repo.insert(changeset)
       assert "does not exist" in errors_on(changeset).world
+    end
+
+    test "SCH-05: nilifies provenance references when instance is deleted" do
+      world = insert(:world)
+      city = insert(:city, world: world)
+      department = insert(:department, world: world, city: city)
+      lemming = insert(:lemming, world: world, city: city, department: department)
+
+      instance =
+        insert(:lemming_instance,
+          world: world,
+          city: city,
+          department: department,
+          lemming: lemming
+        )
+
+      tool_execution =
+        insert(:tool_execution,
+          world: world,
+          lemming_instance: instance
+        )
+
+      artifact =
+        insert(:artifact,
+          world: world,
+          city: city,
+          department: department,
+          lemming: lemming,
+          lemming_instance: instance,
+          created_by_tool_execution: tool_execution
+        )
+
+      Repo.delete!(instance)
+
+      persisted = Repo.get!(Artifact, artifact.id)
+      assert persisted.id == artifact.id
+      assert persisted.lemming_instance_id == nil
+      assert persisted.created_by_tool_execution_id == nil
     end
   end
 end

--- a/test/lemmings_os/artifacts/local_storage_test.exs
+++ b/test/lemmings_os/artifacts/local_storage_test.exs
@@ -50,6 +50,8 @@ defmodule LemmingsOs.Artifacts.LocalStorageTest do
             "nested/file.txt",
             "C:\\temp\\secret.txt",
             "nested\\file.txt",
+            "line\nbreak.txt",
+            "line\rbreak.txt",
             "bad\0name.txt"
           ] do
         assert {:error, :invalid_filename} =

--- a/test/lemmings_os/artifacts/local_storage_test.exs
+++ b/test/lemmings_os/artifacts/local_storage_test.exs
@@ -1,0 +1,136 @@
+defmodule LemmingsOs.Artifacts.LocalStorageTest do
+  use ExUnit.Case, async: false
+
+  alias LemmingsOs.Artifacts.LocalStorage
+
+  doctest LocalStorage
+
+  setup do
+    old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+    root_path =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_artifact_storage_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: root_path)
+
+    on_exit(fn ->
+      if old_artifact_storage do
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      else
+        Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+
+      File.rm_rf(root_path)
+    end)
+
+    {:ok, root_path: root_path}
+  end
+
+  describe "build_storage_ref/3" do
+    test "builds a local artifact storage ref" do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      assert {:ok, storage_ref} =
+               LocalStorage.build_storage_ref(world_id, artifact_id, "artifact.md")
+
+      assert storage_ref == "local://artifacts/#{world_id}/#{artifact_id}/artifact.md"
+    end
+
+    test "rejects unsafe filenames" do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      for filename <- [
+            "../secret.txt",
+            "/tmp/secret.txt",
+            "nested/file.txt",
+            "C:\\temp\\secret.txt",
+            "nested\\file.txt",
+            "bad\0name.txt"
+          ] do
+        assert {:error, :invalid_filename} =
+                 LocalStorage.build_storage_ref(world_id, artifact_id, filename)
+      end
+    end
+  end
+
+  describe "resolve_storage_ref/1" do
+    test "resolves a trusted ref inside configured root", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      assert :ok = File.mkdir_p(Path.join([root_path, world_id, artifact_id]))
+      storage_ref = "local://artifacts/#{world_id}/#{artifact_id}/artifact.md"
+
+      assert {:ok, absolute_path} = LocalStorage.resolve_storage_ref(storage_ref)
+      assert absolute_path == Path.join([root_path, world_id, artifact_id, "artifact.md"])
+    end
+
+    test "rejects malformed or unsafe refs" do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      for storage_ref <- [
+            "local://artifacts/#{world_id}/#{artifact_id}",
+            "local://artifacts/#{world_id}/#{artifact_id}/../secret.txt",
+            "local://artifacts/#{world_id}/#{artifact_id}/nested/file.txt",
+            "local://artifacts/#{world_id}/#{artifact_id}/C:\\temp\\file.txt",
+            "local://artifacts/#{world_id}/#{artifact_id}/bad\0name.txt",
+            "local://wrong/#{world_id}/#{artifact_id}/artifact.md",
+            "s3://artifacts/#{world_id}/#{artifact_id}/artifact.md"
+          ] do
+        assert {:error, :invalid_storage_ref} = LocalStorage.resolve_storage_ref(storage_ref)
+      end
+    end
+  end
+
+  describe "store_copy/4" do
+    test "copies file and returns storage ref, checksum, and size", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      source_path = Path.join(root_path, "workspace-source.md")
+      content = "# Summary\n\nhello\n"
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, content)
+
+      assert {:ok, stored} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
+
+      assert stored.storage_ref == "local://artifacts/#{world_id}/#{artifact_id}/artifact.md"
+      assert stored.size_bytes == byte_size(content)
+
+      expected_checksum =
+        :sha256
+        |> :crypto.hash(content)
+        |> Base.encode16(case: :lower)
+
+      assert stored.checksum == expected_checksum
+
+      copied_path = Path.join([root_path, world_id, artifact_id, "artifact.md"])
+      assert {:ok, copied_content} = File.read(copied_path)
+      assert copied_content == content
+    end
+
+    test "rejects symlink escape in managed path", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      source_path = Path.join(root_path, "workspace-source.md")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "safe")
+
+      outside_path = Path.join(root_path, "outside")
+      linked_world_path = Path.join(root_path, world_id)
+      :ok = File.mkdir_p(outside_path)
+      :ok = File.ln_s(outside_path, linked_world_path)
+
+      assert {:error, :invalid_storage_ref} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
+    end
+  end
+end

--- a/test/lemmings_os/artifacts/promotion_test.exs
+++ b/test/lemmings_os/artifacts/promotion_test.exs
@@ -1,0 +1,235 @@
+defmodule LemmingsOs.Artifacts.PromotionTest do
+  use LemmingsOs.DataCase, async: false
+
+  import LemmingsOs.Factory
+
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.LocalStorage
+  alias LemmingsOs.Artifacts.Promotion
+  alias LemmingsOs.Repo
+
+  doctest Promotion
+
+  setup do
+    old_workspace_root = Application.get_env(:lemmings_os, :runtime_workspace_root)
+    old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_artifacts_promotion_#{System.unique_integer([:positive])}"
+      )
+
+    workspace_root = Path.join(test_root, "workspace")
+    artifact_storage_root = Path.join(test_root, "artifact_storage")
+
+    Application.put_env(:lemmings_os, :runtime_workspace_root, workspace_root)
+
+    Application.put_env(:lemmings_os, :artifact_storage,
+      backend: :local,
+      root_path: artifact_storage_root
+    )
+
+    on_exit(fn ->
+      if old_workspace_root do
+        Application.put_env(:lemmings_os, :runtime_workspace_root, old_workspace_root)
+      else
+        Application.delete_env(:lemmings_os, :runtime_workspace_root)
+      end
+
+      if old_artifact_storage do
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      else
+        Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+
+      File.rm_rf(test_root)
+    end)
+
+    {:ok, workspace_root: workspace_root}
+  end
+
+  describe "promote_workspace_file/2" do
+    test "promotes workspace file into managed storage as ready artifact", %{
+      workspace_root: workspace_root
+    } do
+      instance = insert_scoped_instance()
+      relative_path = "reports/summary.md"
+      source_path = write_workspace_file(workspace_root, instance, relative_path, "# Summary\n")
+
+      assert {:ok, descriptor} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      assert descriptor.status == "ready"
+      assert descriptor.filename == "summary.md"
+      assert descriptor.type == "markdown"
+      refute Map.has_key?(descriptor, :storage_ref)
+      refute Map.has_key?(descriptor, :absolute_path)
+
+      assert File.exists?(source_path)
+
+      persisted = Repo.get!(Artifact, descriptor.id)
+      assert persisted.status == "ready"
+      assert persisted.lemming_instance_id == instance.id
+      assert persisted.storage_ref =~ "local://artifacts/"
+      refute persisted.storage_ref =~ workspace_root
+      refute persisted.storage_ref =~ source_path
+
+      assert {:ok, managed_path} = LocalStorage.resolve_storage_ref(persisted.storage_ref)
+      assert {:ok, managed_content} = File.read(managed_path)
+      assert managed_content == "# Summary\n"
+    end
+
+    test "returns error for missing workspace file" do
+      instance = insert_scoped_instance()
+
+      assert {:error, :source_not_found} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: "reports/missing.md", lemming_instance_id: instance.id}
+               )
+    end
+
+    test "returns error for unsafe workspace path traversal" do
+      instance = insert_scoped_instance()
+
+      assert {:error, :path_outside_workspace} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: "../secret.md", lemming_instance_id: instance.id}
+               )
+    end
+
+    test "requires explicit mode when same-scope filename already exists", %{
+      workspace_root: workspace_root
+    } do
+      instance = insert_scoped_instance()
+      relative_path = "reports/update.md"
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "v1")
+
+      assert {:ok, first} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      first_row = Repo.get!(Artifact, first.id)
+
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "v2")
+
+      assert {:error, :mode_required} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      reloaded = Repo.get!(Artifact, first.id)
+      assert reloaded.checksum == first_row.checksum
+      assert reloaded.size_bytes == first_row.size_bytes
+    end
+
+    test "mode update_existing overwrites managed file and keeps same row id", %{
+      workspace_root: workspace_root
+    } do
+      instance = insert_scoped_instance()
+      relative_path = "reports/plan.txt"
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "old")
+
+      assert {:ok, first} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "new content")
+
+      assert {:ok, updated} =
+               Promotion.promote_workspace_file(promotion_scope(instance), %{
+                 relative_path: relative_path,
+                 lemming_instance_id: instance.id,
+                 mode: :update_existing
+               })
+
+      assert updated.id == first.id
+      refute updated.checksum == first.checksum
+      refute updated.size_bytes == first.size_bytes
+
+      persisted = Repo.get!(Artifact, updated.id)
+      assert {:ok, managed_path} = LocalStorage.resolve_storage_ref(persisted.storage_ref)
+      assert {:ok, managed_content} = File.read(managed_path)
+      assert managed_content == "new content"
+    end
+
+    test "mode promote_as_new keeps existing row and creates new artifact", %{
+      workspace_root: workspace_root
+    } do
+      instance = insert_scoped_instance()
+      relative_path = "reports/new-copy.md"
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "alpha")
+
+      assert {:ok, first} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "beta")
+
+      assert {:ok, second} =
+               Promotion.promote_workspace_file(promotion_scope(instance), %{
+                 relative_path: relative_path,
+                 lemming_instance_id: instance.id,
+                 mode: :promote_as_new
+               })
+
+      refute second.id == first.id
+
+      scope = %{
+        world_id: instance.world_id,
+        city_id: instance.city_id,
+        department_id: instance.department_id,
+        lemming_id: instance.lemming_id
+      }
+
+      assert {:ok, listed} = Artifacts.list_artifacts_for_scope(scope)
+      ids = MapSet.new(Enum.map(listed, & &1.id))
+      assert ids == MapSet.new([first.id, second.id])
+    end
+  end
+
+  defp insert_scoped_instance do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+    lemming = insert(:lemming, world: world, city: city, department: department)
+
+    insert(:lemming_instance,
+      world: world,
+      city: city,
+      department: department,
+      lemming: lemming
+    )
+  end
+
+  defp write_workspace_file(workspace_root, instance, relative_path, content) do
+    base_path = Path.join([workspace_root, instance.department_id, instance.lemming_id])
+    absolute_path = Path.join(base_path, relative_path)
+    :ok = File.mkdir_p(Path.dirname(absolute_path))
+    :ok = File.write(absolute_path, content)
+    absolute_path
+  end
+
+  defp promotion_scope(instance) do
+    %{
+      world_id: instance.world_id,
+      city_id: nil,
+      department_id: nil,
+      lemming_id: nil,
+      lemming_instance_id: nil
+    }
+  end
+end

--- a/test/lemmings_os/artifacts_test.exs
+++ b/test/lemmings_os/artifacts_test.exs
@@ -1,0 +1,235 @@
+defmodule LemmingsOs.ArtifactsTest do
+  use LemmingsOs.DataCase, async: false
+
+  import LemmingsOs.Factory
+
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Repo
+
+  doctest Artifacts
+
+  describe "create_artifact/2" do
+    test "creates an artifact descriptor in explicit world scope" do
+      world = insert(:world)
+
+      attrs = %{
+        filename: "report.md",
+        type: "markdown",
+        content_type: "text/markdown",
+        storage_ref: "local://artifacts/#{world.id}/#{Ecto.UUID.generate()}/report.md",
+        size_bytes: 64,
+        checksum: String.duplicate("a", 64),
+        status: "ready",
+        metadata: %{"source" => "manual_promotion"}
+      }
+
+      assert {:ok, descriptor} = Artifacts.create_artifact(world, attrs)
+      refute Map.has_key?(descriptor, :storage_ref)
+      assert descriptor.world_id == world.id
+      assert descriptor.status == "ready"
+      assert descriptor.filename == "report.md"
+    end
+
+    test "rejects scope mismatches from attrs" do
+      world = insert(:world)
+      other_world = insert(:world)
+
+      attrs = %{
+        world_id: other_world.id,
+        filename: "report.md",
+        type: "markdown",
+        content_type: "text/markdown",
+        storage_ref: "local://artifacts/#{world.id}/#{Ecto.UUID.generate()}/report.md",
+        size_bytes: 64,
+        checksum: String.duplicate("a", 64),
+        status: "ready",
+        metadata: %{"source" => "manual_promotion"}
+      }
+
+      assert {:error, :scope_mismatch} = Artifacts.create_artifact(world, attrs)
+    end
+  end
+
+  describe "get_artifact/2 and get_artifact/3" do
+    test "enforces world scope and defaults to ready artifacts only" do
+      lemming = insert_scoped_lemming()
+      ready_artifact = insert_artifact_for_lemming(lemming, status: "ready")
+      archived_artifact = insert_artifact_for_lemming(lemming, status: "archived")
+
+      assert {:ok, found} = Artifacts.get_artifact(ready_artifact.world, ready_artifact.id)
+      assert found.id == ready_artifact.id
+
+      assert {:error, :not_found} =
+               Artifacts.get_artifact(ready_artifact.world, archived_artifact.id)
+
+      assert {:ok, archived} =
+               Artifacts.get_artifact(
+                 ready_artifact.world,
+                 archived_artifact.id,
+                 include_non_ready: true
+               )
+
+      assert archived.id == archived_artifact.id
+
+      other_world = insert(:world)
+      assert {:error, :not_found} = Artifacts.get_artifact(other_world, ready_artifact.id)
+    end
+  end
+
+  describe "list_artifacts_for_scope/2" do
+    test "returns only ready by default and supports explicit status filters" do
+      lemming = insert_scoped_lemming()
+      ready_artifact = insert_artifact_for_lemming(lemming, status: "ready")
+      archived_artifact = insert_artifact_for_lemming(lemming, status: "archived")
+      _deleted_artifact = insert_artifact_for_lemming(lemming, status: "deleted")
+
+      assert {:ok, listed} = Artifacts.list_artifacts_for_scope(lemming)
+      assert Enum.map(listed, & &1.id) == [ready_artifact.id]
+
+      assert {:ok, listed_with_archived} =
+               Artifacts.list_artifacts_for_scope(lemming, statuses: ["ready", "archived"])
+
+      assert MapSet.new(Enum.map(listed_with_archived, & &1.id)) ==
+               MapSet.new([archived_artifact.id, ready_artifact.id])
+    end
+
+    test "returns invalid_scope for malformed map scope" do
+      assert {:error, :invalid_scope} =
+               Artifacts.list_artifacts_for_scope(%{city_id: Ecto.UUID.generate()})
+    end
+  end
+
+  describe "list_artifacts_for_instance/2 and /3" do
+    test "returns scoped instance artifacts and defaults to ready only" do
+      lemming = insert_scoped_lemming()
+      instance = insert_scoped_instance(lemming)
+
+      ready_artifact =
+        insert_artifact_for_instance(instance, status: "ready")
+
+      archived_artifact =
+        insert_artifact_for_instance(instance, status: "archived")
+
+      other_instance = insert_scoped_instance(lemming)
+
+      _other_instance_artifact = insert_artifact_for_instance(other_instance, status: "ready")
+
+      assert {:ok, listed} = Artifacts.list_artifacts_for_instance(instance.lemming, instance.id)
+      assert Enum.map(listed, & &1.id) == [ready_artifact.id]
+
+      assert {:ok, listed_with_archived} =
+               Artifacts.list_artifacts_for_instance(
+                 instance.lemming,
+                 instance.id,
+                 include_non_ready: true
+               )
+
+      assert MapSet.new(Enum.map(listed_with_archived, & &1.id)) ==
+               MapSet.new([archived_artifact.id, ready_artifact.id])
+    end
+  end
+
+  describe "update_artifact_status/3" do
+    test "updates status in scope and supports non-ready fetch with explicit option" do
+      artifact = insert_artifact_for_lemming(insert_scoped_lemming(), status: "ready")
+
+      assert {:ok, updated} =
+               Artifacts.update_artifact_status(artifact.world, artifact.id, "archived")
+
+      assert updated.status == "archived"
+      assert {:error, :not_found} = Artifacts.get_artifact(artifact.world, artifact.id)
+
+      assert {:ok, fetched} =
+               Artifacts.get_artifact(artifact.world, artifact.id, include_non_ready: true)
+
+      assert fetched.status == "archived"
+    end
+
+    test "returns not_found outside of scope" do
+      artifact = insert_artifact_for_lemming(insert_scoped_lemming(), status: "ready")
+      other_world = insert(:world)
+
+      assert {:error, :not_found} =
+               Artifacts.update_artifact_status(other_world, artifact.id, "archived")
+    end
+
+    test "rejects invalid status values" do
+      artifact = insert_artifact_for_lemming(insert_scoped_lemming(), status: "ready")
+
+      assert {:error, :invalid_status} =
+               Artifacts.update_artifact_status(artifact.world, artifact.id, "pending")
+    end
+  end
+
+  describe "artifact_descriptor/1" do
+    test "omits storage_ref from read model" do
+      artifact = insert_artifact_for_lemming(insert_scoped_lemming())
+      descriptor = Artifacts.artifact_descriptor(artifact)
+
+      refute Map.has_key?(descriptor, :storage_ref)
+      assert descriptor.id == artifact.id
+      assert descriptor.filename == artifact.filename
+    end
+  end
+
+  describe "database behavior through context" do
+    test "create_artifact/2 persists row and keeps storage_ref internal-only" do
+      world = insert(:world)
+      artifact_id = Ecto.UUID.generate()
+
+      attrs = %{
+        filename: "internal.md",
+        type: "markdown",
+        content_type: "text/markdown",
+        storage_ref: "local://artifacts/#{world.id}/#{artifact_id}/internal.md",
+        size_bytes: 11,
+        checksum: String.duplicate("b", 64),
+        status: "ready",
+        metadata: %{"source" => "manual_promotion"}
+      }
+
+      assert {:ok, descriptor} = Artifacts.create_artifact(world, attrs)
+      assert %Artifact{} = persisted = Repo.get(Artifact, descriptor.id)
+      assert persisted.storage_ref == attrs.storage_ref
+      refute Map.has_key?(descriptor, :storage_ref)
+    end
+  end
+
+  defp insert_scoped_lemming do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+    insert(:lemming, world: world, city: city, department: department)
+  end
+
+  defp insert_scoped_instance(lemming) do
+    insert(:lemming_instance,
+      lemming: lemming,
+      world: lemming.world,
+      city: lemming.city,
+      department: lemming.department
+    )
+  end
+
+  defp insert_artifact_for_lemming(lemming, attrs \\ []) do
+    insert(
+      :artifact,
+      [world: lemming.world, city: lemming.city, department: lemming.department, lemming: lemming] ++
+        attrs
+    )
+  end
+
+  defp insert_artifact_for_instance(instance, attrs) do
+    insert(
+      :artifact,
+      [
+        world: instance.world,
+        city: instance.city,
+        department: instance.department,
+        lemming: instance.lemming,
+        lemming_instance: instance
+      ] ++ attrs
+    )
+  end
+end

--- a/test/lemmings_os/lemming_calls_runtime_test.exs
+++ b/test/lemmings_os/lemming_calls_runtime_test.exs
@@ -255,6 +255,30 @@ defmodule LemmingsOs.LemmingCallsRuntimeTest do
              "Do not call fs.read_text_file for these paths unless runtime later provides them inside your own workspace."
   end
 
+  test "S02d: request_call does not inject artifact content when path is not referenced", %{
+    manager_instance: manager_instance
+  } do
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(manager_instance, "private.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "TOP_SECRET_ARTIFACT_CONTENT")
+
+    assert {:ok, _call} =
+             LemmingCalls.request_call(
+               manager_instance,
+               %{target: "ops-worker", request: "Draft incident notes for today"},
+               runtime_mod: CapturingRuntime,
+               runtime_opts: [test_pid: self()]
+             )
+
+    assert_receive {:spawned_child_request, child_request, _opts}
+    assert child_request == "Draft incident notes for today"
+    refute child_request =~ "Delegation Artifact Context:"
+    refute child_request =~ "private.md"
+    refute child_request =~ "TOP_SECRET_ARTIFACT_CONTENT"
+  end
+
   test "S02c: request_call passes runtime opts to spawned child", %{
     manager_instance: manager_instance
   } do

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -3,9 +3,39 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
 
   import LemmingsOs.Factory
 
+  alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.LocalStorage
   alias LemmingsOs.LemmingInstances
+  alias LemmingsOs.Repo
 
   setup do
+    old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+    test_root =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_instance_artifact_controller_#{System.unique_integer([:positive])}"
+      )
+
+    artifact_storage_root = Path.join(test_root, "artifact_storage")
+    File.rm_rf!(test_root)
+    File.mkdir_p!(artifact_storage_root)
+
+    Application.put_env(:lemmings_os, :artifact_storage,
+      backend: :local,
+      root_path: artifact_storage_root
+    )
+
+    on_exit(fn ->
+      File.rm_rf!(test_root)
+
+      if old_artifact_storage do
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      else
+        Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+    end)
+
     world = insert(:world)
     city = insert(:city, world: world, status: "active")
     department = insert(:department, world: world, city: city)
@@ -13,113 +43,206 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
 
     {:ok, instance} = LemmingInstances.spawn_instance(lemming, "Write artifact")
 
-    %{world: world, instance: instance}
+    %{world: world, instance: instance, test_root: test_root}
   end
 
-  test "DL01: serves workspace artifact bytes with safe headers", %{
-    conn: conn,
-    world: world,
-    instance: instance
-  } do
-    _absolute_path =
-      write_workspace_file(instance, "reports/summary.md", "# Summary artifact\nconfidential\n")
+  describe "download/2 durable artifact route" do
+    test "DL01: serves durable artifact bytes with safe headers", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact, content: content} =
+        insert_managed_artifact(instance, test_root, %{
+          filename: "reports/summary.md",
+          content_type: "text/markdown",
+          type: "markdown",
+          content: "# Summary artifact\nconfidential\n"
+        })
 
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "summary.md"]}?#{%{world: world.id}}"
-      )
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
 
-    assert response.status == 200
-    assert response.resp_body == "# Summary artifact\nconfidential\n"
-    assert get_resp_header(response, "content-type") == ["application/octet-stream"]
+      assert response.status == 200
+      assert response.resp_body == content
+      assert get_resp_header(response, "content-type") == ["text/markdown"]
+      assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
 
-    assert get_resp_header(response, "content-disposition") == [
-             ~s(attachment; filename="summary.md")
-           ]
+      assert get_resp_header(response, "content-disposition") == [
+               ~s(attachment; filename="summary.md")
+             ]
+    end
 
-    assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
+    test "DL02: rejects wrong scope before storage resolution", %{
+      conn: conn,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} =
+        insert_managed_artifact(instance, test_root, %{storage_ref: "local://bad/ref"})
+
+      other_world = insert(:world)
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: other_world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
+
+    test "DL03: blocks archived/deleted/error artifacts by default", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      for status <- ~w(archived deleted error) do
+        %{artifact: artifact} =
+          insert_managed_artifact(instance, test_root, %{status: status, filename: "#{status}.md"})
+
+        response =
+          conn
+          |> get(
+            ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+          )
+
+        assert response.status == 404
+        assert response.resp_body == "Artifact not found"
+      end
+    end
+
+    test "DL04: missing physical file returns safe not found without path leakage", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} = insert_managed_artifact(instance, test_root)
+      {:ok, stored_path} = LocalStorage.resolve_storage_ref(artifact.storage_ref)
+      File.rm!(stored_path)
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+      refute response.resp_body =~ stored_path
+      refute response.resp_body =~ artifact.storage_ref
+      refute response.resp_body =~ "artifact_storage"
+    end
+
+    test "DL05: invalid storage ref returns safe not found", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} =
+        insert_managed_artifact(instance, test_root, %{storage_ref: "s3://bucket/artifact.md"})
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
   end
 
-  test "DL02: rejects wrong scope before path resolution", %{conn: conn, instance: instance} do
-    other_world = insert(:world)
+  describe "show/2 workspace route compatibility" do
+    test "DL06: existing workspace catch-all route still serves workspace file", %{
+      conn: conn,
+      world: world,
+      instance: instance
+    } do
+      _absolute_path =
+        write_workspace_file(instance, "reports/runtime.md", "# Runtime workspace artifact\n")
 
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["..", "secret.md"]}?#{%{world: other_world.id}}"
-      )
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "runtime.md"]}?#{%{world: world.id}}"
+        )
 
-    assert response.status == 404
-    assert response.resp_body == "Instance not found"
+      assert response.status == 200
+      assert response.resp_body == "# Runtime workspace artifact\n"
+      assert get_resp_header(response, "content-type") == ["application/octet-stream"]
+      assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
+    end
   end
 
-  test "DL03: rejects traversal path in artifact route", %{
-    conn: conn,
-    world: world,
-    instance: instance
-  } do
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["..", "secret.md"]}?#{%{world: world.id}}"
-      )
+  defp insert_managed_artifact(instance, test_root, attrs \\ %{}) do
+    filename = Map.get(attrs, :filename, "report.md")
+    content = Map.get(attrs, :content, "# Artifact content\n")
+    status = Map.get(attrs, :status, "ready")
+    type = Map.get(attrs, :type, "markdown")
+    content_type = Map.get(attrs, :content_type, "text/markdown")
 
-    assert response.status == 404
-    assert response.resp_body == "Artifact not found"
-  end
+    source_path =
+      Path.join([
+        test_root,
+        "sources",
+        "#{System.unique_integer([:positive])}-#{Path.basename(filename)}"
+      ])
 
-  test "DL04: missing file returns safe not found without path leakage", %{
-    conn: conn,
-    world: world,
-    instance: instance
-  } do
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "missing.md"]}?#{%{world: world.id}}"
-      )
+    File.mkdir_p!(Path.dirname(source_path))
+    File.write!(source_path, content)
 
-    assert response.status == 404
-    assert response.resp_body == "Artifact not found"
-    refute response.resp_body =~ "reports/missing.md"
-    refute response.resp_body =~ "workspace"
-  end
+    artifact_id = Ecto.UUID.generate()
 
-  test "DL05: rejects symlink targets outside workspace", %{
-    conn: conn,
-    world: world,
-    instance: instance
-  } do
-    {:ok, %{absolute_path: safe_path}} =
-      LemmingInstances.artifact_absolute_path(instance, "safe.md")
+    stored =
+      case Map.get(attrs, :storage_ref) do
+        storage_ref when is_binary(storage_ref) ->
+          %{
+            storage_ref: storage_ref,
+            checksum: String.duplicate("f", 64),
+            size_bytes: byte_size(content)
+          }
 
-    work_area = Path.dirname(safe_path)
-    outside_path = Path.join(Path.dirname(work_area), "outside-artifact.md")
-    File.mkdir_p!(work_area)
-    File.mkdir_p!(Path.dirname(outside_path))
-    File.write!(outside_path, "# Secret artifact\n")
-    assert :ok = File.ln_s(outside_path, Path.join(work_area, "artifact-link.md"))
+        nil ->
+          {:ok, stored} =
+            LocalStorage.store_copy(
+              instance.world_id,
+              artifact_id,
+              source_path,
+              Path.basename(filename)
+            )
 
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["artifact-link.md"]}?#{%{world: world.id}}"
-      )
+          stored
+      end
 
-    assert response.status == 404
-    assert response.resp_body == "Artifact not found"
-  end
+    artifact =
+      %Artifact{id: artifact_id}
+      |> Artifact.changeset(%{
+        world_id: instance.world_id,
+        city_id: instance.city_id,
+        department_id: instance.department_id,
+        lemming_id: instance.lemming_id,
+        lemming_instance_id: instance.id,
+        filename: Path.basename(filename),
+        type: type,
+        content_type: content_type,
+        storage_ref: stored.storage_ref,
+        size_bytes: stored.size_bytes,
+        checksum: stored.checksum,
+        status: status,
+        metadata: %{"source" => "manual_promotion"}
+      })
+      |> Repo.insert!()
 
-  test "DL06: unknown world returns world not found", %{conn: conn, instance: instance} do
-    response =
-      conn
-      |> get(
-        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["summary.md"]}?#{%{world: Ecto.UUID.generate()}}"
-      )
-
-    assert response.status == 404
-    assert response.resp_body == "World not found"
+    %{artifact: artifact, content: content}
   end
 
   defp write_workspace_file(instance, relative_path, content) do

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -77,6 +77,33 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
              ]
     end
 
+    test "DL01b: strips control characters from content-disposition filename", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} =
+        insert_managed_artifact(instance, test_root, %{filename: "header.md"})
+
+      artifact =
+        artifact
+        |> Artifact.changeset(%{filename: "safe\r\nname.md"})
+        |> Repo.update!()
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
+
+      [disposition] = get_resp_header(response, "content-disposition")
+      assert response.status == 200
+      assert disposition == ~s(attachment; filename="safename.md")
+      refute String.contains?(disposition, "\r")
+      refute String.contains?(disposition, "\n")
+    end
+
     test "DL02: rejects wrong scope before storage resolution", %{
       conn: conn,
       instance: instance,

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -1,0 +1,133 @@
+defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
+  use LemmingsOsWeb.ConnCase, async: false
+
+  import LemmingsOs.Factory
+
+  alias LemmingsOs.LemmingInstances
+
+  setup do
+    world = insert(:world)
+    city = insert(:city, world: world, status: "active")
+    department = insert(:department, world: world, city: city)
+    lemming = insert(:lemming, world: world, city: city, department: department, status: "active")
+
+    {:ok, instance} = LemmingInstances.spawn_instance(lemming, "Write artifact")
+
+    %{world: world, instance: instance}
+  end
+
+  test "DL01: serves workspace artifact bytes with safe headers", %{
+    conn: conn,
+    world: world,
+    instance: instance
+  } do
+    _absolute_path =
+      write_workspace_file(instance, "reports/summary.md", "# Summary artifact\nconfidential\n")
+
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "summary.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 200
+    assert response.resp_body == "# Summary artifact\nconfidential\n"
+    assert get_resp_header(response, "content-type") == ["application/octet-stream"]
+
+    assert get_resp_header(response, "content-disposition") == [
+             ~s(attachment; filename="summary.md")
+           ]
+
+    assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
+  end
+
+  test "DL02: rejects wrong scope before path resolution", %{conn: conn, instance: instance} do
+    other_world = insert(:world)
+
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["..", "secret.md"]}?#{%{world: other_world.id}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "Instance not found"
+  end
+
+  test "DL03: rejects traversal path in artifact route", %{
+    conn: conn,
+    world: world,
+    instance: instance
+  } do
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["..", "secret.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "Artifact not found"
+  end
+
+  test "DL04: missing file returns safe not found without path leakage", %{
+    conn: conn,
+    world: world,
+    instance: instance
+  } do
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "missing.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "Artifact not found"
+    refute response.resp_body =~ "reports/missing.md"
+    refute response.resp_body =~ "workspace"
+  end
+
+  test "DL05: rejects symlink targets outside workspace", %{
+    conn: conn,
+    world: world,
+    instance: instance
+  } do
+    {:ok, %{absolute_path: safe_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "safe.md")
+
+    work_area = Path.dirname(safe_path)
+    outside_path = Path.join(Path.dirname(work_area), "outside-artifact.md")
+    File.mkdir_p!(work_area)
+    File.mkdir_p!(Path.dirname(outside_path))
+    File.write!(outside_path, "# Secret artifact\n")
+    assert :ok = File.ln_s(outside_path, Path.join(work_area, "artifact-link.md"))
+
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["artifact-link.md"]}?#{%{world: world.id}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "Artifact not found"
+  end
+
+  test "DL06: unknown world returns world not found", %{conn: conn, instance: instance} do
+    response =
+      conn
+      |> get(
+        ~p"/lemmings/instances/#{instance.id}/artifacts/#{["summary.md"]}?#{%{world: Ecto.UUID.generate()}}"
+      )
+
+    assert response.status == 404
+    assert response.resp_body == "World not found"
+  end
+
+  defp write_workspace_file(instance, relative_path, content) do
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, relative_path)
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, content)
+    absolute_path
+  end
+end

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -97,6 +97,38 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
       assert response.resp_body == "Artifact not found"
     end
 
+    test "DL02b: rejects artifact ids that belong to a different instance", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} = insert_managed_artifact(instance, test_root)
+
+      other_city = insert(:city, world: world, status: "active")
+      other_department = insert(:department, world: world, city: other_city)
+
+      other_lemming =
+        insert(:lemming,
+          world: world,
+          city: other_city,
+          department: other_department,
+          status: "active"
+        )
+
+      {:ok, other_instance} =
+        LemmingInstances.spawn_instance(other_lemming, "Other instance request")
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{other_instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
+
     test "DL03: blocks archived/deleted/error artifacts by default", %{
       conn: conn,
       world: world,
@@ -134,11 +166,18 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
           ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
         )
 
+      headers_blob =
+        response.resp_headers
+        |> Enum.map_join("\n", fn {key, value} -> "#{key}: #{value}" end)
+
       assert response.status == 404
       assert response.resp_body == "Artifact not found"
       refute response.resp_body =~ stored_path
       refute response.resp_body =~ artifact.storage_ref
       refute response.resp_body =~ "artifact_storage"
+      refute headers_blob =~ stored_path
+      refute headers_blob =~ artifact.storage_ref
+      refute headers_blob =~ "artifact_storage"
     end
 
     test "DL05: invalid storage ref returns safe not found", %{

--- a/test/lemmings_os_web/live/cities_live_test.exs
+++ b/test/lemmings_os_web/live/cities_live_test.exs
@@ -322,4 +322,64 @@ defmodule LemmingsOsWeb.CitiesLiveTest do
       refute Connections.get_connection(city, created.id)
     end
   end
+
+  describe "artifacts tab" do
+    test "S13: city detail lists artifacts filtered by city", %{conn: conn} do
+      world = insert(:world)
+
+      city_a =
+        insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")
+
+      city_b = insert(:city, world: world, name: "Beta City", slug: "beta-city", status: "active")
+
+      department_a =
+        insert(:department, world: world, city: city_a, name: "Support", slug: "support")
+
+      city_artifact =
+        insert(:artifact,
+          world: world,
+          city: city_a,
+          department: nil,
+          lemming: nil,
+          lemming_instance: nil,
+          filename: "city-a.md"
+        )
+
+      other_city_artifact =
+        insert(:artifact,
+          world: world,
+          city: city_b,
+          department: nil,
+          lemming: nil,
+          lemming_instance: nil,
+          filename: "city-b.md"
+        )
+
+      department_artifact =
+        insert(:artifact,
+          world: world,
+          city: city_a,
+          department: department_a,
+          lemming: nil,
+          lemming_instance: nil,
+          filename: "department-a.md"
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/cities?city=#{city_a.id}")
+
+      view |> element("#city-tab-artifacts") |> render_click()
+
+      assert has_element?(view, "#city-artifacts-panel")
+      assert has_element?(view, "#city-artifacts-row-#{city_artifact.id}")
+      refute has_element?(view, "#city-artifacts-row-#{other_city_artifact.id}")
+      assert has_element?(view, "#city-artifacts-row-#{department_artifact.id}")
+      assert has_element?(view, "#city-artifacts-context-city-#{city_artifact.id}", "alpha-city")
+
+      assert has_element?(
+               view,
+               "#city-artifacts-context-department-#{department_artifact.id}",
+               "support"
+             )
+    end
+  end
 end

--- a/test/lemmings_os_web/live/departments_live_test.exs
+++ b/test/lemmings_os_web/live/departments_live_test.exs
@@ -543,6 +543,77 @@ defmodule LemmingsOsWeb.DepartmentsLiveTest do
 
       refute Connections.get_connection(department, created.id)
     end
+
+    test "S16: artifacts tab lists artifacts filtered by department", %{conn: conn} do
+      world = insert(:world)
+      city = insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")
+      department = insert(:department, world: world, city: city, name: "Support", slug: "support")
+
+      lemming =
+        insert(:lemming, world: world, city: city, department: department, status: "active")
+
+      department_artifact =
+        insert(:artifact,
+          world: world,
+          city: city,
+          department: department,
+          lemming: nil,
+          lemming_instance: nil,
+          filename: "department.md"
+        )
+
+      city_artifact =
+        insert(:artifact,
+          world: world,
+          city: city,
+          department: nil,
+          lemming: nil,
+          lemming_instance: nil,
+          filename: "city.md"
+        )
+
+      lemming_artifact =
+        insert(:artifact,
+          world: world,
+          city: city,
+          department: department,
+          lemming: lemming,
+          lemming_instance: nil,
+          filename: "lemming.md"
+        )
+
+      {:ok, view, _html} = live(conn, ~p"/departments?#{%{city: city.id, dept: department.id}}")
+
+      view |> element("#department-tab-artifacts") |> render_click()
+
+      assert_patch(
+        view,
+        ~p"/departments?#{%{city: city.id, dept: department.id, tab: "artifacts"}}"
+      )
+
+      assert has_element?(view, "#department-artifacts-panel")
+      assert has_element?(view, "#department-artifacts-row-#{department_artifact.id}")
+      refute has_element?(view, "#department-artifacts-row-#{city_artifact.id}")
+      assert has_element?(view, "#department-artifacts-row-#{lemming_artifact.id}")
+
+      assert has_element?(
+               view,
+               "#department-artifacts-context-city-#{department_artifact.id}",
+               city.slug
+             )
+
+      assert has_element?(
+               view,
+               "#department-artifacts-context-department-#{department_artifact.id}",
+               department.slug
+             )
+
+      assert has_element?(
+               view,
+               "#department-artifacts-context-lemming-#{lemming_artifact.id}",
+               lemming.slug
+             )
+    end
   end
 
   describe "import lemmings" do

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -3,6 +3,7 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
 
   import LemmingsOs.Factory
   import Phoenix.LiveViewTest
+  import ExUnit.CaptureLog
 
   @moduletag capture_log: true
 
@@ -801,6 +802,15 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
       live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
 
     assert has_element?(view, "#artifact-promotion-form-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-promotion-help-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-promotion-help-summary-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-promotion-help-text-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-promotion-source-#{tool_execution.id}")
+
+    assert has_element?(
+             view,
+             "#artifact-promotion-form-#{tool_execution.id}[aria-describedby~=\"artifact-promotion-source-#{tool_execution.id}\"]"
+           )
 
     assert has_element?(
              view,
@@ -821,6 +831,11 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
              view,
              "#artifact-promotion-status-#{tool_execution.id}",
              "Artifact promoted: promo.md"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-promotion-status-#{tool_execution.id}[role='status'][aria-live='polite'][aria-atomic='true'][tabindex='-1']"
            )
 
     assert eventually_has_element?(view, "#artifact-reference-#{tool_execution.id}")
@@ -856,6 +871,12 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
            )
 
     assert eventually_has_element?(view, "#artifact-reference-download-#{tool_execution.id}")
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-download-#{tool_execution.id}[aria-label='Download Artifact promo.md']"
+           )
+
     assert eventually_lacks_element?(view, "#artifact-promote-button-#{tool_execution.id}")
     assert eventually_lacks_element?(view, "#artifact-update-button-#{tool_execution.id}")
     refute has_element?(view, "#artifact-reference-#{tool_execution.id}", "local://")
@@ -923,7 +944,49 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
     assert has_element?(view, "#artifact-reference-#{tool_execution.id}")
     assert has_element?(view, "#artifact-reference-summary-#{tool_execution.id}", "existing.md")
     assert has_element?(view, "#artifact-reference-notes-toggle-#{tool_execution.id}")
+
+    assert has_element?(
+             view,
+             "#artifact-reference-notes-summary-#{tool_execution.id}[aria-controls='artifact-reference-notes-#{tool_execution.id}']"
+           )
+
     assert has_element?(view, "#artifact-reference-notes-#{tool_execution.id}", "Operator note")
+  end
+
+  test "S08m2: promotion failure logging omits raw relative paths and only records a reason token",
+       %{
+         conn: conn
+       } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "reports/safe.md"},
+        summary: "Wrote file reports/safe.md",
+        result: %{"path" => "reports/safe.md", "bytes" => 10}
+      })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    log =
+      capture_log(fn ->
+        view
+        |> element("#artifact-promotion-form-#{tool_execution.id}")
+        |> render_submit(%{
+          "artifact_promotion" => %{
+            "tool_execution_id" => tool_execution.id,
+            "relative_path" => "../outside.md"
+          }
+        })
+      end)
+
+    assert log =~ "artifact promotion failed"
+    assert log =~ "reason_token=path_outside_workspace"
+    refute log =~ "../outside.md"
+    refute log =~ "relative_path="
   end
 
   test "S08n: promote as new action creates a second Artifact row for the same filename", %{

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -912,11 +912,181 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
 
     assert has_element?(view, "#artifact-promotion-form-#{tool_execution.id}")
     assert has_element?(view, "#artifact-update-button-#{tool_execution.id}", "Update Artifact")
+
+    assert has_element?(
+             view,
+             "#artifact-promote-as-new-button-#{tool_execution.id}",
+             "Promote as New Artifact"
+           )
+
     refute has_element?(view, "#artifact-promote-button-#{tool_execution.id}")
     assert has_element?(view, "#artifact-reference-#{tool_execution.id}")
     assert has_element?(view, "#artifact-reference-summary-#{tool_execution.id}", "existing.md")
     assert has_element?(view, "#artifact-reference-notes-toggle-#{tool_execution.id}")
     assert has_element?(view, "#artifact-reference-notes-#{tool_execution.id}", "Operator note")
+  end
+
+  test "S08n: promote as new action creates a second Artifact row for the same filename", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "reports/collision.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "# Collision v1\n")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "reports/collision.md", "content" => "# Collision v1\n"},
+        summary: "Wrote file reports/collision.md",
+        result: %{"path" => "reports/collision.md", "bytes" => 15}
+      })
+
+    assert {:ok, first_artifact} =
+             Artifacts.promote_workspace_file(
+               %{
+                 world_id: world.id,
+                 city_id: instance.city_id,
+                 department_id: instance.department_id,
+                 lemming_id: instance.lemming_id,
+                 lemming_instance_id: instance.id
+               },
+               %{
+                 relative_path: "reports/collision.md",
+                 lemming_instance_id: instance.id,
+                 created_by_tool_execution_id: tool_execution.id
+               }
+             )
+
+    File.write!(absolute_path, "# Collision v2\n")
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#artifact-update-button-#{tool_execution.id}", "Update Artifact")
+
+    assert has_element?(
+             view,
+             "#artifact-promote-as-new-button-#{tool_execution.id}",
+             "Promote as New Artifact"
+           )
+
+    view
+    |> element("#artifact-promotion-form-#{tool_execution.id}")
+    |> render_submit(%{
+      "artifact_promotion" => %{
+        "tool_execution_id" => tool_execution.id,
+        "relative_path" => "reports/collision.md",
+        "mode" => "promote_as_new"
+      }
+    })
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-promotion-status-#{tool_execution.id}",
+             "Artifact promoted: collision.md"
+           )
+
+    assert {:ok, descriptors} =
+             Artifacts.list_artifacts_for_instance(
+               %{
+                 world_id: world.id,
+                 city_id: instance.city_id,
+                 department_id: instance.department_id,
+                 lemming_id: instance.lemming_id,
+                 lemming_instance_id: instance.id
+               },
+               instance.id,
+               include_non_ready: true
+             )
+
+    collision_artifacts = Enum.filter(descriptors, &(&1.filename == "collision.md"))
+    ids = MapSet.new(Enum.map(collision_artifacts, & &1.id))
+    assert MapSet.member?(ids, first_artifact.id)
+    assert MapSet.size(ids) == 2
+  end
+
+  test "S08o: Artifact reference rendering omits storage refs, paths, metadata, and note text in summary",
+       %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    workspace_path_sentinel = "/tmp/workspaces/w1/i1/private/secret.txt"
+    notes_sentinel = "NOTE_LEAK_SENTINEL_DO_NOT_LOG"
+
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "reports/safe-ref.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "# Safe ref\nvisible summary only\n")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{
+          "path" => "reports/safe-ref.md",
+          "content" => "TOP_SECRET_ARTIFACT_CONTENT",
+          "workspace_path" => workspace_path_sentinel
+        },
+        summary: "Wrote file reports/safe-ref.md",
+        result: %{"path" => "reports/safe-ref.md", "bytes" => 30}
+      })
+
+    assert {:ok, _artifact} =
+             Artifacts.promote_workspace_file(
+               %{
+                 world_id: world.id,
+                 city_id: instance.city_id,
+                 department_id: instance.department_id,
+                 lemming_id: instance.lemming_id,
+                 lemming_instance_id: instance.id
+               },
+               %{
+                 relative_path: "reports/safe-ref.md",
+                 lemming_instance_id: instance.id,
+                 created_by_tool_execution_id: tool_execution.id,
+                 notes: notes_sentinel,
+                 metadata: %{"source" => "manual_promotion"}
+               }
+             )
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#artifact-reference-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-reference-summary-#{tool_execution.id}", "safe-ref.md")
+    assert has_element?(view, "#artifact-reference-notes-toggle-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-reference-notes-#{tool_execution.id}", notes_sentinel)
+
+    refute has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "TOP_SECRET_ARTIFACT_CONTENT"
+           )
+
+    refute has_element?(view, "#artifact-reference-summary-#{tool_execution.id}", "local://")
+
+    refute has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             workspace_path_sentinel
+           )
+
+    refute has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "manual_promotion"
+           )
+
+    refute has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             notes_sentinel
+           )
   end
 
   test "S08g: artifact download rejects symlink targets outside workspace", %{conn: conn} do

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -8,6 +8,8 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
 
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Departments.Department
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Artifacts.Artifact
   alias LemmingsOs.LemmingCalls
   alias LemmingsOs.LemmingCalls.LemmingCall
   alias LemmingsOs.Lemmings.Lemming
@@ -82,6 +84,7 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
   end
 
   setup do
+    Repo.delete_all(Artifact)
     Repo.delete_all(ToolExecution)
     Repo.delete_all(Message)
     Repo.delete_all(LemmingInstance)
@@ -773,6 +776,147 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
       |> render_click()
 
     assert html =~ "Workspace path copied."
+  end
+
+  test "S08l: tool execution promotion renders a safe Artifact reference", %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "reports/promo.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "# Operator report\nsensitive-content-sentinel")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "reports/promo.md", "content" => "sensitive-content-sentinel"},
+        summary: "Wrote file reports/promo.md",
+        preview: "reports/promo.md",
+        result: %{"path" => "reports/promo.md", "bytes" => 41}
+      })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#artifact-promotion-form-#{tool_execution.id}")
+
+    assert has_element?(
+             view,
+             "#artifact-promote-button-#{tool_execution.id}",
+             "Promote to Artifact"
+           )
+
+    view
+    |> element("#artifact-promotion-form-#{tool_execution.id}")
+    |> render_submit(%{
+      "artifact_promotion" => %{
+        "tool_execution_id" => tool_execution.id,
+        "relative_path" => "reports/promo.md"
+      }
+    })
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-promotion-status-#{tool_execution.id}",
+             "Artifact promoted: promo.md"
+           )
+
+    assert eventually_has_element?(view, "#artifact-reference-#{tool_execution.id}")
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "promo.md"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "(ready)"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "markdown"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "bytes"
+           )
+
+    assert eventually_has_element?(
+             view,
+             "#artifact-reference-summary-#{tool_execution.id}",
+             "Created"
+           )
+
+    assert eventually_has_element?(view, "#artifact-reference-download-#{tool_execution.id}")
+    assert eventually_lacks_element?(view, "#artifact-promote-button-#{tool_execution.id}")
+    assert eventually_lacks_element?(view, "#artifact-update-button-#{tool_execution.id}")
+    refute has_element?(view, "#artifact-reference-#{tool_execution.id}", "local://")
+    refute has_element?(view, "#artifact-reference-#{tool_execution.id}", absolute_path)
+
+    refute has_element?(
+             view,
+             "#artifact-reference-#{tool_execution.id}",
+             "sensitive-content-sentinel"
+           )
+  end
+
+  test "S08m: existing same-filename Artifact shows update action only when file changed", %{
+    conn: conn
+  } do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, %{absolute_path: absolute_path}} =
+      LemmingInstances.artifact_absolute_path(instance, "reports/existing.md")
+
+    File.mkdir_p!(Path.dirname(absolute_path))
+    File.write!(absolute_path, "# Existing artifact content\n")
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "fs.write_text_file",
+        status: "ok",
+        args: %{"path" => "reports/existing.md", "content" => "# Existing artifact content\n"},
+        summary: "Wrote file reports/existing.md",
+        result: %{"path" => "reports/existing.md", "bytes" => 28}
+      })
+
+    assert {:ok, _artifact} =
+             Artifacts.promote_workspace_file(
+               %{
+                 world_id: world.id,
+                 city_id: instance.city_id,
+                 department_id: instance.department_id,
+                 lemming_id: instance.lemming_id,
+                 lemming_instance_id: instance.id
+               },
+               %{
+                 relative_path: "reports/existing.md",
+                 lemming_instance_id: instance.id,
+                 created_by_tool_execution_id: tool_execution.id,
+                 notes: "Operator note for rollout"
+               }
+             )
+
+    File.write!(absolute_path, "# Existing artifact content updated\n")
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#artifact-promotion-form-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-update-button-#{tool_execution.id}", "Update Artifact")
+    refute has_element?(view, "#artifact-promote-button-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-reference-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-reference-summary-#{tool_execution.id}", "existing.md")
+    assert has_element?(view, "#artifact-reference-notes-toggle-#{tool_execution.id}")
+    assert has_element?(view, "#artifact-reference-notes-#{tool_execution.id}", "Operator note")
   end
 
   test "S08g: artifact download rejects symlink targets outside workspace", %{conn: conn} do

--- a/test/lemmings_os_web/live/lemmings_live_test.exs
+++ b/test/lemmings_os_web/live/lemmings_live_test.exs
@@ -195,6 +195,78 @@ defmodule LemmingsOsWeb.LemmingsLiveTest do
     assert has_element?(view, "#lemming-edit-runtime")
   end
 
+  test "artifacts tab lists artifacts filtered by lemming", %{conn: conn} do
+    world = insert(:world)
+    city = insert(:city, world: world, status: "active")
+    department = insert(:department, world: world, city: city, status: "active")
+    lemming = insert(:lemming, world: world, city: city, department: department, status: "active")
+
+    instance =
+      insert(:lemming_instance,
+        world: world,
+        city: city,
+        department: department,
+        lemming: lemming
+      )
+
+    lemming_artifact =
+      insert(:artifact,
+        world: world,
+        city: city,
+        department: department,
+        lemming: lemming,
+        lemming_instance: nil,
+        filename: "lemming.md"
+      )
+
+    department_artifact =
+      insert(:artifact,
+        world: world,
+        city: city,
+        department: department,
+        lemming: nil,
+        lemming_instance: nil,
+        filename: "department.md"
+      )
+
+    instance_artifact =
+      insert(:artifact,
+        world: world,
+        city: city,
+        department: department,
+        lemming: lemming,
+        lemming_instance: instance,
+        filename: "instance.md"
+      )
+
+    {:ok, view, _html} =
+      live(
+        conn,
+        ~p"/lemmings/#{lemming.id}?#{%{city: city.id, dept: department.id, tab: "artifacts"}}"
+      )
+
+    assert has_element?(view, "#lemming-artifacts-panel")
+    assert has_element?(view, "#lemming-tab-artifacts[aria-current='page']")
+    assert has_element?(view, "#lemming-artifacts-row-#{lemming_artifact.id}")
+    refute has_element?(view, "#lemming-artifacts-row-#{department_artifact.id}")
+    assert has_element?(view, "#lemming-artifacts-row-#{instance_artifact.id}")
+    assert has_element?(view, "#lemming-artifacts-download-#{instance_artifact.id}")
+    refute has_element?(view, "#lemming-artifacts-download-#{lemming_artifact.id}")
+    assert has_element?(view, "#lemming-artifacts-context-city-#{lemming_artifact.id}", city.slug)
+
+    assert has_element?(
+             view,
+             "#lemming-artifacts-context-department-#{lemming_artifact.id}",
+             department.slug
+           )
+
+    assert has_element?(
+             view,
+             "#lemming-artifacts-context-lemming-#{lemming_artifact.id}",
+             lemming.slug
+           )
+  end
+
   test "settings save persists mutable fields and local overrides", %{conn: conn} do
     world = insert(:world)
     city = insert(:city, world: world, status: "active")

--- a/test/lemmings_os_web/live/world_live_test.exs
+++ b/test/lemmings_os_web/live/world_live_test.exs
@@ -370,6 +370,52 @@ defmodule LemmingsOsWeb.WorldLiveTest do
     refute Connections.get_connection(world, created.id)
   end
 
+  test "artifacts tab lists artifacts filtered by world", %{conn: conn} do
+    path =
+      WorldBootstrapTestHelpers.write_temp_file!(WorldBootstrapTestHelpers.valid_bootstrap_yaml())
+
+    world =
+      insert(:world,
+        slug: "local",
+        name: "Local World",
+        bootstrap_path: path,
+        bootstrap_source: "direct",
+        last_import_status: "ok"
+      )
+
+    city = insert(:city, world: world, status: "active", slug: "ops-city")
+
+    world_artifact =
+      insert(:artifact,
+        world: world,
+        city: nil,
+        department: nil,
+        lemming: nil,
+        lemming_instance: nil,
+        filename: "world-level.md"
+      )
+
+    city_artifact =
+      insert(:artifact,
+        world: world,
+        city: city,
+        department: nil,
+        lemming: nil,
+        lemming_instance: nil,
+        filename: "city-level.md"
+      )
+
+    {:ok, view, _html} = live(conn, ~p"/world")
+
+    view |> element("#world-tab-artifacts") |> render_click()
+
+    assert has_element?(view, "#world-artifacts-panel")
+    assert has_element?(view, "#world-artifacts-row-#{world_artifact.id}")
+    assert has_element?(view, "#world-artifacts-context-world-#{world_artifact.id}", "world")
+    assert has_element?(view, "#world-artifacts-row-#{city_artifact.id}")
+    assert has_element?(view, "#world-artifacts-context-city-#{city_artifact.id}", "ops-city")
+  end
+
   defp put_secret_bank_config(config) do
     previous = Application.get_env(:lemmings_os, LemmingsOs.SecretBank, [])
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -3,6 +3,7 @@ defmodule LemmingsOs.Factory do
 
   use ExMachina.Ecto, repo: LemmingsOs.Repo
 
+  alias LemmingsOs.Artifacts.Artifact
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Config.CostsConfig
   alias LemmingsOs.Config.CostsConfig.Budgets
@@ -248,5 +249,28 @@ defmodule LemmingsOs.Factory do
       city: department.city,
       department: department
     )
+  end
+
+  def artifact_factory do
+    lemming = build(:lemming)
+
+    %Artifact{
+      world: lemming.world,
+      city: lemming.city,
+      department: lemming.department,
+      lemming: lemming,
+      lemming_instance: nil,
+      created_by_tool_execution: nil,
+      type: "markdown",
+      filename: "artifact-#{sequence(:artifact_unique, & &1)}.md",
+      content_type: "text/markdown",
+      storage_ref:
+        "local://artifacts/#{Ecto.UUID.generate()}/#{Ecto.UUID.generate()}/artifact.md",
+      size_bytes: 128,
+      checksum: String.duplicate("a", 64),
+      status: "ready",
+      notes: nil,
+      metadata: %{"source" => "manual_promotion"}
+    }
   end
 end


### PR DESCRIPTION
## Summary

Adds the initial Artifact domain model for promoted runtime outputs.

This PR introduces durable Artifact metadata, managed local file storage, manual promotion from workspace files, controlled download/open behavior, and minimal instance timeline integration.

Artifacts are intentionally separate from scratch workspace files:

- workspace files remain temporary execution files
- Artifacts are manually promoted, durable, scoped runtime outputs
- file bytes are stored in managed local storage, not in Postgres
- future workflows can reference Artifacts by ID instead of raw filesystem paths

## Scope

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [x] Docs
- [ ] Chore

## Linked Issues

Closes #27
Related #

## Technical Notes

- Key implementation details:
  - Adds `artifacts` schema/context for scoped Artifact metadata.
  - Adds local Artifact storage with opaque `storage_ref`.
  - Adds manual workspace-file promotion flow.
  - Adds explicit update/promote-as-new behavior for same-scope filename matches.
  - Adds controlled Artifact download route using `artifact_id`.
  - Adds minimal instance timeline UI for promotion and Artifact references.
  - Keeps Artifact contents out of LLM context by default.
  - Keeps Artifact observability lightweight; durable platform audit is left for a future design.

- Data model / migration impact:
  - Adds `artifacts` table.
  - Stores scope/provenance fields, type, filename, content type, storage ref, size, checksum, status, notes, and metadata.
  - File bytes are not stored in the database.
  - Provenance references are nullable so Artifacts can outlive creator instances/tool executions.

- Config/env var changes:
  - Adds configurable local Artifact storage root.
  - Uses env-backed configuration for managed Artifact storage path.

- Security/privacy considerations:
  - Artifact code does not access Secret Bank.
  - No secret scanning is implemented in this PR.
  - Promotion treats source files as opaque bytes.
  - Logs/UI/context avoid raw file contents, raw workspace paths, resolved filesystem paths, storage refs, notes, and full metadata dumps.
  - Download resolves storage paths only after scope/status checks.

## Validation

- [ ] `mix format`
- [ ] `mix test`
- [ ] `mix precommit`
- [ ] Manual validation completed

### Manual validation notes

Suggested manual checks:

1. Run a Lemming instance that creates a workspace file.
2. Confirm the file appears in the instance timeline.
3. Promote the workspace file to an Artifact.
4. Confirm the Artifact appears in the timeline with safe descriptor fields only.
5. Open/download the Artifact through the Artifact route.
6. Modify/regenerate the same workspace filename.
7. Confirm update/promote-as-new behavior is explicit.
8. Confirm archived/deleted/error Artifacts are not normally selectable/downloadable.
9. Confirm no raw paths or file contents appear in rendered UI or logs.

## Screenshots / Recordings (if UI changes)

<img width="1901" height="936" alt="image" src="https://github.com/user-attachments/assets/51cecbfd-3acc-47bb-b512-911d6a6ca77b" />

 
<img width="2051" height="678" alt="image" src="https://github.com/user-attachments/assets/cb795346-8cf1-4a43-ac02-7b882573ad92" />


## Rollout / Rollback

- Rollout notes:
  - Run the new database migration.
  - Ensure the configured Artifact storage directory exists and is writable by the app.
  - For container deployments, mount the Artifact storage path to persistent storage if Artifacts must survive container replacement.

- Rollback notes:
  - Rollback requires reverting the migration and removing the managed Artifact storage files if they are no longer needed.
  - Files already copied into Artifact storage are not automatically deleted by DB rollback.
  - Existing scratch workspace file behavior is preserved separately from durable Artifacts.

## Checklist

- [x] Tests added/updated for changed behavior
- [x] Docs updated (README/docs/ADR/runbook) when needed
- [x] No secrets or sensitive data committed
- [x] Backward compatibility considered