### PR TITLE
Implement local Artifact storage backend

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -7,6 +7,6 @@ export PORT="${PORT:-${MIX_PORT}}"
 export OLLAMA_BASE_URL=http://localhost:11434
 
 export LEMMINGS_WORK_AREAS_PATH="~/.lemmings/workspace"
-export LEMMINGS_ARTIFACT_STORAGE_PATH="~/.lemmings/storage"
+export LEMMINGS_ARTIFACT_STORAGE_ROOT="~/.lemmings/storage"
 
 [ -f .envrc.custom ] && source .envrc.custom

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,7 +17,8 @@ config :lemmings_os, :runtime_city_heartbeat,
 
 config :lemmings_os, :artifact_storage,
   backend: :local,
-  root_path: Path.expand("../priv/runtime/storage", __DIR__)
+  root_path: Path.expand("../priv/runtime/storage", __DIR__),
+  max_file_size_bytes: 100 * 1024 * 1024
 
 config :lemmings_os, :runtime_dets, directory: Path.expand("../priv/runtime/dets", __DIR__)
 config :lemmings_os, :runtime_engine_on_startup, true
@@ -120,6 +121,10 @@ config :logger, :default_formatter,
     :skipped_count,
     :table,
     :path,
+    :artifact_id,
+    :filename,
+    :size_bytes,
+    :checksum,
     :bootstrap_path,
     :issue_count,
     :world_id,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -19,14 +19,21 @@ work_areas_path =
 artifact_storage = Application.get_env(:lemmings_os, :artifact_storage, [])
 
 artifact_storage_root_path =
-  System.get_env("LEMMINGS_ARTIFACT_STORAGE_PATH") ||
+  System.get_env("LEMMINGS_ARTIFACT_STORAGE_ROOT") ||
     Keyword.get(artifact_storage, :root_path, Path.expand("../priv/runtime/storage", __DIR__))
+
+artifact_storage_max_file_size_bytes =
+  Keyword.get(artifact_storage, :max_file_size_bytes, 100 * 1024 * 1024)
 
 runtime_city_node_name = System.get_env("LEMMINGS_CITY_NODE_NAME") || Atom.to_string(node())
 runtime_city_heartbeat = Application.get_env(:lemmings_os, :runtime_city_heartbeat, [])
 
 config :lemmings_os, :work_areas_path, work_areas_path
-config :lemmings_os, :artifact_storage, backend: :local, root_path: artifact_storage_root_path
+
+config :lemmings_os, :artifact_storage,
+  backend: :local,
+  root_path: artifact_storage_root_path,
+  max_file_size_bytes: artifact_storage_max_file_size_bytes
 
 config :lemmings_os, :runtime_city,
   node_name: runtime_city_node_name,

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,7 +33,8 @@ config :lemmings_os, :work_areas_path, Path.expand("../tmp/runtime/work_areas", 
 
 config :lemmings_os, :artifact_storage,
   backend: :local,
-  root_path: Path.expand("../tmp/runtime/storage", __DIR__)
+  root_path: Path.expand("../tmp/runtime/storage", __DIR__),
+  max_file_size_bytes: 100 * 1024 * 1024
 
 config :lemmings_os, :model_runtime,
   provider_module: LemmingsOs.ModelRuntime.Providers.Ollama,

--- a/docs/features/artifacts.md
+++ b/docs/features/artifacts.md
@@ -55,12 +55,39 @@ Artifact bytes are stored in managed local filesystem storage.
 
 - Config key: `:lemmings_os, :artifact_storage`
 - Backend: `:local` only
-- Runtime env override: `LEMMINGS_ARTIFACT_STORAGE_PATH`
+- Runtime env override: `LEMMINGS_ARTIFACT_STORAGE_ROOT`
 - Default root path: `priv/runtime/storage`
+- Default max file size: `100 * 1024 * 1024` bytes
 - Physical layout: `<artifact_storage_root>/<world_id>/<artifact_id>/<filename>`
 - Durable reference format: `local://artifacts/<world_id>/<artifact_id>/<filename>`
 
 Promotion copies the source workspace file into managed storage (source file is not moved).
+The local backend writes through a temporary file in the target directory and
+renames into place after the copy succeeds. Directory and file permissions are
+best-effort private filesystem permissions where the host supports them.
+
+Artifact metadata lives in Postgres. Artifact bytes do not. A row with
+`storage_ref`, `checksum`, and `size_bytes` is only the database side of the
+durable Artifact; the corresponding file under the configured storage root must
+also be retained.
+
+## Self-host and backup requirements
+
+Container and self-host deployments must mount the artifact storage root on
+persistent storage. If the configured root is inside an ephemeral container
+filesystem, promoted Artifact bytes are lost on container replacement or host
+restart even though their database rows remain.
+
+Backups must include both:
+- the Postgres database
+- the artifact storage root or volume
+
+A DB-only backup is insufficient because it restores Artifact metadata without
+the file bytes. A filesystem-only backup is also insufficient because it lacks
+scope, lifecycle, checksum, content type, and provenance metadata.
+
+Soft-deleted Artifacts are lifecycle rows only. Setting status to `deleted` does
+not physically purge the managed file in this implementation.
 
 ## Collision and update behavior
 
@@ -98,11 +125,13 @@ Two routes exist:
 
 1. Durable Artifact download route:
 - `GET /lemmings/instances/:instance_id/artifacts/:artifact_id/download`
-- world + instance + artifact scope is validated before storage ref resolution
+- world + instance + artifact scope is validated before storage open
 - only `ready` Artifacts are downloadable by default
 - response includes safe headers:
   - `x-content-type-options: nosniff`
   - `content-disposition: attachment; filename="..."`
+- missing or broken managed storage returns a safe `404` and marks the ready
+  Artifact as `error` with safe storage-error metadata
 
 2. Workspace compatibility route (legacy path-based open/download):
 - `GET /lemmings/instances/:instance_id/artifacts/*path`
@@ -130,7 +159,8 @@ In this implementation slice:
 
 - Artifact lifecycle operations do not write durable audit/event rows to `events`
 - Artifact code does not rely on `LemmingsOs.Events` for lifecycle audit semantics
-- observability is limited to lightweight non-durable logging/telemetry
+- observability is limited to lightweight non-durable Logger metadata and
+  `:telemetry` events under `[:lemmings_os, :artifact_storage, ...]`
 
 ## Out of scope
 
@@ -140,6 +170,11 @@ Not implemented:
 - Artifact version graph/workflows
 - durable Artifact read/download audit taxonomy
 - Artifact content ingestion/RAG workflows
+- physical cleanup/retention of soft-deleted files
+- encryption at rest beyond host filesystem permissions
+- content scanning or malware scanning
+- previews/thumbnails
+- cross-City shared Artifact storage
 
 ## Future work
 

--- a/lib/lemmings_os/artifacts.ex
+++ b/lib/lemmings_os/artifacts.ex
@@ -10,6 +10,7 @@ defmodule LemmingsOs.Artifacts do
   import Ecto.Query, warn: false
 
   alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.LocalStorage
   alias LemmingsOs.Artifacts.Promotion
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Departments.Department
@@ -19,6 +20,7 @@ defmodule LemmingsOs.Artifacts do
   alias LemmingsOs.Worlds.World
 
   @ready_status "ready"
+  @error_status "error"
   @artifact_statuses Artifact.statuses()
   @status_fields ~w(status statuses include_non_ready)a
   @scope_fields ~w(world_id city_id department_id lemming_id lemming_instance_id)a
@@ -78,6 +80,13 @@ defmodule LemmingsOs.Artifacts do
           filename: String.t(),
           content_type: String.t(),
           storage_ref: String.t()
+        }
+
+  @type opened_download :: %{
+          path: String.t(),
+          filename: String.t(),
+          content_type: String.t(),
+          size_bytes: non_neg_integer()
         }
 
   @doc """
@@ -202,6 +211,39 @@ defmodule LemmingsOs.Artifacts do
   end
 
   def get_artifact_download(_scope, _artifact_id), do: {:error, :invalid_scope}
+
+  @doc """
+  Opens one ready Artifact for trusted download use after scope/status checks.
+
+  If a ready Artifact points at missing or unreadable storage, the record is
+  marked `error` with safe storage metadata. That write is an intentional
+  consistency repair for broken storage, not a general read-side mutation.
+
+  ## Examples
+
+      iex> LemmingsOs.Artifacts.open_artifact_download(%{city_id: Ecto.UUID.generate()}, Ecto.UUID.generate())
+      {:error, :invalid_scope}
+  """
+  @spec open_artifact_download(scope(), Ecto.UUID.t()) ::
+          {:ok, opened_download()} | {:error, :invalid_scope | :not_found}
+  def open_artifact_download(scope, artifact_id) when is_binary(artifact_id) do
+    with {:ok, scope_data} <- scope_data(scope),
+         {:ok, artifact} <- get_ready_artifact_record(scope_data, artifact_id) do
+      case LocalStorage.open(artifact.storage_ref,
+             filename: artifact.filename,
+             content_type: artifact.content_type
+           ) do
+        {:ok, opened} ->
+          {:ok, opened}
+
+        {:error, reason} ->
+          mark_storage_error(artifact, :open, reason)
+          {:error, :not_found}
+      end
+    end
+  end
+
+  def open_artifact_download(_scope, _artifact_id), do: {:error, :invalid_scope}
 
   @doc """
   Lists `ready` artifacts in an explicit scope.
@@ -367,6 +409,33 @@ defmodule LemmingsOs.Artifacts do
     |> Repo.one()
     |> normalize_artifact_result()
   end
+
+  defp get_ready_artifact_record(scope_data, artifact_id) do
+    Artifact
+    |> filter_query(scope_filters(scope_data))
+    |> filter_query(id: artifact_id, status: @ready_status)
+    |> Repo.one()
+    |> normalize_artifact_result()
+  end
+
+  defp mark_storage_error(%Artifact{} = artifact, operation, reason) do
+    metadata =
+      artifact.metadata
+      |> Map.take(["source"])
+      |> Map.merge(%{
+        "storage_error_reason" => safe_reason(reason),
+        "storage_error_operation" => Atom.to_string(operation),
+        "storage_error_at" =>
+          DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+      })
+
+    artifact
+    |> Artifact.changeset(%{status: @error_status, metadata: metadata})
+    |> Repo.update()
+  end
+
+  defp safe_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp safe_reason({reason, _detail}) when is_atom(reason), do: Atom.to_string(reason)
 
   defp normalize_read_result(nil), do: {:error, :not_found}
   defp normalize_read_result(%Artifact{} = artifact), do: {:ok, artifact_descriptor(artifact)}

--- a/lib/lemmings_os/artifacts/artifact.ex
+++ b/lib/lemmings_os/artifacts/artifact.ex
@@ -28,6 +28,8 @@ defmodule LemmingsOs.Artifacts.Artifact do
   @required ~w(world_id filename type content_type storage_ref size_bytes checksum status metadata)a
   @optional ~w(city_id department_id lemming_id lemming_instance_id created_by_tool_execution_id notes)a
   @allowed_metadata_sources ~w(manual_promotion)
+  @allowed_storage_error_keys ~w(storage_error_reason storage_error_operation storage_error_at)
+  @allowed_metadata_keys ["source" | @allowed_storage_error_keys]
 
   @type t :: %__MODULE__{
           id: Ecto.UUID.t() | nil,
@@ -187,20 +189,11 @@ defmodule LemmingsOs.Artifacts.Artifact do
     end)
   end
 
-  defp metadata_contract_errors(%{} = metadata) do
-    with :ok <- validate_metadata_keys(metadata),
-         :ok <- validate_metadata_source(metadata) do
-      []
-    else
-      {:error, reason} -> [metadata: reason]
-    end
-  end
-
   defp validate_metadata_keys(metadata) do
-    case Map.keys(metadata) do
-      [] -> :ok
-      ["source"] -> :ok
-      _keys -> {:error, dgettext("errors", ".invalid_value")}
+    if Enum.all?(Map.keys(metadata), &(&1 in @allowed_metadata_keys)) do
+      :ok
+    else
+      {:error, dgettext("errors", ".invalid_value")}
     end
   end
 
@@ -211,4 +204,35 @@ defmodule LemmingsOs.Artifacts.Artifact do
     do: {:error, dgettext("errors", ".invalid_choice")}
 
   defp validate_metadata_source(%{}), do: :ok
+
+  defp metadata_contract_errors(%{} = metadata) do
+    with :ok <- validate_metadata_keys(metadata),
+         :ok <- validate_metadata_source(metadata),
+         :ok <- validate_storage_error_metadata(metadata) do
+      []
+    else
+      {:error, reason} -> [metadata: reason]
+    end
+  end
+
+  defp validate_storage_error_metadata(metadata) do
+    metadata
+    |> Map.take(@allowed_storage_error_keys)
+    |> Enum.reduce_while(:ok, fn {_key, value}, :ok ->
+      if safe_storage_error_value?(value) do
+        {:cont, :ok}
+      else
+        {:halt, {:error, dgettext("errors", ".invalid_value")}}
+      end
+    end)
+  end
+
+  defp safe_storage_error_value?(value) when is_binary(value) do
+    value != "" and byte_size(value) <= 256 and not String.contains?(value, <<0>>) and
+      not Regex.match?(~r/[\x00-\x1F\x7F]/, value) and
+      not String.contains?(value, "/") and not String.contains?(value, "\\") and
+      not Regex.match?(~r/[A-Za-z]:/, value)
+  end
+
+  defp safe_storage_error_value?(_value), do: false
 end

--- a/lib/lemmings_os/artifacts/local_storage.ex
+++ b/lib/lemmings_os/artifacts/local_storage.ex
@@ -11,8 +11,14 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
   checksum/size calculation.
   """
 
+  @behaviour LemmingsOs.Artifacts.Storage.Adapter
+
+  require Logger
+
   @storage_scheme "local"
   @storage_host "artifacts"
+  @default_max_file_size_bytes 100 * 1024 * 1024
+  @copy_chunk_size 65_536
 
   @typedoc """
   Metadata returned after storing a file in managed artifact storage.
@@ -57,6 +63,16 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
   def store_copy(world_id, artifact_id, source_path, filename)
       when is_binary(world_id) and is_binary(artifact_id) and is_binary(source_path) and
              is_binary(filename) do
+    metadata = storage_metadata(world_id, artifact_id, filename, %{operation: :write})
+
+    instrument_write(metadata, fn ->
+      do_store_copy(world_id, artifact_id, source_path, filename)
+    end)
+  end
+
+  def store_copy(_world_id, _artifact_id, _source_path, _filename), do: {:error, :invalid_input}
+
+  defp do_store_copy(world_id, artifact_id, source_path, filename) do
     with :ok <- validate_world_id(world_id),
          :ok <- validate_artifact_id(artifact_id),
          :ok <- validate_filename(filename),
@@ -64,8 +80,8 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
          {:ok, storage_ref} <- build_storage_ref(world_id, artifact_id, filename),
          :ok <- ensure_storage_root(root_path()),
          {:ok, destination_path} <- resolve_storage_ref(storage_ref),
-         :ok <- File.mkdir_p(Path.dirname(destination_path)),
-         :ok <- copy_file(source_absolute_path, destination_path),
+         :ok <- ensure_storage_directory(Path.dirname(destination_path)),
+         :ok <- copy_file_atomic(source_absolute_path, destination_path, max_file_size_bytes()),
          {:ok, size_bytes} <- size_bytes(destination_path),
          {:ok, checksum} <- checksum(destination_path) do
       {:ok,
@@ -77,7 +93,14 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
     end
   end
 
-  def store_copy(_world_id, _artifact_id, _source_path, _filename), do: {:error, :invalid_input}
+  @impl true
+  @doc """
+  Behaviour callback wrapper for storing a trusted source file.
+  """
+  @spec put(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t()) ::
+          {:ok, stored_file()} | {:error, atom() | {atom(), term()}}
+  def put(world_id, artifact_id, source_path, filename),
+    do: store_copy(world_id, artifact_id, source_path, filename)
 
   @doc """
   Builds an opaque local artifact storage reference.
@@ -140,6 +163,52 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
 
   def resolve_storage_ref(_storage_ref), do: {:error, :invalid_storage_ref}
 
+  @impl true
+  @doc """
+  Behaviour callback for resolving a trusted storage reference into an internal path.
+  """
+  @spec path_for(String.t(), keyword()) :: {:ok, String.t()} | {:error, atom()}
+  def path_for(storage_ref, _opts \\ []), do: resolve_storage_ref(storage_ref)
+
+  @impl true
+  @doc """
+  Behaviour callback for checking whether the managed file exists for a trusted ref.
+  """
+  @spec exists?(String.t(), keyword()) :: {:ok, boolean()} | {:error, atom()}
+  def exists?(storage_ref, _opts \\ []) do
+    with {:ok, path} <- resolve_storage_ref(storage_ref) do
+      {:ok, File.regular?(path)}
+    end
+  end
+
+  @impl true
+  @doc """
+  Behaviour callback for opening a managed file after scope/status checks.
+  """
+  @spec open(String.t(), keyword()) ::
+          {:ok,
+           %{
+             path: String.t(),
+             filename: String.t(),
+             content_type: String.t(),
+             size_bytes: non_neg_integer()
+           }}
+          | {:error, atom() | {atom(), term()}}
+  def open(storage_ref, opts \\ []) do
+    filename = Keyword.get(opts, :filename, "artifact.bin")
+    content_type = Keyword.get(opts, :content_type, "application/octet-stream")
+    metadata = storage_ref_metadata(storage_ref, %{operation: :open, filename: filename})
+
+    instrument_open(metadata, fn ->
+      with {:ok, path} <- resolve_storage_ref(storage_ref),
+           true <- File.regular?(path) or {:error, :not_found},
+           {:ok, size_bytes} <- size_bytes(path) do
+        {:ok,
+         %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}}
+      end
+    end)
+  end
+
   @doc """
   Returns the configured artifact storage root path.
 
@@ -160,6 +229,239 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
     |> Keyword.get(:root_path, Path.expand("priv/runtime/storage", File.cwd!()))
     |> Path.expand()
   end
+
+  @doc """
+  Returns the configured max artifact file size in bytes.
+  """
+  @spec max_file_size_bytes() :: pos_integer()
+  def max_file_size_bytes do
+    :lemmings_os
+    |> Application.get_env(:artifact_storage, [])
+    |> Keyword.get(:max_file_size_bytes, @default_max_file_size_bytes)
+  end
+
+  @impl true
+  @doc """
+  Behaviour callback that verifies the storage root is available.
+  """
+  @spec health_check(keyword()) :: :ok | {:error, atom()}
+  def health_check(_opts \\ []) do
+    root = root_path()
+
+    instrument_health_check(%{operation: :health_check}, fn ->
+      with :ok <- ensure_storage_root(root),
+           {:ok, temp_file_path} <- create_health_check_file(root) do
+        delete_health_check_file(temp_file_path)
+      end
+    end)
+  end
+
+  defp instrument_write(metadata, fun) do
+    start_time = System.monotonic_time()
+    emit_telemetry([:lemmings_os, :artifact_storage, :write, :start], %{count: 1}, metadata)
+
+    case fun.() do
+      {:ok, stored} ->
+        duration_ms = duration_ms(start_time)
+
+        success_metadata =
+          Map.merge(metadata, %{
+            checksum: stored.checksum,
+            size_bytes: stored.size_bytes,
+            status: :ok
+          })
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :write, :stop],
+          %{count: 1, duration_ms: duration_ms, size_bytes: stored.size_bytes},
+          success_metadata
+        )
+
+        Logger.info("artifact storage write succeeded",
+          event: "artifact.storage.write.succeeded",
+          operation: Map.get(metadata, :operation),
+          world_id: Map.get(metadata, :world_id),
+          artifact_id: Map.get(metadata, :artifact_id),
+          filename: Map.get(metadata, :filename),
+          size_bytes: stored.size_bytes,
+          checksum: stored.checksum
+        )
+
+        {:ok, stored}
+
+      {:error, reason} ->
+        duration_ms = duration_ms(start_time)
+        failure_metadata = Map.merge(metadata, %{reason: reason_token(reason), status: :error})
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :write, :exception],
+          %{count: 1, duration_ms: duration_ms},
+          failure_metadata
+        )
+
+        Logger.warning("artifact storage write failed",
+          event: "artifact.storage.write.failed",
+          operation: Map.get(metadata, :operation),
+          world_id: Map.get(metadata, :world_id),
+          artifact_id: Map.get(metadata, :artifact_id),
+          filename: Map.get(metadata, :filename),
+          reason: reason_token(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp instrument_open(metadata, fun) do
+    start_time = System.monotonic_time()
+
+    case fun.() do
+      {:ok, opened} ->
+        duration_ms = duration_ms(start_time)
+        success_metadata = Map.merge(metadata, %{size_bytes: opened.size_bytes, status: :ok})
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :open, :stop],
+          %{count: 1, duration_ms: duration_ms, size_bytes: opened.size_bytes},
+          success_metadata
+        )
+
+        Logger.info("artifact storage open succeeded",
+          event: "artifact.storage.open.succeeded",
+          operation: Map.get(metadata, :operation),
+          world_id: Map.get(metadata, :world_id),
+          artifact_id: Map.get(metadata, :artifact_id),
+          filename: Map.get(metadata, :filename),
+          size_bytes: opened.size_bytes
+        )
+
+        {:ok, opened}
+
+      {:error, reason} ->
+        duration_ms = duration_ms(start_time)
+        failure_metadata = Map.merge(metadata, %{reason: reason_token(reason), status: :error})
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :open, :exception],
+          %{count: 1, duration_ms: duration_ms},
+          failure_metadata
+        )
+
+        Logger.warning("artifact storage open failed",
+          event: "artifact.storage.open.failed",
+          operation: Map.get(metadata, :operation),
+          world_id: Map.get(metadata, :world_id),
+          artifact_id: Map.get(metadata, :artifact_id),
+          filename: Map.get(metadata, :filename),
+          reason: reason_token(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp instrument_health_check(metadata, fun) do
+    start_time = System.monotonic_time()
+
+    case fun.() do
+      :ok ->
+        duration_ms = duration_ms(start_time)
+        success_metadata = Map.put(metadata, :status, :ok)
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :health_check, :stop],
+          %{count: 1, duration_ms: duration_ms},
+          success_metadata
+        )
+
+        Logger.info("artifact storage health check succeeded",
+          event: "artifact.storage.health_check.succeeded",
+          operation: :health_check
+        )
+
+        :ok
+
+      {:error, reason} ->
+        duration_ms = duration_ms(start_time)
+        failure_metadata = Map.merge(metadata, %{reason: reason_token(reason), status: :error})
+
+        emit_telemetry(
+          [:lemmings_os, :artifact_storage, :health_check, :exception],
+          %{count: 1, duration_ms: duration_ms},
+          failure_metadata
+        )
+
+        Logger.warning("artifact storage health check failed",
+          event: "artifact.storage.health_check.failed",
+          operation: :health_check,
+          reason: reason_token(reason)
+        )
+
+        {:error, reason}
+    end
+  end
+
+  defp emit_telemetry(event, measurements, metadata) do
+    :telemetry.execute(event, measurements, metadata)
+    :ok
+  rescue
+    _exception -> :ok
+  catch
+    _kind, _reason -> :ok
+  end
+
+  defp duration_ms(start_time) do
+    (System.monotonic_time() - start_time)
+    |> System.convert_time_unit(:native, :millisecond)
+  end
+
+  defp storage_metadata(world_id, artifact_id, filename, extra) do
+    %{
+      world_id: world_id,
+      artifact_id: artifact_id,
+      filename: filename
+    }
+    |> Map.merge(extra)
+    |> Map.update(:filename, nil, &safe_metadata_string/1)
+  end
+
+  defp storage_ref_metadata(storage_ref, extra) when is_binary(storage_ref) do
+    case parse_storage_ref(storage_ref) do
+      {:ok, world_id, artifact_id, filename} ->
+        storage_metadata(world_id, artifact_id, filename, extra)
+
+      {:error, _reason} ->
+        %{
+          world_id: nil,
+          artifact_id: nil,
+          filename: safe_metadata_string(Map.get(extra, :filename)),
+          operation: Map.get(extra, :operation)
+        }
+    end
+  end
+
+  defp storage_ref_metadata(_storage_ref, extra) do
+    %{
+      world_id: nil,
+      artifact_id: nil,
+      filename: safe_metadata_string(Map.get(extra, :filename)),
+      operation: Map.get(extra, :operation)
+    }
+  end
+
+  defp reason_token(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp reason_token({reason, _detail}) when is_atom(reason), do: Atom.to_string(reason)
+  defp reason_token(_reason), do: "storage_error"
+
+  defp safe_metadata_string(value) when is_binary(value) do
+    value
+    |> String.replace(~r/[\x00-\x1F\x7F]/, "")
+    |> String.replace("/", "")
+    |> String.replace("\\", "")
+    |> String.slice(0, 255)
+  end
+
+  defp safe_metadata_string(_value), do: nil
 
   defp parse_storage_ref(storage_ref) do
     uri = URI.parse(storage_ref)
@@ -273,9 +575,9 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
 
   defp ensure_storage_root(root_path) do
     case File.stat(root_path) do
-      {:ok, %File.Stat{type: :directory}} -> :ok
+      {:ok, %File.Stat{type: :directory}} -> set_directory_permissions(root_path)
       {:ok, _stat} -> {:error, :storage_unavailable}
-      {:error, :enoent} -> File.mkdir_p(root_path)
+      {:error, :enoent} -> ensure_storage_directory(root_path)
       {:error, _reason} -> {:error, :storage_unavailable}
     end
   end
@@ -327,10 +629,141 @@ defmodule LemmingsOs.Artifacts.LocalStorage do
     end
   end
 
-  defp copy_file(source, destination) do
-    case File.cp(source, destination) do
+  defp ensure_storage_directory(path) do
+    case File.mkdir_p(path) do
+      :ok -> set_directory_permissions(path)
+      {:error, _reason} -> {:error, :storage_unavailable}
+    end
+  end
+
+  defp copy_file_atomic(source, destination, max_file_size_bytes) do
+    temp_path = temp_path_for(destination)
+
+    result =
+      case File.open(source, [:read, :binary]) do
+        {:ok, source_device} ->
+          try do
+            copy_to_temp_and_rename(source_device, temp_path, destination, max_file_size_bytes)
+          after
+            _ = File.close(source_device)
+          end
+
+        {:error, _reason} ->
+          {:error, :copy_failed}
+      end
+
+    case result do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        _ = File.rm(temp_path)
+        {:error, reason}
+    end
+  end
+
+  defp copy_to_temp_and_rename(source_device, temp_path, destination, max_file_size_bytes) do
+    case File.open(temp_path, [:write, :binary, :exclusive]) do
+      {:ok, temp_device} ->
+        try do
+          with {:ok, _size_bytes} <-
+                 stream_copy_limited(source_device, temp_device, max_file_size_bytes),
+               :ok <- set_file_permissions(temp_path),
+               :ok <- rename_temp_file(temp_path, destination) do
+            set_file_permissions(destination)
+          end
+        after
+          _ = File.close(temp_device)
+        end
+
+      {:error, _reason} ->
+        {:error, :copy_failed}
+    end
+  end
+
+  defp stream_copy_limited(source_device, temp_device, max_file_size_bytes) do
+    do_stream_copy_limited(source_device, temp_device, max_file_size_bytes, 0)
+  end
+
+  defp do_stream_copy_limited(source_device, temp_device, max_file_size_bytes, bytes_written) do
+    case IO.binread(source_device, @copy_chunk_size) do
+      :eof ->
+        {:ok, bytes_written}
+
+      {:error, _reason} ->
+        {:error, :copy_failed}
+
+      chunk when is_binary(chunk) ->
+        next_bytes_written = bytes_written + byte_size(chunk)
+
+        if next_bytes_written > max_file_size_bytes do
+          {:error, :file_too_large}
+        else
+          :ok = IO.binwrite(temp_device, chunk)
+
+          do_stream_copy_limited(
+            source_device,
+            temp_device,
+            max_file_size_bytes,
+            next_bytes_written
+          )
+        end
+    end
+  end
+
+  defp rename_temp_file(temp_path, destination) do
+    case File.rename(temp_path, destination) do
       :ok -> :ok
-      {:error, reason} -> {:error, {:copy_failed, reason}}
+      {:error, _reason} -> {:error, :copy_failed}
+    end
+  end
+
+  defp temp_path_for(destination) do
+    directory = Path.dirname(destination)
+    base_name = Path.basename(destination)
+    suffix = System.unique_integer([:positive, :monotonic])
+    Path.join(directory, ".#{base_name}.tmp-#{suffix}")
+  end
+
+  defp set_directory_permissions(path) do
+    case File.chmod(path, 0o700) do
+      :ok -> :ok
+      {:error, :enotsup} -> :ok
+      {:error, :eperm} -> :ok
+      {:error, :einval} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp set_file_permissions(path) do
+    case File.chmod(path, 0o600) do
+      :ok -> :ok
+      {:error, :enotsup} -> :ok
+      {:error, :eperm} -> :ok
+      {:error, :einval} -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp create_health_check_file(root_path) do
+    temp_file_path =
+      Path.join(
+        root_path,
+        ".storage-healthcheck-#{System.unique_integer([:positive, :monotonic])}"
+      )
+
+    with :ok <- File.write(temp_file_path, "ok", [:write, :exclusive]),
+         :ok <- set_file_permissions(temp_file_path) do
+      {:ok, temp_file_path}
+    else
+      {:error, _reason} -> {:error, :storage_unavailable}
+    end
+  end
+
+  defp delete_health_check_file(temp_file_path) do
+    case File.rm(temp_file_path) do
+      :ok -> :ok
+      {:error, _reason} -> {:error, :storage_unavailable}
     end
   end
 

--- a/lib/lemmings_os/artifacts/storage/adapter.ex
+++ b/lib/lemmings_os/artifacts/storage/adapter.ex
@@ -1,0 +1,27 @@
+defmodule LemmingsOs.Artifacts.Storage.Adapter do
+  @moduledoc """
+  Behaviour contract for trusted Artifact byte storage adapters.
+  """
+
+  @type reason :: atom() | {atom(), term()}
+  @type open_result :: %{
+          path: String.t(),
+          filename: String.t(),
+          content_type: String.t(),
+          size_bytes: non_neg_integer()
+        }
+
+  @callback put(Ecto.UUID.t(), Ecto.UUID.t(), String.t(), String.t()) ::
+              {:ok,
+               %{
+                 storage_ref: String.t(),
+                 checksum: String.t(),
+                 size_bytes: non_neg_integer()
+               }}
+              | {:error, reason()}
+
+  @callback open(String.t(), keyword()) :: {:ok, open_result()} | {:error, reason()}
+  @callback path_for(String.t(), keyword()) :: {:ok, String.t()} | {:error, reason()}
+  @callback exists?(String.t(), keyword()) :: {:ok, boolean()} | {:error, reason()}
+  @callback health_check(keyword()) :: :ok | {:error, reason()}
+end

--- a/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+++ b/lib/lemmings_os_web/controllers/instance_artifact_controller.ex
@@ -12,7 +12,6 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
   use LemmingsOsWeb, :controller
 
   alias LemmingsOs.Artifacts
-  alias LemmingsOs.Artifacts.LocalStorage
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.Worlds
 
@@ -20,9 +19,8 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
     with %{} = world <- resolve_world(params),
          {:ok, instance_id} <- fetch_instance_id(params),
          {:ok, instance} <- LemmingInstances.get_instance(instance_id, world: world),
-         {:ok, artifact} <- Artifacts.get_artifact_download(instance, artifact_id),
-         {:ok, absolute_path} <- LocalStorage.resolve_storage_ref(artifact.storage_ref),
-         {:ok, content} <- File.read(absolute_path) do
+         {:ok, artifact} <- Artifacts.open_artifact_download(instance, artifact_id),
+         {:ok, content} <- File.read(artifact.path) do
       conn
       |> put_resp_header("content-type", artifact.content_type)
       |> put_resp_header("x-content-type-options", "nosniff")
@@ -32,8 +30,6 @@ defmodule LemmingsOsWeb.InstanceArtifactController do
       nil -> send_resp(conn, 404, "World not found")
       {:error, :missing_instance_id} -> send_resp(conn, 404, "Artifact not found")
       {:error, :not_found} -> send_resp(conn, 404, "Artifact not found")
-      {:error, :invalid_storage_ref} -> send_resp(conn, 404, "Artifact not found")
-      {:error, :storage_unavailable} -> send_resp(conn, 404, "Artifact not found")
       {:error, :enoent} -> send_resp(conn, 404, "Artifact not found")
       {:error, _reason} -> send_resp(conn, 404, "Artifact not found")
     end

--- a/llms/tasks/0011_local_artifact_storage/01_storage_test_scenarios.md
+++ b/llms/tasks/0011_local_artifact_storage/01_storage_test_scenarios.md
@@ -1,0 +1,65 @@
+# Task 01: Storage Test Scenarios
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-test-scenarios` - Test scenario designer for acceptance criteria, edge cases, regressions, and coverage planning.
+
+## Agent Invocation
+Act as `qa-test-scenarios`. Define the complete scenario matrix for the local Artifact storage backend before implementation starts.
+
+## Objective
+Convert the feature plan into a concrete, ordered test and acceptance scenario matrix covering storage, context integration, download behavior, observability, docs, security, accessibility scope, and release validation.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Existing tests under `test/lemmings_os/artifacts*` and `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+
+## Expected Outputs
+- [ ] Scenario matrix documented in this task file.
+- [ ] Clear P0/P1/P2 coverage recommendations by subsystem.
+- [ ] Explicit negative/security cases: traversal, symlink escape, path leakage, oversized files, missing managed files, unsafe metadata.
+- [ ] Explicit no-persistent-audit expectation for `LemmingsOs.Events`.
+
+## Acceptance Criteria
+- [ ] Scenarios cover every acceptance criterion in `plan.md`.
+- [ ] Scenarios are grouped by storage backend, Artifact context, controller/download, observability, docs, security, accessibility scope, and release validation.
+- [ ] Each scenario has a clear expected outcome and suggested test layer.
+- [ ] No implementation code is changed in this task.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts/local_storage.ex
+lib/lemmings_os/artifacts/promotion.ex
+lib/lemmings_os/artifacts.ex
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+test/lemmings_os/artifacts/local_storage_test.exs
+test/lemmings_os/artifacts/promotion_test.exs
+test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+```
+
+### Constraints
+- Do not write implementation tests in this task.
+- Do not perform git operations.
+- Treat durable audit persistence through `LemmingsOs.Events` as out of scope.
+
+## Execution Instructions
+1. Read all inputs.
+2. Build a scenario table with ID, priority, layer, setup, action, expected result, and later task owner.
+3. Highlight coverage gaps that Task 06 must convert into ExUnit tests.
+4. Document assumptions and any ambiguous behavior for human review.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/01_storage_test_scenarios.md
+++ b/llms/tasks/0011_local_artifact_storage/01_storage_test_scenarios.md
@@ -1,8 +1,8 @@
 # Task 01: Storage Test Scenarios
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-test-scenarios` - Test scenario designer for acceptance criteria, edge cases, regressions, and coverage planning.
@@ -14,24 +14,24 @@ Act as `qa-test-scenarios`. Define the complete scenario matrix for the local Ar
 Convert the feature plan into a concrete, ordered test and acceptance scenario matrix covering storage, context integration, download behavior, observability, docs, security, accessibility scope, and release validation.
 
 ## Inputs Required
-- [ ] `llms/constitution.md`
-- [ ] `llms/project_context.md`
-- [ ] `llms/coding_styles/elixir.md`
-- [ ] `llms/coding_styles/elixir_tests.md`
-- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
-- [ ] Existing tests under `test/lemmings_os/artifacts*` and `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+- [x] `llms/constitution.md`
+- [x] `llms/project_context.md`
+- [x] `llms/coding_styles/elixir.md`
+- [x] `llms/coding_styles/elixir_tests.md`
+- [x] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [x] Existing tests under `test/lemmings_os/artifacts*` and `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
 
 ## Expected Outputs
-- [ ] Scenario matrix documented in this task file.
-- [ ] Clear P0/P1/P2 coverage recommendations by subsystem.
-- [ ] Explicit negative/security cases: traversal, symlink escape, path leakage, oversized files, missing managed files, unsafe metadata.
-- [ ] Explicit no-persistent-audit expectation for `LemmingsOs.Events`.
+- [x] Scenario matrix documented in this task file.
+- [x] Clear P0/P1/P2 coverage recommendations by subsystem.
+- [x] Explicit negative/security cases: traversal, symlink escape, path leakage, oversized files, missing managed files, unsafe metadata.
+- [x] Explicit no-persistent-audit expectation for `LemmingsOs.Events`.
 
 ## Acceptance Criteria
-- [ ] Scenarios cover every acceptance criterion in `plan.md`.
-- [ ] Scenarios are grouped by storage backend, Artifact context, controller/download, observability, docs, security, accessibility scope, and release validation.
-- [ ] Each scenario has a clear expected outcome and suggested test layer.
-- [ ] No implementation code is changed in this task.
+- [x] Scenarios cover every acceptance criterion in `plan.md`.
+- [x] Scenarios are grouped by storage backend, Artifact context, controller/download, observability, docs, security, accessibility scope, and release validation.
+- [x] Each scenario has a clear expected outcome and suggested test layer.
+- [x] No implementation code is changed in this task.
 
 ## Technical Notes
 ### Relevant Code Locations
@@ -58,8 +58,143 @@ test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
 
 ---
 
+## Scope & Assumptions
+
+This plan covers the local filesystem Artifact storage hardening described in `plan.md`. It defines what Tasks 02 through 11 must validate; it does not implement tests or production code.
+
+Assumptions:
+- V1 supports only the local backend. S3/MinIO, deletion, retention, scanning, previews, RAG ingestion, versioning, and cross-City shared storage remain future work.
+- `path_for/2` and `open/2` may return internal trusted filesystem paths only after caller-side scope/status checks.
+- Public read models, controller responses, Logger metadata, telemetry metadata, and persisted safe error metadata must not expose storage roots, absolute paths, raw workspace paths, file contents, notes, full metadata, exception dumps, or secrets.
+- A ready Artifact may be marked `error` as a limited repair side effect when trusted open/download discovers missing, unreadable, or broken managed storage.
+- Durable storage audit rows through `LemmingsOs.Events` are explicitly out of scope; this feature uses Logger and telemetry only.
+- Any tests that mutate application env must restore prior values with `on_exit`.
+
+## Risk Areas
+
+- **Filesystem escape**: traversal, absolute path input, unsafe filename bytes, Windows-style separators, and symlink components could read/write outside the configured root.
+- **Path leakage**: errors, descriptors, responses, logs, telemetry, and metadata could reveal host paths or workspace paths.
+- **Artifact corruption**: failed updates could update DB metadata before a safe replacement exists.
+- **Oversized files**: storage writes could copy beyond the configured maximum and leave ready-looking artifacts or temp files.
+- **Broken durable downloads**: controller code could bypass context/storage checks and call `File.read/1` directly.
+- **Observability drift**: telemetry names or metadata could differ from the plan, or persistent audit events could be introduced accidentally.
+- **Operational mismatch**: docs could imply DB-only backup is enough or omit persistent volume requirements.
+
+## Scenario Matrix
+
+| ID | Priority | Layer | Area | Scenario | Preconditions | Steps | Expected Result | Owner / Notes |
+|---|---|---|---|---|---|---|---|---|
+| STOR-001 | P0 | Unit | Storage | Adapter behavior contract exists with V1 callbacks only | Task 02 implementation present | Inspect/compile `LemmingsOs.Artifacts.Storage.Adapter` and `LocalStorage` implementation | Callbacks are `put/4`, `open/2`, `path_for/2`, `exists?/2`, `health_check/1`; no delete callback | Task 02 / Task 06 |
+| STOR-002 | P0 | Unit | Config | Storage root config uses `LEMMINGS_ARTIFACT_STORAGE_ROOT` | Runtime config test can set env safely | Set root env and evaluate config | Root env wins over app config | Task 02 / restore env in `on_exit` |
+| STOR-003 | P1 | Unit | Config | Default max file size is 100 MB | No explicit max configured | Read configured storage options | `max_file_size_bytes == 100 * 1024 * 1024` | Task 02 |
+| STOR-004 | P0 | Unit | Storage | Canonical storage ref format | Valid UUIDs and safe filename | Build/store artifact ref | Ref is `local://artifacts/<world_id>/<artifact_id>/<safe_filename>` and excludes root/workspace paths | Existing coverage to keep |
+| STOR-005 | P0 | Unit | Security | Unsafe filenames are rejected | Valid UUIDs | Try empty, `.`, `..`, traversal, absolute, nested path, backslash, drive prefix, null byte, control char, leading tilde | Returns safe reason token such as `:invalid_filename`; no file is written | Expand existing coverage |
+| STOR-006 | P0 | Unit | Security | Malformed storage refs are rejected | Configured root | Try missing segment, wrong scheme/host, query/fragment, traversal, nested filename, null byte, bad UUID | Returns `{:error, :invalid_storage_ref}` and does not expose paths | Expand existing coverage |
+| STOR-007 | P0 | Unit | Security | Resolved trusted path remains inside root | Configured root and valid ref | Resolve/path_for valid ref | Result path is under expanded root and physical layout is `<root>/<world_id>/<artifact_id>/<filename>` | Existing coverage to keep |
+| STOR-008 | P0 | Unit | Security | Symlink escape in world/artifact/file path is rejected | Root contains symlink component pointing outside root | Call `store_copy/put`, `path_for`, and `open` for matching ref | Returns structured error; no outside write/read occurs | Must cover read and write, not only write |
+| STOR-009 | P0 | Unit | Storage | Atomic first write | Valid source file and empty destination | Store file | Writes temp file in target dir, renames atomically, final file exists, no temp files remain | Task 03 / implementation-aware assertion |
+| STOR-010 | P0 | Unit | Storage | Failed write does not leave ready-looking final file | Source read or copy fails before rename | Attempt store | Returns structured error; final managed file does not exist; temp file cleaned when possible | Task 03 |
+| STOR-011 | P0 | Unit | Storage | Oversized file is rejected by configured max | Max set below source size | Store file | Returns `:file_too_large` or equivalent safe token; no final file; no ready Artifact metadata should be created by integration flow | Task 03 + Task 04 |
+| STOR-012 | P0 | Unit | Storage | Checksum and size are computed from managed file | Valid source file | Store file, then inspect returned data and managed bytes | `size_bytes` and SHA-256 match final managed content, not untrusted metadata | Existing coverage to keep |
+| STOR-013 | P1 | Unit | Storage | Best-effort permissions are applied | Platform supports POSIX mode inspection | Store file | Directories are `0700` and files `0600` where supported; test is tolerant/skipped when unsupported | Task 03 |
+| STOR-014 | P0 | Unit | Storage | `open/2` returns locked success shape | Ready file exists in managed storage | Call backend `open/2` after valid ref | Returns `{:ok, %{path:, filename:, content_type:, size_bytes:}}`; path is internal and root-bounded | Task 03 |
+| STOR-015 | P0 | Unit | Storage | `open/2` returns safe errors for missing/unreadable files | Valid ref but missing or unreadable final file | Call `open/2` | Returns `{:error, reason_token}` only; no paths or exception dumps in reason | Task 03 |
+| STOR-016 | P1 | Unit | Storage | `exists?/2` is explicit and root-safe | Valid, missing, malformed, and symlink-escape refs | Call `exists?/2` | Returns boolean or explicit tuple per contract; malformed/escaping refs are not treated as existing | Task 03 |
+| STOR-017 | P1 | Unit | Storage | `path_for/2` is trusted/internal only and root-safe | Valid and unsafe refs | Call `path_for/2` | Valid returns internal root-bounded path; unsafe returns safe error token | Task 03 |
+| STOR-018 | P1 | Unit | Observability | `health_check/1` validates create/write/remove behavior | Temporary storage root config | Call health check for writable root, unwritable/missing bad root, and symlink escape root | Returns explicit success/error tuples and emits safe telemetry in observability task | Task 03 + Task 05 |
+| CTX-001 | P0 | Integration | Artifact Context | First promotion persists ready Artifact after successful storage write | Workspace file exists | Promote file through context | Artifact row is ready with storage_ref, checksum, size; descriptor omits `storage_ref` and paths | Existing coverage to keep |
+| CTX-002 | P0 | Integration | Artifact Context | Failed first-time storage write creates no misleading ready Artifact | Storage returns error, bad source, unsafe filename, or oversized source | Promote file | Returns safe error; no ready Artifact row is inserted | Task 04 / Task 06 |
+| CTX-003 | P0 | Integration | Artifact Context | `:update_existing` writes safely before DB metadata update | Existing ready Artifact with valid managed file | Update with new source | Same row id; checksum/size and managed file reflect new content after successful replacement | Existing coverage to keep |
+| CTX-004 | P0 | Integration | Artifact Context | Failed update preserves prior row and file | Existing ready Artifact; replacement storage fails before safe rename | Promote with `mode: :update_existing` | Returns safe error; old managed file, checksum, size, and status remain unchanged | Existing partial coverage for `:mode_required`; add storage failure |
+| CTX-005 | P1 | Integration | Artifact Context | `:promote_as_new` creates independent row | Existing same-scope filename | Promote with `mode: :promote_as_new` | New row id; existing row unchanged; both list in scope as expected | Existing coverage to keep |
+| CTX-006 | P0 | Integration | Validation | Safe storage error metadata is accepted | Artifact changeset attrs include allowed storage error keys | Validate/insert metadata with `storage_error_reason`, `storage_error_operation`, `storage_error_at` | Changeset valid when values are safe strings and optional `source` contract is preserved | Task 04 / Task 06 |
+| CTX-007 | P0 | Integration | Validation | Unsafe storage error metadata is rejected | Metadata contains unexpected keys or unsafe values | Validate metadata with absolute path, root path, workspace path, file content, notes, exception dump, secret-like value, non-string value | Changeset invalid with safe validation errors | Task 04 / Task 06 |
+| CTX-008 | P0 | Integration | Security | Public descriptors never expose storage internals | Artifact persisted with storage ref and metadata | Call create/get/list/list_for_instance descriptors | Descriptor omits `storage_ref`, absolute paths, root path, and raw workspace path | Existing coverage to keep and expand |
+| CTX-009 | P0 | Integration | Artifact Context | Trusted download/open API enforces scope and status before storage open | Ready, archived, deleted, error, wrong-world, wrong-instance artifacts | Call context download/open function | Ready in scope opens; wrong scope/status returns `:not_found` without resolving storage | Task 04 |
+| CTX-010 | P0 | Integration | Artifact Context | Missing/unreadable ready storage marks Artifact error when context can repair | Ready Artifact row points to missing or unreadable managed file | Call trusted context open/download | Returns storage error/not found; persisted Artifact becomes `error` with safe metadata | Task 04 |
+| CTX-011 | P1 | Integration | Lifecycle | Soft-deleted Artifacts do not physically delete files | Ready Artifact with managed file | Mark status `deleted` | DB status changes; managed file remains on disk | Task 04 / confirms no delete callback |
+| DL-001 | P0 | Controller | Downloads | Durable artifact download serves bytes with safe headers | Ready Artifact in scope with managed bytes | GET durable download route | 200, body bytes match, `content-type`, `x-content-type-options: nosniff`, safe attachment filename | Existing coverage to keep |
+| DL-002 | P0 | Controller | Downloads | Wrong world/instance/status returns safe 404 before storage resolution | Artifact with invalid storage ref but wrong scope/status | GET route with wrong world, wrong instance, archived/deleted/error | 404 `Artifact not found`; no storage path/ref/root leak | Existing coverage to keep |
+| DL-003 | P0 | Controller | Downloads | Missing managed file returns safe 404 and repairs status where applicable | Ready Artifact; physical file removed | GET durable download route | 404 without path/ref/root leakage; Artifact is marked `error` if context owns repair | Existing coverage lacks repair assertion |
+| DL-004 | P0 | Controller | Downloads | Invalid storage ref returns safe 404 | Ready Artifact has unsupported/malformed storage ref | GET durable download route | 404 without leaking ref or root; optional status repair metadata is safe | Existing coverage to keep and expand |
+| DL-005 | P0 | Controller | Security | Header filename sanitization prevents response splitting | Artifact filename contains CR/LF/control chars in DB | GET route | `content-disposition` strips controls and remains a single safe header | Existing coverage to keep |
+| DL-006 | P1 | Controller | Compatibility | Workspace catch-all route remains compatible | Runtime workspace file exists | GET existing workspace artifact route | Still serves workspace bytes with safe headers; durable storage changes do not regress route | Existing coverage to keep |
+| OBS-001 | P0 | Integration | Observability | Storage write emits canonical telemetry start/stop/exception | Telemetry test handler attached | Successful and failing write/update | Events use `[:lemmings_os, :artifact_storage, :write, ...]`; metadata includes allowed IDs/filename/content type/size/checksum/operation/reason | Task 05 / Task 06 |
+| OBS-002 | P0 | Integration | Observability | Storage open emits canonical telemetry stop/exception | Telemetry test handler attached | Successful and failing open/download | Events use `[:lemmings_os, :artifact_storage, :open, ...]`; metadata excludes forbidden fields | Task 05 / Task 06 |
+| OBS-003 | P1 | Integration | Observability | Health check emits canonical telemetry | Telemetry test handler attached | Run successful and failing health checks | Events use `[:lemmings_os, :artifact_storage, :health_check, ...]`; metadata is safe | Task 05 / Task 06 |
+| OBS-004 | P0 | Integration | Observability | Logger metadata is useful and non-leaky | Capture logs around write/open/health failures | Trigger success and failure paths | Logs may include safe event string and IDs/reason; logs exclude paths, root, workspace source, contents, metadata, notes, secrets, exception dumps | Task 05 / Task 06 |
+| OBS-005 | P0 | Integration | Audit | No durable audit rows are persisted through `LemmingsOs.Events` | Event count or test double available | Run write/open/download failures and successes | No Artifact storage audit/event rows are inserted; only Logger/telemetry are used | Task 05 / Task 06 |
+| DOC-001 | P1 | Manual | Docs | Env var and local layout are documented | Docs updated in Task 07 | Review docs | `LEMMINGS_ARTIFACT_STORAGE_ROOT`, layout, default max size, and local-only behavior are documented | Task 07 |
+| DOC-002 | P0 | Manual | Docs | Backup and volume requirements are explicit | Docs updated in Task 07 | Review self-host/Docker docs | Operators are told to back up Postgres plus artifact storage volume; DB-only backup is insufficient | Task 07 |
+| DOC-003 | P1 | Manual | Docs | Non-goals are documented | Docs updated in Task 07 | Review feature docs | Soft delete does not purge bytes; cleanup/retention/S3/MinIO/encryption beyond FS permissions/scanning/previews/RAG/versioning are future work | Task 07 |
+| A11Y-001 | P1 | Manual | Accessibility | No accessibility-impacting UI changes are introduced | Implementation complete | Diff templates/components/controllers | If no operator-facing UI changed, document no review needed; if UI changed, run accessibility audit on changed surfaces | Task 08 |
+| SEC-001 | P0 | Manual | Security | End-to-end leak review | Implementation complete | Review tests, controller responses, logs, telemetry, metadata, descriptors | Forbidden path/content/secret surfaces are covered by assertions or manual audit notes | Task 09 |
+| REL-001 | P0 | Manual | Release | Narrow tests and final validation pass | Implementation and tests complete | Run targeted storage/context/controller/observability tests, `mix format`, then `mix precommit` | All pass with zero warnings/errors; env-mutating tests restore config | Task 11 |
+
+## Acceptance Criteria
+
+- Given a valid world id, artifact id, safe filename, and configured storage root, when a file is stored, then the persisted ref is canonical, the physical path is root-bounded, size/checksum are computed from managed bytes, permissions are applied best-effort, and no temp files remain.
+- Given unsafe filename or storage ref input, when any storage API receives it, then the operation returns a safe reason token and does not write, read, or leak any filesystem path.
+- Given a symlink inside the storage root that points outside the root, when storing, resolving, pathing, opening, or checking existence, then the backend rejects the operation before accessing the external target.
+- Given a source file over `max_file_size_bytes`, when promotion/storage is attempted, then no ready Artifact is created or updated and no final managed file remains.
+- Given an existing ready Artifact, when `:update_existing` succeeds, then the same DB row is retained and its checksum/size match the new managed bytes.
+- Given an existing ready Artifact, when `:update_existing` storage replacement fails, then the old DB metadata and old managed file remain valid.
+- Given a ready Artifact whose managed file is missing or unreadable, when the trusted context/controller open path is used, then the user receives safe 404 behavior and the Artifact is marked `error` with safe metadata where the context has enough information.
+- Given wrong World scope, wrong instance, or non-ready status, when download/open is requested, then storage is not resolved and the caller receives `:not_found` or a safe 404.
+- Given Logger or telemetry observations for storage operations, when payloads are inspected, then event names follow the plan and metadata includes only safe IDs/tokens, never roots, absolute paths, raw workspace paths, contents, notes, full metadata, secrets, or exception dumps.
+- Given storage operations succeed or fail, when durable event tables are inspected, then no storage audit rows are persisted through `LemmingsOs.Events`.
+- Given soft-deleted Artifacts, when status changes to `deleted`, then the managed file remains on disk and no physical delete code path exists in the adapter.
+- Given final documentation, when an operator reads backup guidance, then it is clear that Artifact metadata is in Postgres and bytes are in the configured storage root, and both must be backed up.
+
+## Coverage Recommendations
+
+- **P0 for Task 06**: STOR-004 through STOR-012, STOR-014, STOR-015, CTX-001 through CTX-004, CTX-006 through CTX-010, DL-001 through DL-005, OBS-001, OBS-002, OBS-004, OBS-005, SEC-001, REL-001.
+- **P1 for Task 06**: STOR-002, STOR-003, STOR-013, STOR-016 through STOR-018, CTX-005, CTX-011, DL-006, OBS-003, DOC-001 through DOC-003, A11Y-001.
+- **P2**: Cosmetic or platform-specific permission details beyond best-effort mode checks; broad browser accessibility testing only if UI surfaces change.
+
+Task 06 should prioritize ExUnit coverage in this order:
+1. `test/lemmings_os/artifacts/local_storage_test.exs` for path safety, atomic write, size limit, adapter functions, health check, and tuple errors.
+2. `test/lemmings_os/artifacts/artifact_test.exs` and `test/lemmings_os/artifacts_test.exs` for safe metadata, descriptor leakage, and scope/status behavior.
+3. `test/lemmings_os/artifacts/promotion_test.exs` for failed first writes and failed replacement preservation.
+4. `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs` for trusted context open, safe 404s, repair side effect, and header safety.
+5. Focused observability tests for telemetry/log metadata and no `LemmingsOs.Events` persistence.
+
+## Regression Checklist
+
+- [ ] Canonical refs remain `local://artifacts/<world_id>/<artifact_id>/<safe_filename>`.
+- [ ] `storage_ref` and filesystem paths remain internal-only.
+- [ ] Unsafe names/refs/traversal/null/control chars/backslashes/drive prefixes are rejected.
+- [ ] Symlink escape is rejected on both write and read/open paths.
+- [ ] Writes and updates are atomic and clean temp files.
+- [ ] Oversized files do not create or corrupt ready Artifacts.
+- [ ] Missing/unreadable managed files produce safe errors and safe controller 404s.
+- [ ] Ready Artifact repair to `error` happens only for intentional storage-missing/unreadable paths.
+- [ ] Soft delete does not physically delete bytes.
+- [ ] Logger and telemetry metadata are safe and use canonical event names.
+- [ ] No `LemmingsOs.Events` durable audit rows are added for storage operations.
+- [ ] Docs cover env var, volume, backup, DB-plus-bytes split, no cleanup/retention, and future object storage.
+- [ ] Any tests that mutate app env restore it in `on_exit`.
+- [ ] Targeted tests, `mix format`, and `mix precommit` pass.
+
+## Out-of-scope
+
+- Writing ExUnit implementation in this task.
+- New object-storage backend, MinIO/S3 integration, cross-City shared storage, cleanup sweeper, retention policy, physical purge, file versioning, previews, scanning, RAG ingestion, or encryption-at-rest beyond filesystem permissions.
+- New operator-facing UI unless later implementation tasks choose to change templates.
+- Persistent Artifact storage audit rows through `LemmingsOs.Events`.
+- Git operations.
+
+## Ambiguities For Human Review
+
+- Confirm whether `exists?/2` should return bare booleans or `{:ok, boolean} | {:error, reason}`; tests should match the Task 02 behavior contract once implemented.
+- Confirm the exact safe reason tokens for oversized file, unreadable file, and missing file. Scenarios require tokenized errors but do not require specific atom names unless Task 02/03 define them.
+- `LEMMINGS_ARTIFACT_STORAGE_ROOT` is the only runtime env var for Artifact storage root in this MVP.
+
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Completed the local Artifact storage scenario plan directly in this task file.
+- Covered storage backend, adapter/config contract, Artifact context integration, durable download behavior, observability, docs, security, accessibility scope, and release validation.
+- Included explicit negative/security cases for traversal, symlink escape, path leakage, oversized files, missing managed files, unsafe metadata, and forbidden durable audit persistence through `LemmingsOs.Events`.
+- Mapped follow-on coverage to Task 06 target test files and implementation tasks.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/02_adapter_config_contract.md
+++ b/llms/tasks/0011_local_artifact_storage/02_adapter_config_contract.md
@@ -1,8 +1,8 @@
 # Task 02: Adapter Config Contract
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior Elixir/Phoenix backend engineer for contexts, configuration, behaviours, and safe filesystem boundaries.
@@ -27,7 +27,7 @@ Introduce the backend adapter seam and lock configuration behavior without dupli
 - [ ] `LemmingsOs.Artifacts.Storage.Adapter` behaviour exists.
 - [ ] Existing `LemmingsOs.Artifacts.LocalStorage` implements or delegates behind the behaviour.
 - [ ] V1 callbacks are write/open/path/existence/health only; no physical delete callback.
-- [ ] Config prefers `LEMMINGS_ARTIFACT_STORAGE_ROOT`, optionally falling back to deprecated `LEMMINGS_ARTIFACT_STORAGE_PATH`.
+- [ ] Config uses `LEMMINGS_ARTIFACT_STORAGE_ROOT` for runtime root overrides.
 - [ ] Default `max_file_size_bytes` is `100 * 1024 * 1024`.
 - [ ] Focused compile/config tests or equivalent assertions are added where useful.
 
@@ -64,7 +64,11 @@ config/test.exs                              # Test defaults
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Added `LemmingsOs.Artifacts.Storage.Adapter` with `put/4`, `open/2`, `path_for/2`, `exists?/2`, and `health_check/1`; no physical delete callback exists.
+- Wired `LemmingsOs.Artifacts.LocalStorage` to implement the behavior while preserving existing public helpers and canonical `local://artifacts/<world_id>/<artifact_id>/<safe_filename>` refs.
+- Updated artifact storage config to include `max_file_size_bytes: 100 * 1024 * 1024`.
+- Updated runtime config to use `LEMMINGS_ARTIFACT_STORAGE_ROOT` for Artifact storage root overrides.
+- Added focused adapter/config tests.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/02_adapter_config_contract.md
+++ b/llms/tasks/0011_local_artifact_storage/02_adapter_config_contract.md
@@ -1,0 +1,70 @@
+# Task 02: Adapter Config Contract
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior Elixir/Phoenix backend engineer for contexts, configuration, behaviours, and safe filesystem boundaries.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Implement only the adapter behaviour and configuration contract for local Artifact storage.
+
+## Objective
+Introduce the backend adapter seam and lock configuration behavior without duplicating the existing `LemmingsOs.Artifacts.LocalStorage` implementation.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/01_storage_test_scenarios.md`
+- [ ] `lib/lemmings_os/artifacts/local_storage.ex`
+- [ ] `config/config.exs`, `config/runtime.exs`, `config/test.exs`
+
+## Expected Outputs
+- [ ] `LemmingsOs.Artifacts.Storage.Adapter` behaviour exists.
+- [ ] Existing `LemmingsOs.Artifacts.LocalStorage` implements or delegates behind the behaviour.
+- [ ] V1 callbacks are write/open/path/existence/health only; no physical delete callback.
+- [ ] Config prefers `LEMMINGS_ARTIFACT_STORAGE_ROOT`, optionally falling back to deprecated `LEMMINGS_ARTIFACT_STORAGE_PATH`.
+- [ ] Default `max_file_size_bytes` is `100 * 1024 * 1024`.
+- [ ] Focused compile/config tests or equivalent assertions are added where useful.
+
+## Acceptance Criteria
+- [ ] No new independent local adapter duplicates `LocalStorage` behavior.
+- [ ] Canonical refs remain `local://artifacts/<world_id>/<artifact_id>/<safe_filename>`.
+- [ ] No physical deletion path is introduced.
+- [ ] Public functions added or materially changed have `@doc` where important.
+- [ ] Narrow relevant tests pass.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts/local_storage.ex   # Existing local backend
+lib/lemmings_os/artifacts/storage/           # New behaviour location if introduced
+config/runtime.exs                           # Runtime env handling
+config/config.exs                            # Defaults
+config/test.exs                              # Test defaults
+```
+
+### Constraints
+- Do not change Artifact context/download behavior in this task.
+- Do not implement atomic copy hardening yet unless required by a small interface compile fix.
+- Do not persist `LemmingsOs.Events` audit rows.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs.
+2. Add the behaviour and wire existing `LocalStorage` to it.
+3. Update config/env handling and max-size default.
+4. Run targeted compile/tests for touched files.
+5. Document changed files, commands, assumptions, and any follow-up constraints.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/03_local_storage_hardening.md
+++ b/llms/tasks/0011_local_artifact_storage/03_local_storage_hardening.md
@@ -1,8 +1,8 @@
 # Task 03: Local Storage Hardening
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior backend engineer for filesystem safety, tuple-return APIs, and deterministic tests.
@@ -68,7 +68,12 @@ test/lemmings_os/artifacts/local_storage_test.exs
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Hardened `LemmingsOs.Artifacts.LocalStorage` writes to stream through a temp file in the destination directory and atomically rename into place.
+- Enforced configured `max_file_size_bytes` during copy and return `:file_too_large` without leaving a final managed file.
+- Kept checksum and size calculation based on the managed destination file.
+- Added best-effort private permissions for storage directories and files.
+- Implemented explicit tuple-return `open/2`, `exists?/2`, `path_for/2`, and writable `health_check/1` behavior.
+- Added focused tests for temp cleanup, oversized writes, permissions, symlink rejection, open shape, and health checks.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/03_local_storage_hardening.md
+++ b/llms/tasks/0011_local_artifact_storage/03_local_storage_hardening.md
@@ -1,0 +1,74 @@
+# Task 03: Local Storage Hardening
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for filesystem safety, tuple-return APIs, and deterministic tests.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Harden `LemmingsOs.Artifacts.LocalStorage` only.
+
+## Objective
+Make the local storage backend safe and complete: atomic writes, max-size enforcement, permissions, structured open/path/existence APIs, and health checks.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Task 01 scenario matrix
+- [ ] Task 02 output
+- [ ] `lib/lemmings_os/artifacts/local_storage.ex`
+- [ ] `test/lemmings_os/artifacts/local_storage_test.exs`
+
+## Expected Outputs
+- [ ] Writes/copies use a temp file in the target directory and atomic rename.
+- [ ] Max file size is enforced during write/copy.
+- [ ] `size_bytes` and SHA-256 are computed from managed storage.
+- [ ] Best-effort directory/file permissions are applied where supported.
+- [ ] `open/2`, `exists?/2`, `path_for/2`, and `health_check/1` return explicit tuples.
+- [ ] `open/2` contract is `{:ok, %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}} | {:error, reason_token}`.
+- [ ] Path safety preserves traversal, absolute path, separator, null byte, control char, and symlink-escape rejection.
+- [ ] Any trusted storage path is resolved/expanded and verified to remain inside the configured storage root before it is opened or returned.
+- [ ] Focused storage tests cover success and failure paths.
+
+## Acceptance Criteria
+- [ ] Failed writes do not leave a ready-looking final managed file.
+- [ ] Successful writes do not leave temp files behind.
+- [ ] `open/2` returns an internal trusted path only after storage ref validation and root-bound resolution.
+- [ ] Structured errors never include absolute paths, root path, raw workspace paths, file contents, or exception dumps.
+- [ ] Symlinks inside the storage root that point outside the root are rejected before open/path return.
+- [ ] Health check verifies root create/writable/temp create/remove behavior.
+- [ ] Targeted local storage tests pass.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts/local_storage.ex
+test/lemmings_os/artifacts/local_storage_test.exs
+```
+
+### Constraints
+- Do not change controller/download behavior in this task.
+- Do not add dependencies.
+- Keep permission tests tolerant of OS/container differences.
+- Do not persist `LemmingsOs.Events` audit rows.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs and current tests.
+2. Harden storage internals behind existing public helpers where possible.
+3. Add focused unit tests for new backend behavior.
+4. Run targeted storage tests.
+5. Document files changed, commands, residual risks, and assumptions.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/04_artifact_context_and_downloads.md
+++ b/llms/tasks/0011_local_artifact_storage/04_artifact_context_and_downloads.md
@@ -1,0 +1,79 @@
+# Task 04: Artifact Context And Downloads
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-backend-elixir-engineer` - Senior backend engineer for Phoenix contexts, controllers, and scoped APIs.
+
+## Agent Invocation
+Act as `dev-backend-elixir-engineer`. Wire the hardened storage backend through the Artifact context and durable download controller path.
+
+## Objective
+Move trusted Artifact file opening behind scoped context/storage APIs and ensure missing/broken storage failures are safe and recoverable.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-03 outputs
+- [ ] `lib/lemmings_os/artifacts.ex`
+- [ ] `lib/lemmings_os/artifacts/artifact.ex`
+- [ ] `lib/lemmings_os/artifacts/promotion.ex`
+- [ ] `lib/lemmings_os_web/controllers/instance_artifact_controller.ex`
+
+## Expected Outputs
+- [ ] Trusted Artifact context open/download function performs scope/status checks before storage access.
+- [ ] Context open/download success returns `{:ok, %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}}` for trusted controller use.
+- [ ] Controller no longer resolves storage refs and calls `File.read/1` directly.
+- [ ] Missing/unreadable/broken managed files return safe 404 responses without leakage.
+- [ ] Ready Artifacts are marked `error` with safe metadata where applicable.
+- [ ] The read/open mutation that marks a ready Artifact as `error` is documented as an intentional storage consistency repair, not a general read mutation pattern.
+- [ ] `Artifact` metadata validation accepts only the approved storage error keys in addition to existing source metadata.
+- [ ] Existing `:update_existing` and `:promote_as_new` behavior remains intact.
+
+## Acceptance Criteria
+- [ ] Web layer calls context/storage boundary, not raw resolved file paths directly.
+- [ ] Controller uses the trusted path only after context scope/status checks succeed.
+- [ ] Public descriptors still exclude `storage_ref` and filesystem paths.
+- [ ] Failed first-time storage writes do not create misleading ready rows.
+- [ ] Failed replacement before safe rename does not corrupt existing valid metadata.
+- [ ] Download/read tests cover the intentional missing/unreadable storage repair side effect.
+- [ ] Targeted context/controller tests pass.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts.ex
+lib/lemmings_os/artifacts/artifact.ex
+lib/lemmings_os/artifacts/promotion.ex
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+test/lemmings_os/artifacts_test.exs
+test/lemmings_os/artifacts/promotion_test.exs
+test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+```
+
+### Constraints
+- Do not add persistent audit events.
+- Do not broaden download authorization rules or UI behavior.
+- Do not introduce any other read-path DB mutations beyond the explicit storage-missing/unreadable repair path.
+- Do not physically delete files for soft-deleted Artifacts.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs and current controller tests.
+2. Add the scoped context/open boundary and wire the controller through it.
+3. Extend metadata validation narrowly for storage errors.
+4. Add or update focused tests.
+5. Run targeted context/controller tests and document results.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/04_artifact_context_and_downloads.md
+++ b/llms/tasks/0011_local_artifact_storage/04_artifact_context_and_downloads.md
@@ -1,8 +1,8 @@
 # Task 04: Artifact Context And Downloads
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 `dev-backend-elixir-engineer` - Senior backend engineer for Phoenix contexts, controllers, and scoped APIs.
@@ -73,7 +73,11 @@ test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Added `Artifacts.open_artifact_download/2` as the trusted scoped download/open boundary.
+- Updated durable artifact downloads to use the Artifact context before reading the trusted opened path.
+- Missing or invalid ready storage now returns safe not-found behavior and marks the Artifact `error` with safe storage error metadata.
+- Extended `Artifact` metadata validation for only `storage_error_reason`, `storage_error_operation`, and `storage_error_at`, preserving the existing `source` contract.
+- Added context, controller, schema, and promotion tests for repair behavior, metadata validation, oversized first writes, and failed replacement preservation.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/05_storage_observability.md
+++ b/llms/tasks/0011_local_artifact_storage/05_storage_observability.md
@@ -1,8 +1,8 @@
 # Task 05: Storage Observability
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `dev-logging-daily-guardian` - Logging quality guardian for structured safe metadata and telemetry consistency.
@@ -68,7 +68,11 @@ lib/lemmings_os/runtime/activity_log.ex   # In-memory feed; not required for thi
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Added safe Logger metadata and canonical `:telemetry` events for local storage write, open, and health-check outcomes.
+- Telemetry events use `[:lemmings_os, :artifact_storage, ...]` atom-list names for write start/stop/exception, open stop/exception, and health_check stop/exception.
+- Metadata is limited to ids, operation, sanitized filename token, size/checksum, status, and normalized reason tokens.
+- Added tests for write/open/health telemetry, metadata leakage prevention, and safe failure logs.
+- Verified no durable `LemmingsOs.Events` persistence is used in artifact storage/controller paths.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/05_storage_observability.md
+++ b/llms/tasks/0011_local_artifact_storage/05_storage_observability.md
@@ -1,0 +1,74 @@
+# Task 05: Storage Observability
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`dev-logging-daily-guardian` - Logging quality guardian for structured safe metadata and telemetry consistency.
+
+## Agent Invocation
+Act as `dev-logging-daily-guardian`. Add or review only local Artifact storage observability. You may add narrow Logger/telemetry instrumentation and focused tests, but you must not change storage behavior.
+
+## Objective
+Ensure storage write/update/open/health paths emit safe Logger metadata and telemetry while explicitly avoiding durable audit/event persistence for this issue.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-04 outputs
+- [ ] `lib/lemmings_os/artifacts/local_storage.ex`
+- [ ] `lib/lemmings_os/artifacts.ex`
+- [ ] Existing logging/telemetry patterns under `lib/lemmings_os/**`
+
+## Expected Outputs
+- [ ] Safe `Logger` metadata for storage success/failure paths where useful.
+- [ ] Safe `:telemetry.execute/3` events for storage write/update/open/health outcomes.
+- [ ] Canonical telemetry event names use atom-list events: `[:lemmings_os, :artifact_storage, :write, :start]`, `[:lemmings_os, :artifact_storage, :write, :stop]`, `[:lemmings_os, :artifact_storage, :write, :exception]`, `[:lemmings_os, :artifact_storage, :open, :stop]`, `[:lemmings_os, :artifact_storage, :open, :exception]`, `[:lemmings_os, :artifact_storage, :health_check, :stop]`, and `[:lemmings_os, :artifact_storage, :health_check, :exception]`.
+- [ ] Artifact update/replacement uses the same storage write telemetry events; use metadata `operation: :update` when distinguishing replacement from first write is useful.
+- [ ] String-style names such as `"artifact.storage.write.succeeded"` are used only for Logger `:event` metadata or log messages, not telemetry event names.
+- [ ] Metadata includes hierarchy ids where available, operation, reason token, size/checksum where safe.
+- [ ] Metadata excludes absolute paths, root path, raw workspace path, file contents, full metadata, notes, and secrets.
+- [ ] No Artifact storage audit/telemetry rows are persisted with `LemmingsOs.Events`.
+- [ ] Focused observability tests or test guidance for Task 06.
+
+## Acceptance Criteria
+- [ ] Telemetry event names match the canonical atom-list shapes from this task.
+- [ ] All emitted telemetry has hierarchy metadata where available.
+- [ ] Reason values are normalized safe tokens, not inspected exceptions with paths.
+- [ ] `rg "Events.record_event|LemmingsOs.Events"` in Artifact storage paths shows no new durable event persistence for this feature.
+- [ ] Tests or documented assertions verify forbidden fields are absent.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts/local_storage.ex
+lib/lemmings_os/artifacts.ex
+lib/lemmings_os/events.ex                 # Durable events API; do not use for this issue
+lib/lemmings_os/runtime/activity_log.ex   # In-memory feed; not required for this issue
+```
+
+### Constraints
+- May add narrow Logger/telemetry instrumentation and focused tests.
+- Must not change storage behavior, storage refs, file writing, path resolution, or download semantics.
+- Do not write durable audit rows through `LemmingsOs.Events`.
+- Do not log file contents, host paths, workspace paths, notes, full metadata, or secrets.
+- Do not broaden feature behavior.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs and current observability patterns.
+2. Add or adjust safe Logger/telemetry only where useful.
+3. Verify no durable Artifact storage audit persistence was introduced.
+4. Run targeted tests or compilation checks.
+5. Document metadata shape, commands, and any residual risk.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/06_storage_test_coverage.md
+++ b/llms/tasks/0011_local_artifact_storage/06_storage_test_coverage.md
@@ -1,8 +1,8 @@
 # Task 06: Storage Test Coverage
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `qa-elixir-test-author` - QA-driven Elixir test writer for ExUnit unit, integration, controller, and telemetry tests.
@@ -64,7 +64,9 @@ test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Expanded ExUnit coverage across storage, schema, context, promotion, controller, config, and observability layers.
+- Covered adapter callback contract/no delete callback, canonical refs, unsafe names/refs, symlink rejection across write/path/open/existence, temp cleanup, max size, permissions, open shape, health checks, storage error metadata, failed promotion/update behavior, safe downloads, repair-to-error behavior, telemetry metadata, safe logs, and no durable audit persistence.
+- Targeted artifact/config/controller suite passed with `20 doctests, 71 tests, 0 failures`.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/06_storage_test_coverage.md
+++ b/llms/tasks/0011_local_artifact_storage/06_storage_test_coverage.md
@@ -1,0 +1,70 @@
+# Task 06: Storage Test Coverage
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`qa-elixir-test-author` - QA-driven Elixir test writer for ExUnit unit, integration, controller, and telemetry tests.
+
+## Agent Invocation
+Act as `qa-elixir-test-author`. Implement or complete ExUnit coverage for local Artifact storage after backend work is in place.
+
+## Objective
+Convert the scenario matrix and implementation behavior into deterministic ExUnit coverage across storage, Artifact context, controller/downloads, metadata validation, and observability safety.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-05 outputs
+- [ ] Existing tests under `test/lemmings_os/artifacts*`
+- [ ] `test/lemmings_os_web/controllers/instance_artifact_controller_test.exs`
+
+## Expected Outputs
+- [ ] Storage unit tests for atomic write, temp cleanup, max size, checksum/size, path safety, open/path/existence, and health check.
+- [ ] Storage/context tests assert `open/2` success shape: `{:ok, %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}}`.
+- [ ] Schema/context tests for safe storage error metadata and rejected unsafe metadata.
+- [ ] Promotion/update tests for unchanged metadata on failed replacement.
+- [ ] Controller tests for safe downloads, wrong scope/status, missing/broken storage, and leakage prevention.
+- [ ] Telemetry/log tests or assertions for safe metadata and no durable `Events` persistence.
+- [ ] Narrow-to-broad test command evidence.
+
+## Acceptance Criteria
+- [ ] Tests are deterministic, use factories/temp dirs, and restore app env in `on_exit`.
+- [ ] No external network or timing-sensitive assertions.
+- [ ] No broad raw HTML assertions except targeted leakage checks.
+- [ ] Tests fail for the main regressions identified in Task 01.
+- [ ] Targeted tests pass.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+test/lemmings_os/artifacts/local_storage_test.exs
+test/lemmings_os/artifacts/artifact_test.exs
+test/lemmings_os/artifacts/promotion_test.exs
+test/lemmings_os/artifacts_test.exs
+test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+```
+
+### Constraints
+- Do not introduce fixture-style helpers or `*_fixture` naming.
+- Keep permission tests platform-tolerant.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs and scenario matrix.
+2. Add focused tests in the appropriate test layers.
+3. Run narrow relevant tests first.
+4. Run broader tests only as needed for confidence.
+5. Document commands, outputs, files changed, and residual gaps.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/07_feature_documentation.md
+++ b/llms/tasks/0011_local_artifact_storage/07_feature_documentation.md
@@ -1,0 +1,63 @@
+# Task 07: Feature Documentation
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`docs-feature-documentation-author` - Feature documentation writer aligned with actual application behavior.
+
+## Agent Invocation
+Act as `docs-feature-documentation-author`. Update operator/self-host documentation for local Artifact storage.
+
+## Objective
+Document the local Artifact storage operational contract after implementation is complete.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-06 outputs
+- [ ] Existing docs under `docs/` and `README.md`
+- [ ] Final implemented config behavior from `config/runtime.exs`
+
+## Expected Outputs
+- [ ] Docs mention `LEMMINGS_ARTIFACT_STORAGE_ROOT` and optional deprecated `LEMMINGS_ARTIFACT_STORAGE_PATH` fallback if implemented.
+- [ ] Docs explain DB metadata vs filesystem bytes split.
+- [ ] Docs explain required persistent volume for Docker/self-host deployments.
+- [ ] Docs state DB-only backup is insufficient; DB and artifact volume must both be backed up.
+- [ ] Docs state soft-deleted Artifacts are not physically purged in this issue.
+- [ ] Docs state S3/MinIO, cleanup/retention, encryption-at-rest beyond FS permissions, scanning, previews, RAG ingestion, cross-City shared storage, and versioning are future work.
+
+## Acceptance Criteria
+- [ ] Documentation matches actual implemented env var names and defaults.
+- [ ] No docs imply automatic cleanup, cross-City shared storage, object storage support, or content scanning.
+- [ ] Docs are operator-readable and concise.
+- [ ] Markdown formatting is clean.
+
+## Technical Notes
+### Relevant Documentation Locations
+```text
+docs/features/                 # Feature docs if present
+README.md                      # Feature/config links if appropriate
+llms/tasks/0011_local_artifact_storage/plan.md
+```
+
+### Constraints
+- Do not change executable code in this task unless fixing a typo in docs references requires it.
+- Do not invent behavior not implemented in Tasks 02-06.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read implementation summaries and current docs.
+2. Update the narrowest relevant docs.
+3. Verify docs reflect actual config and out-of-scope boundaries.
+4. Document files changed and any doc gaps.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/07_feature_documentation.md
+++ b/llms/tasks/0011_local_artifact_storage/07_feature_documentation.md
@@ -1,8 +1,8 @@
 # Task 07: Feature Documentation
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `docs-feature-documentation-author` - Feature documentation writer aligned with actual application behavior.
@@ -22,7 +22,7 @@ Document the local Artifact storage operational contract after implementation is
 - [ ] Final implemented config behavior from `config/runtime.exs`
 
 ## Expected Outputs
-- [ ] Docs mention `LEMMINGS_ARTIFACT_STORAGE_ROOT` and optional deprecated `LEMMINGS_ARTIFACT_STORAGE_PATH` fallback if implemented.
+- [ ] Docs mention `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
 - [ ] Docs explain DB metadata vs filesystem bytes split.
 - [ ] Docs explain required persistent volume for Docker/self-host deployments.
 - [ ] Docs state DB-only backup is insufficient; DB and artifact volume must both be backed up.
@@ -57,7 +57,10 @@ llms/tasks/0011_local_artifact_storage/plan.md
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Updated `docs/features/artifacts.md` with the implemented local storage contract.
+- Documented `LEMMINGS_ARTIFACT_STORAGE_ROOT`, default max file size, local layout, and local-only backend behavior.
+- Documented the Postgres metadata vs filesystem bytes split, persistent volume requirement, and DB-plus-artifact-volume backup requirement.
+- Documented soft-delete non-purge behavior and future-work boundaries including S3/MinIO, cleanup/retention, scanning, previews, RAG ingestion, cross-City storage, and versioning.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/08_accessibility_scope_review.md
+++ b/llms/tasks/0011_local_artifact_storage/08_accessibility_scope_review.md
@@ -1,8 +1,8 @@
 # Task 08: Accessibility Scope Review
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `audit-accessibility` - Accessibility auditor for Phoenix LiveView interfaces and WCAG-impacting UI changes.
@@ -52,7 +52,10 @@ lib/lemmings_os_web/controllers/instance_artifact_controller.ex
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+- Reviewed the implementation diff for UI-impacting files.
+- No LiveView, HEEx template, or component changes were introduced.
+- The only web-layer implementation change was controller download plumbing through the trusted Artifact context/storage boundary; it does not alter rendered UI, keyboard behavior, focus behavior, ARIA, or semantic markup.
+- Accessibility review is not applicable for this backend/docs/test slice.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/08_accessibility_scope_review.md
+++ b/llms/tasks/0011_local_artifact_storage/08_accessibility_scope_review.md
@@ -1,0 +1,58 @@
+# Task 08: Accessibility Scope Review
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-accessibility` - Accessibility auditor for Phoenix LiveView interfaces and WCAG-impacting UI changes.
+
+## Agent Invocation
+Act as `audit-accessibility`. Confirm whether this storage backend work introduced accessibility-impacting UI changes; perform a focused review only if it did.
+
+## Objective
+Close the accessibility concern for this backend-focused issue without manufacturing unnecessary UI work.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-07 outputs
+- [ ] Final implementation diff
+
+## Expected Outputs
+- [ ] Statement confirming no accessibility-impacting UI changes were introduced, or a focused accessibility review if UI changed.
+- [ ] Findings documented in this task file, ordered by severity if any.
+- [ ] Focused fixes only for confirmed in-scope accessibility regressions if safe.
+
+## Acceptance Criteria
+- [ ] If no LiveView/HEEx/operator UI changed, task records accessibility review as not applicable for this backend slice.
+- [ ] If UI changed, keyboard/focus/semantic/ARIA/accessibility behavior is reviewed against affected UI only.
+- [ ] Any fixes are narrow and validated with relevant tests or manual inspection notes.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os_web/live/
+lib/lemmings_os_web/components/
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+```
+
+### Constraints
+- Do not broaden the feature into new UI work.
+- Do not audit unrelated pages.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Inspect final diff for UI/HEEx/LiveView changes.
+2. If none, document that accessibility is out of scope for this implementation.
+3. If UI changed, perform focused accessibility review and document findings/fixes.
+4. Run relevant checks only for any fixes made.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/09_security_audit.md
+++ b/llms/tasks/0011_local_artifact_storage/09_security_audit.md
@@ -1,0 +1,66 @@
+# Task 09: Security Audit
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-security` - Security reviewer for input validation, authorization, secrets, logging, and data leakage risk.
+
+## Agent Invocation
+Act as `audit-security`. Review the completed local Artifact storage implementation for security issues and implement narrow fixes for confirmed in-scope findings.
+
+## Objective
+Verify local Artifact storage cannot escape the configured root, leak sensitive paths/content, weaken scope checks, or introduce secret/audit persistence risks.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-08 outputs
+- [ ] Full implementation diff
+- [ ] Relevant test results
+
+## Expected Outputs
+- [ ] Findings-first security audit documented in this task file.
+- [ ] Review of path traversal, absolute path handling, symlink escape, null/control chars, filename separators, permissions, and max size.
+- [ ] Review of scope/status checks before storage open/download.
+- [ ] Review of error metadata, logs, telemetry, and controller responses for path/content/secret leakage.
+- [ ] Confirmation no Artifact storage durable audit rows are persisted through `LemmingsOs.Events`.
+- [ ] Focused fixes and regression tests for confirmed findings where safe.
+
+## Acceptance Criteria
+- [ ] High/medium findings are fixed or explicitly documented as blockers.
+- [ ] No SecretBank coupling is added to Artifact storage.
+- [ ] No file contents, absolute paths, root paths, raw workspace paths, full metadata, notes, or secrets leak through DB/logs/events/responses.
+- [ ] Targeted tests or grep evidence back security claims.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts.ex
+lib/lemmings_os/artifacts/local_storage.ex
+lib/lemmings_os/artifacts/artifact.ex
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+test/lemmings_os/artifacts*
+test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+```
+
+### Constraints
+- Do not broaden authorization or UI scope beyond confirmed defects.
+- Do not perform git operations.
+
+## Execution Instructions
+1. Read all inputs and inspect final diff.
+2. Produce findings first, ordered by severity with file/line references.
+3. Implement narrow fixes only for confirmed in-scope issues.
+4. Run targeted tests for fixes.
+5. Document residual risks and evidence.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/09_security_audit.md
+++ b/llms/tasks/0011_local_artifact_storage/09_security_audit.md
@@ -1,8 +1,8 @@
 # Task 09: Security Audit
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `audit-security` - Security reviewer for input validation, authorization, secrets, logging, and data leakage risk.
@@ -60,7 +60,28 @@ test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Findings
+
+1. **Medium - unsafe persisted filenames could enter Logger/telemetry metadata.**
+   - Location: `LemmingsOs.Artifacts.LocalStorage.open/2` observability metadata.
+   - Impact: an Artifact row can contain control characters in `filename`; HTTP headers sanitize that value, but storage open Logger/telemetry metadata previously received the raw filename.
+   - Fix: storage metadata now sanitizes filename values before Logger/telemetry emission, stripping control characters and path separators and truncating to 255 bytes. Added regression coverage for CR/LF filename metadata.
+
+2. **No high findings.**
+
+### Review Notes
+
+- Path traversal, absolute paths, separators, null/control characters, drive prefixes, and leading `~` filenames are rejected by `LocalStorage` validation.
+- Storage refs are parsed as `local://artifacts/<world_id>/<artifact_id>/<filename>`, validate UUIDs and filename shape, reject query/fragment, and resolve under the configured root before returning/opening paths.
+- Symlink components under the storage root are rejected before `path_for/2`, `exists?/2`, `open/2`, or writes return/access a managed path.
+- Downloads now call `Artifacts.open_artifact_download/2`, which checks scope/status before storage open and repairs missing/broken ready storage to `error` with safe metadata.
+- Storage error metadata is limited to `storage_error_reason`, `storage_error_operation`, and `storage_error_at`; values reject paths, control characters, drive-style strings, and non-strings.
+- Logger/telemetry metadata uses ids, operation, filename token, size/checksum, and normalized reason tokens only; tests assert no root/source path/ref/content leakage on representative paths.
+- `rg "Events.record_event|LemmingsOs.Events" lib/lemmings_os/artifacts lib/lemmings_os_web/controllers/instance_artifact_controller.ex` returned no matches, confirming no durable Artifact storage audit rows were introduced.
+
+### Evidence
+
+- Targeted suite passed: `mix test test/lemmings_os/artifacts/local_storage_test.exs test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os/config/runtime_artifact_storage_config_test.exs`.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/10_staff_elixir_pr_audit.md
+++ b/llms/tasks/0011_local_artifact_storage/10_staff_elixir_pr_audit.md
@@ -1,8 +1,8 @@
 # Task 10: Staff Elixir PR Audit
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `audit-pr-elixir` - Staff-level PR reviewer for Elixir/Phoenix correctness, design, security, performance, logging, and tests.
@@ -62,7 +62,29 @@ docs/
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Findings
+
+1. **Medium - invalid-ref observability fallback bypassed filename sanitization.**
+   - Location: `LemmingsOs.Artifacts.LocalStorage.storage_ref_metadata/2`.
+   - Impact: the valid storage-ref metadata path sanitized filenames, but invalid storage refs used the caller-provided filename directly in Logger/telemetry metadata.
+   - Fix: both invalid-ref fallback branches now sanitize filename metadata with the same helper. Regression coverage was added to the open-failure telemetry test.
+
+2. **No high findings.**
+
+### Checklist
+
+- Adapter design: `LemmingsOs.Artifacts.Storage.Adapter` exposes `put/4`, `open/2`, `path_for/2`, `exists?/2`, and `health_check/1`; no physical delete callback exists.
+- Context boundary: durable downloads now call `Artifacts.open_artifact_download/2`, which checks scope/status before storage open.
+- Filesystem safety: root-bound resolution, symlink component rejection, max-size enforcement, temp+rename writes, and best-effort private permissions are covered.
+- Metadata validation: storage error metadata keys are narrowly allowed and reject unsafe values.
+- Observability: telemetry names match the canonical atom-list events, Logger metadata uses safe tokens, and no durable `LemmingsOs.Events` writes are introduced.
+- Style: no `String.to_atom/1`, no map access syntax on structs, public behavior/context additions have docs, and env-mutating tests restore prior config.
+- Tests: focused storage/context/schema/controller/config coverage passes deterministically with temp dirs and sandboxed database tests.
+
+### Evidence
+
+- `mix compile --warnings-as-errors` passed.
+- Targeted suite passed: `mix test test/lemmings_os/artifacts/local_storage_test.exs test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os/config/runtime_artifact_storage_config_test.exs`.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/10_staff_elixir_pr_audit.md
+++ b/llms/tasks/0011_local_artifact_storage/10_staff_elixir_pr_audit.md
@@ -1,0 +1,68 @@
+# Task 10: Staff Elixir PR Audit
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`audit-pr-elixir` - Staff-level PR reviewer for Elixir/Phoenix correctness, design, security, performance, logging, and tests.
+
+## Agent Invocation
+Act as `audit-pr-elixir`. Perform a staff-level Elixir/Phoenix review of the full local Artifact storage implementation.
+
+## Objective
+Catch correctness, style, maintainability, performance, logging, and regression issues before release validation.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-09 outputs
+- [ ] Full implementation diff and test results
+
+## Expected Outputs
+- [ ] Findings-first staff audit documented in this task file.
+- [ ] Constitution/style compliance checklist.
+- [ ] Review of adapter design, context boundaries, scoped APIs, filesystem safety, metadata validation, telemetry/logging, docs alignment, and test quality.
+- [ ] Focused fixes and tests for confirmed findings where safe.
+
+## Acceptance Criteria
+- [ ] Findings are ordered by severity with file/line references.
+- [ ] Explicit World/scope boundaries are verified.
+- [ ] Tuple-return and public-doc expectations are checked.
+- [ ] No map access syntax on structs or unsafe atom creation is introduced.
+- [ ] Tests are deterministic and aligned with style guide.
+- [ ] Targeted tests pass after any fixes.
+
+## Technical Notes
+### Relevant Code Locations
+```text
+lib/lemmings_os/artifacts*
+lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+config/*.exs
+test/lemmings_os/artifacts*
+test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+docs/
+```
+
+### Constraints
+- Do not perform git operations.
+- Do not broaden feature scope.
+- Do not hide failures; document blockers clearly.
+
+## Execution Instructions
+1. Read all inputs.
+2. Review implementation against plan, constitution, and coding styles.
+3. Document findings first.
+4. Implement narrow fixes only for confirmed in-scope issues.
+5. Run targeted tests and document results.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/11_release_validation.md
+++ b/llms/tasks/0011_local_artifact_storage/11_release_validation.md
@@ -1,0 +1,73 @@
+# Task 11: Release Validation
+
+## Status
+- **Status**: ⏳ PENDING
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+`rm-release-manager` - Release manager for validation evidence, rollout risk, rollback notes, and final sign-off preparation.
+
+## Agent Invocation
+Act as `rm-release-manager`. Prepare final release validation for the local Artifact storage backend hardening.
+
+## Objective
+Close the issue with validation evidence, documentation/security/style review summary, operational notes, residual risks, and human sign-off checklist.
+
+## Inputs Required
+- [ ] `llms/constitution.md`
+- [ ] `llms/project_context.md`
+- [ ] `llms/coding_styles/elixir.md`
+- [ ] `llms/coding_styles/elixir_tests.md`
+- [ ] `llms/tasks/0011_local_artifact_storage/plan.md`
+- [ ] Tasks 01-10 outputs
+- [ ] Full implementation diff and final test results
+
+## Expected Outputs
+- [ ] Release validation summary documented in this task file.
+- [ ] Exact command evidence for narrow tests, broader tests as appropriate, `mix format`, and `mix precommit`.
+- [ ] Confirmation docs are updated and match implementation.
+- [ ] Confirmation final reviews covered docs, style/format, security/path leakage, accessibility scope, and regression risk.
+- [ ] Operational notes for storage root, persistent volume, backup, rollback, and orphan-file risk.
+- [ ] Human sign-off checklist.
+
+## Acceptance Criteria
+- [ ] Narrow relevant tests run and pass.
+- [ ] `mix format` run or formatting verified.
+- [ ] `mix precommit` passes with zero warnings/errors, or blocker is documented.
+- [ ] Docs mention storage root, backup, persistent volume, no cleanup, and future S3/MinIO.
+- [ ] Security and staff audit outputs have no unresolved high/medium blockers.
+- [ ] No persistent Artifact storage audit rows through `LemmingsOs.Events` are introduced.
+
+## Technical Notes
+### Suggested Commands
+```bash
+mix test test/lemmings_os/artifacts/local_storage_test.exs
+mix test test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os/artifacts_test.exs
+mix test test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+mix test
+mix format
+mix precommit
+rg -n "Events.record_event|LemmingsOs.Events" lib/lemmings_os/artifacts* lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+rg -n "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib/lemmings_os/artifacts* lib/lemmings_os_web/controllers/instance_artifact_controller.ex
+```
+Adjust commands to actual files changed.
+
+### Constraints
+- Do not perform git operations.
+- Do not approve release if final validation fails without a documented human waiver.
+- Do not hide residual risks.
+
+## Execution Instructions
+1. Read all task outputs and final diff.
+2. Run validation commands in narrow-to-broad order.
+3. Document command results exactly enough for human review.
+4. Summarize docs/security/style/accessibility/regression review status.
+5. Prepare rollback and residual risk notes.
+
+---
+
+## Execution Summary
+*[Filled by executing agent after completion]*
+
+## Human Review
+*[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/11_release_validation.md
+++ b/llms/tasks/0011_local_artifact_storage/11_release_validation.md
@@ -1,8 +1,8 @@
 # Task 11: Release Validation
 
 ## Status
-- **Status**: ⏳ PENDING
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETE
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 `rm-release-manager` - Release manager for validation evidence, rollout risk, rollback notes, and final sign-off preparation.
@@ -67,7 +67,28 @@ Adjust commands to actual files changed.
 ---
 
 ## Execution Summary
-*[Filled by executing agent after completion]*
+### Validation Commands
+
+- `mix format` passed.
+- `mix test test/lemmings_os/artifacts/local_storage_test.exs test/lemmings_os/artifacts/artifact_test.exs test/lemmings_os/artifacts_test.exs test/lemmings_os/artifacts/promotion_test.exs test/lemmings_os_web/controllers/instance_artifact_controller_test.exs test/lemmings_os/config/runtime_artifact_storage_config_test.exs` passed: `20 doctests, 71 tests, 0 failures`.
+- `mix test` passed: `162 doctests, 790 tests, 0 failures`.
+- `mix precommit` passed with Dialyzer total errors `0` and Credo `found no issues`.
+- `rg -n "Events.record_event|LemmingsOs.Events" lib/lemmings_os/artifacts lib/lemmings_os_web/controllers/instance_artifact_controller.ex` returned no matches.
+- `rg -n "SecretBank|SecretsBank|secret_bank|resolve_runtime_secret" lib/lemmings_os/artifacts lib/lemmings_os_web/controllers/instance_artifact_controller.ex` returned no matches.
+
+### Release Summary
+
+- Local Artifact storage now has an adapter behavior, hardened local backend, scoped context open/download boundary, safe storage-error repair metadata, Logger/telemetry observability, and expanded regression coverage.
+- Docs match implementation for `LEMMINGS_ARTIFACT_STORAGE_ROOT`, default max size, local layout, persistent volume requirements, DB plus artifact-volume backups, soft-delete non-purge behavior, and future object-storage/retention boundaries.
+- Accessibility review found no UI/HEEx/LiveView changes.
+- Security and staff Elixir audits found no unresolved high or medium blockers after the filename metadata sanitization fixes.
+
+### Operational Notes
+
+- Operators must put the artifact storage root on persistent storage in self-host/container deployments.
+- Backups must include both Postgres and the artifact storage root or volume.
+- Soft-deleted Artifacts are not physically purged; orphaned bytes can accumulate until a future cleanup/retention feature exists.
+- Rollback of this code does not remove files already written under the configured root; database rows and local bytes should be handled together if reverting a deployment.
 
 ## Human Review
 *[Filled by human reviewer]*

--- a/llms/tasks/0011_local_artifact_storage/plan.md
+++ b/llms/tasks/0011_local_artifact_storage/plan.md
@@ -13,7 +13,7 @@ This issue does not redefine Artifact lifecycle, promotion UI, download authoriz
 - `LemmingsOs.Artifacts.LocalStorage` already builds `local://artifacts/...` refs, resolves trusted refs under the configured root, copies files, and computes checksum/size.
 - `LemmingsOs.Artifacts.Promotion` already promotes workspace files and supports explicit `:update_existing` and `:promote_as_new` behavior.
 - `InstanceArtifactController.download/2` currently resolves storage refs and reads files directly for downloads after scope/status checks.
-- Runtime config currently reads `LEMMINGS_ARTIFACT_STORAGE_PATH`; this issue standardizes on `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
+- Runtime config standardizes on `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
 - `Artifact` metadata validation currently allows only empty metadata or `%{"source" => "manual_promotion"}`; it must be extended narrowly for safe storage error metadata.
 
 ## Decisions
@@ -25,7 +25,7 @@ This issue does not redefine Artifact lifecycle, promotion UI, download authoriz
 - V1 adapter callbacks are `put/4`, `open/2`, `path_for/2`, `exists?/2`, and `health_check/1`; do not include `delete/2` because physical deletion is out of scope.
 - `path_for/2` is trusted/internal only. Public Artifact APIs must not expose resolved filesystem paths.
 - `open/2` returns an internal trusted path only after the caller has performed Artifact scope/status checks. Its contract is `{:ok, %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}} | {:error, reason_token}`.
-- `LEMMINGS_ARTIFACT_STORAGE_ROOT` is the primary runtime env var. `LEMMINGS_ARTIFACT_STORAGE_PATH` may be supported only as a deprecated fallback to avoid breaking existing local envs.
+- `LEMMINGS_ARTIFACT_STORAGE_ROOT` is the runtime env var for the local storage root.
 - Default `max_file_size_bytes` is `100 * 1024 * 1024`.
 - Observability uses existing repo conventions: safe `Logger` metadata and `:telemetry.execute/3`; do not invent an undefined artifact event helper.
 - Canonical telemetry event names are atom-list events under `[:lemmings_os, :artifact_storage, ...]`. String-style names are allowed only in Logger `:event` metadata or log messages.
@@ -37,16 +37,16 @@ This issue does not redefine Artifact lifecycle, promotion UI, download authoriz
 | # | Task | Agent | Status | Approved |
 |---|------|-------|--------|----------|
 | 01 | Storage Test Scenarios | `qa-test-scenarios` | ⏳ PENDING | [ ] |
-| 02 | Adapter Config Contract | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
-| 03 | Local Storage Hardening | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
-| 04 | Artifact Context And Downloads | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
-| 05 | Storage Observability | `dev-logging-daily-guardian` | ⏳ PENDING | [ ] |
-| 06 | Storage Test Coverage | `qa-elixir-test-author` | ⏳ PENDING | [ ] |
-| 07 | Feature Documentation | `docs-feature-documentation-author` | ⏳ PENDING | [ ] |
-| 08 | Accessibility Scope Review | `audit-accessibility` | ⏳ PENDING | [ ] |
-| 09 | Security Audit | `audit-security` | ⏳ PENDING | [ ] |
-| 10 | Staff Elixir PR Audit | `audit-pr-elixir` | ⏳ PENDING | [ ] |
-| 11 | Release Validation | `rm-release-manager` | ⏳ PENDING | [ ] |
+| 02 | Adapter Config Contract | `dev-backend-elixir-engineer` | COMPLETE | [ ] |
+| 03 | Local Storage Hardening | `dev-backend-elixir-engineer` | COMPLETE | [ ] |
+| 04 | Artifact Context And Downloads | `dev-backend-elixir-engineer` | COMPLETE | [ ] |
+| 05 | Storage Observability | `dev-logging-daily-guardian` | COMPLETE | [ ] |
+| 06 | Storage Test Coverage | `qa-elixir-test-author` | COMPLETE | [ ] |
+| 07 | Feature Documentation | `docs-feature-documentation-author` | COMPLETE | [ ] |
+| 08 | Accessibility Scope Review | `audit-accessibility` | COMPLETE | [ ] |
+| 09 | Security Audit | `audit-security` | COMPLETE | [ ] |
+| 10 | Staff Elixir PR Audit | `audit-pr-elixir` | COMPLETE | [ ] |
+| 11 | Release Validation | `rm-release-manager` | COMPLETE | [ ] |
 
 Each task requires human approval before the next starts. Human reviewers own all git operations.
 
@@ -111,7 +111,7 @@ Each task requires human approval before the next starts. Human reviewers own al
 
 - [ ] `LemmingsOs.Artifacts.Storage.Adapter` exists with no physical delete callback in v1.
 - [ ] Existing `LemmingsOs.Artifacts.LocalStorage` implements or delegates behind the adapter without creating a duplicate local storage implementation.
-- [ ] Storage root is configurable through app config and `LEMMINGS_ARTIFACT_STORAGE_ROOT`, with `LEMMINGS_ARTIFACT_STORAGE_PATH` only as an optional deprecated fallback.
+- [ ] Storage root is configurable through app config and `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
 - [ ] Canonical persisted refs use `local://artifacts/<world_id>/<artifact_id>/<safe_filename>` and never absolute filesystem paths.
 - [ ] Storage path uses `<root>/<world_id>/<artifact_id>/<safe_filename>`.
 - [ ] Writes and explicit updates use temp file plus atomic rename.

--- a/llms/tasks/0011_local_artifact_storage/plan.md
+++ b/llms/tasks/0011_local_artifact_storage/plan.md
@@ -1,0 +1,145 @@
+# Implement local Artifact storage backend
+
+## Summary
+
+Implement and harden the existing local filesystem storage path for Artifacts.
+
+The repo already has the Artifact domain model, `LemmingsOs.Artifacts.LocalStorage`, promotion integration, durable artifact download routing, and focused tests. This task must harden that current implementation instead of creating a parallel storage system. The goal is a safe, adapter-shaped local backend for reading and writing Artifact bytes on disk, with a clean seam for future MinIO/S3-style backends.
+
+This issue does not redefine Artifact lifecycle, promotion UI, download authorization, or broad Artifact metadata semantics. It may make the narrow Artifact schema/changeset adjustment required to persist safe storage error metadata.
+
+## Current State
+
+- `LemmingsOs.Artifacts.LocalStorage` already builds `local://artifacts/...` refs, resolves trusted refs under the configured root, copies files, and computes checksum/size.
+- `LemmingsOs.Artifacts.Promotion` already promotes workspace files and supports explicit `:update_existing` and `:promote_as_new` behavior.
+- `InstanceArtifactController.download/2` currently resolves storage refs and reads files directly for downloads after scope/status checks.
+- Runtime config currently reads `LEMMINGS_ARTIFACT_STORAGE_PATH`; this issue standardizes on `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
+- `Artifact` metadata validation currently allows only empty metadata or `%{"source" => "manual_promotion"}`; it must be extended narrowly for safe storage error metadata.
+
+## Decisions
+
+- Canonical storage ref format is `local://artifacts/<world_id>/<artifact_id>/<safe_filename>`.
+- Physical layout is `<artifact_storage_root>/<world_id>/<artifact_id>/<safe_filename>`.
+- Keep `LemmingsOs.Artifacts.LocalStorage` as the local backend module unless a tiny adapter wrapper is cleaner; do not create a duplicate independent storage implementation.
+- Add `LemmingsOs.Artifacts.Storage.Adapter` behavior and make the existing local backend implement or delegate behind that behavior.
+- V1 adapter callbacks are `put/4`, `open/2`, `path_for/2`, `exists?/2`, and `health_check/1`; do not include `delete/2` because physical deletion is out of scope.
+- `path_for/2` is trusted/internal only. Public Artifact APIs must not expose resolved filesystem paths.
+- `open/2` returns an internal trusted path only after the caller has performed Artifact scope/status checks. Its contract is `{:ok, %{path: path, filename: filename, content_type: content_type, size_bytes: size_bytes}} | {:error, reason_token}`.
+- `LEMMINGS_ARTIFACT_STORAGE_ROOT` is the primary runtime env var. `LEMMINGS_ARTIFACT_STORAGE_PATH` may be supported only as a deprecated fallback to avoid breaking existing local envs.
+- Default `max_file_size_bytes` is `100 * 1024 * 1024`.
+- Observability uses existing repo conventions: safe `Logger` metadata and `:telemetry.execute/3`; do not invent an undefined artifact event helper.
+- Canonical telemetry event names are atom-list events under `[:lemmings_os, :artifact_storage, ...]`. String-style names are allowed only in Logger `:event` metadata or log messages.
+- Durable Artifact storage audit persistence via `LemmingsOs.Events` is out of scope. Storage operations may emit safe Logger metadata and `:telemetry` events only.
+- Accessibility review is out of scope unless implementation changes operator-facing UI or LiveView templates.
+
+## Task Sequence
+
+| # | Task | Agent | Status | Approved |
+|---|------|-------|--------|----------|
+| 01 | Storage Test Scenarios | `qa-test-scenarios` | ⏳ PENDING | [ ] |
+| 02 | Adapter Config Contract | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
+| 03 | Local Storage Hardening | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
+| 04 | Artifact Context And Downloads | `dev-backend-elixir-engineer` | ⏳ PENDING | [ ] |
+| 05 | Storage Observability | `dev-logging-daily-guardian` | ⏳ PENDING | [ ] |
+| 06 | Storage Test Coverage | `qa-elixir-test-author` | ⏳ PENDING | [ ] |
+| 07 | Feature Documentation | `docs-feature-documentation-author` | ⏳ PENDING | [ ] |
+| 08 | Accessibility Scope Review | `audit-accessibility` | ⏳ PENDING | [ ] |
+| 09 | Security Audit | `audit-security` | ⏳ PENDING | [ ] |
+| 10 | Staff Elixir PR Audit | `audit-pr-elixir` | ⏳ PENDING | [ ] |
+| 11 | Release Validation | `rm-release-manager` | ⏳ PENDING | [ ] |
+
+Each task requires human approval before the next starts. Human reviewers own all git operations.
+
+## Implementation Changes
+
+### Storage Backend
+
+- Add `LemmingsOs.Artifacts.Storage.Adapter` with explicit `{:ok, result} | {:error, reason}` callbacks for write/open/path/existence/health operations.
+- Refactor `LemmingsOs.Artifacts.LocalStorage` to satisfy the behavior while preserving existing public helpers where tests or callers already use them.
+- Replace direct `File.cp/2` destination writes with temp-file-in-same-directory plus atomic rename.
+- Enforce `max_file_size_bytes` before or during copy so oversized source files do not produce ready Artifacts.
+- Compute `size_bytes` and SHA-256 from the managed temp/final file and return them with the canonical storage ref.
+- Apply best-effort permissions where supported: directories `0700`, files `0600`.
+- Keep path safety behavior: reject path traversal, absolute paths, null bytes, control characters, separators inside filenames, symlink escape components, and empty filenames.
+- When resolving any trusted storage path, resolve/expand the final path and verify it remains inside the configured storage root before opening it or returning it. This must protect against symlinks inside the root that point outside the root even when traversal checks pass.
+- Add `exists?/2`, `open/2`, trusted `path_for/2`, and `health_check/1` on the backend. `open/2` must follow the locked return contract and return structured storage errors without exposing host paths in error values.
+
+### Artifact Context And Downloads
+
+- Add or update a trusted Artifact context function for download/open that performs scope/status checks first, then delegates file access to the storage backend and returns the `open/2` success shape to the controller.
+- Update `InstanceArtifactController.download/2` to use the trusted context/backend open path instead of resolving the storage ref and calling `File.read/1` directly.
+- Preserve explicit update behavior: `:update_existing` overwrites the managed file atomically and keeps the same Artifact row; `:promote_as_new` creates a new row.
+- Failed first-time storage writes must not create misleading ready Artifacts.
+- Failed updates before a safe replacement must leave the existing Artifact DB row and existing managed file metadata unchanged.
+- Missing/unreadable/broken managed files for ready Artifacts should return a structured storage error, produce a safe 404 at the controller boundary, and mark the Artifact as `error` where the context has enough information to do so.
+- A trusted read/open path may mark a ready Artifact as `error` when storage is missing or unreadable. This is an intentional repair/consistency side effect, not a general read mutation pattern.
+
+### Metadata, Config, And Observability
+
+- Extend `Artifact` metadata validation only enough to support safe storage error metadata while preserving the existing `source` contract.
+- Allowed storage error keys are `storage_error_reason`, `storage_error_operation`, and `storage_error_at`; values must be safe strings and must not include absolute paths, storage roots, raw workspace paths, file contents, full exception dumps, notes, or secrets.
+- Update runtime/config defaults to include `max_file_size_bytes: 100 * 1024 * 1024` and prefer `LEMMINGS_ARTIFACT_STORAGE_ROOT`.
+- Emit safe Logger metadata and canonical telemetry events for storage write/update/open/health outcomes.
+- Telemetry event names must use these shapes: `[:lemmings_os, :artifact_storage, :write, :start]`, `[:lemmings_os, :artifact_storage, :write, :stop]`, `[:lemmings_os, :artifact_storage, :write, :exception]`, `[:lemmings_os, :artifact_storage, :open, :stop]`, `[:lemmings_os, :artifact_storage, :open, :exception]`, `[:lemmings_os, :artifact_storage, :health_check, :stop]`, and `[:lemmings_os, :artifact_storage, :health_check, :exception]`.
+- Artifact update/replacement uses the same storage write telemetry events; use metadata `operation: :update` when distinguishing replacement from first write is useful.
+- String-style names such as `"artifact.storage.write.succeeded"` may be used only for Logger `:event` metadata or log messages, not as telemetry event names.
+- Do not persist Artifact storage audit/telemetry rows through `LemmingsOs.Events` in this issue.
+- Event/log metadata may include ids, filename, content type, size, checksum, operation, and reason token. It must not include absolute paths, root path, source workspace path, file contents, full metadata, notes, or secret values.
+
+### Docs
+
+- Document `LEMMINGS_ARTIFACT_STORAGE_ROOT`, local layout, Docker/self-host persistent volume requirements, and backup expectations.
+- State clearly that Artifact metadata is in Postgres but Artifact bytes are in the configured storage root; operators must back up both.
+- Document that DB-only backup is insufficient.
+- Document that soft-deleted Artifacts are not physically purged in this issue.
+- Document that S3/MinIO, physical cleanup, retention, encryption-at-rest beyond filesystem permissions, scanning, previews, RAG ingestion, cross-City shared storage, and versioning are future work.
+
+## Test Plan
+
+- Unit: canonical ref format, root-bounded path resolution, unsafe filename rejection, symlink escape rejection, storage ref excludes root path, and public descriptors exclude `storage_ref`.
+- Unit: atomic write uses temp file plus rename, computes checksum/size, enforces 100 MB max by config default, applies permissions where reliable, cleans temp files after success, and returns structured errors for bad source or bad managed file.
+- Unit: `exists?/2`, `open/2`, `path_for/2`, and `health_check/1` return explicit success/error tuples without path leakage.
+- Schema/context: safe storage error metadata is accepted; unexpected metadata keys and unsafe storage error values are rejected.
+- Integration: promotion first write persists `storage_ref`, checksum, and size; `:update_existing` recomputes metadata and keeps the same row; failed replacement does not corrupt existing valid metadata.
+- Controller: durable artifact downloads still serve bytes with safe headers; wrong scope/status returns safe 404; missing/broken storage returns safe 404 without leaking path/ref/root and marks ready Artifact as `error` where applicable.
+- Controller/context: tests cover the intentional read/open repair side effect that marks ready Artifacts as `error` for missing/unreadable storage.
+- Observability: Logger/telemetry events are emitted for storage success/failure and exclude absolute paths, root path, raw workspace path, file contents, full metadata, notes, and secrets.
+- Docs: docs mention `LEMMINGS_ARTIFACT_STORAGE_ROOT`, persistent volume, DB plus artifact volume backup, no cleanup/retention, and future S3/MinIO.
+- Final validation: run the narrowest relevant tests first, then `mix format`, then `mix precommit`.
+
+## Acceptance Criteria
+
+- [ ] `LemmingsOs.Artifacts.Storage.Adapter` exists with no physical delete callback in v1.
+- [ ] Existing `LemmingsOs.Artifacts.LocalStorage` implements or delegates behind the adapter without creating a duplicate local storage implementation.
+- [ ] Storage root is configurable through app config and `LEMMINGS_ARTIFACT_STORAGE_ROOT`, with `LEMMINGS_ARTIFACT_STORAGE_PATH` only as an optional deprecated fallback.
+- [ ] Canonical persisted refs use `local://artifacts/<world_id>/<artifact_id>/<safe_filename>` and never absolute filesystem paths.
+- [ ] Storage path uses `<root>/<world_id>/<artifact_id>/<safe_filename>`.
+- [ ] Writes and explicit updates use temp file plus atomic rename.
+- [ ] Checksum and byte size are computed during write/update.
+- [ ] Configurable max file size is enforced with a default of `100 * 1024 * 1024` bytes.
+- [ ] Best-effort directory/file permissions are applied where supported.
+- [ ] Unsafe filenames, path traversal, absolute paths, null bytes, control characters, separators, and symlink escapes are rejected.
+- [ ] Trusted open/download path uses the storage backend instead of direct controller `File.read/1` against resolved refs.
+- [ ] Missing/unreadable/broken files return structured errors and safe controller responses.
+- [ ] Storage failures update Artifact status/metadata safely where applicable.
+- [ ] Read/open status mutation is documented and limited to the intentional storage-missing/unreadable repair path.
+- [ ] Safe storage error metadata is accepted by `Artifact` validation; unsafe metadata remains rejected.
+- [ ] Soft-deleted Artifacts do not physically delete files.
+- [ ] No cleanup/sweeper or object-storage backend is implemented.
+- [ ] Logger/telemetry events are emitted with safe metadata only.
+- [ ] No Artifact storage audit rows are persisted through `LemmingsOs.Events` in this issue.
+- [ ] Logs/events/DB/public descriptors do not expose root paths, absolute paths, raw workspace paths, file contents, full metadata, notes, or secrets.
+- [ ] No accessibility-impacting UI changes are introduced; if UI changes are made, they receive an accessibility review.
+- [ ] Health check exists and is covered by tests.
+- [ ] Docker/self-host docs explain volume mount and backup requirements.
+- [ ] Final review covers docs, style/format, security/path leakage, and regression risk.
+- [ ] Tests that mutate app env restore previous values in `on_exit`.
+- [ ] Relevant targeted tests, `mix format`, and `mix precommit` pass.
+
+## Risks And Guardrails
+
+- Existing valid Artifacts can be corrupted if DB metadata is updated before replacement storage succeeds; always write and verify temp file, rename atomically, then update DB metadata.
+- Filesystem paths reveal host layout; keep path resolution inside the backend and test logs/events/responses for forbidden fields.
+- Soft-deleted Artifacts will grow disk usage; document this explicitly and leave retention/purge for a future task.
+- Local storage is node-local or volume-local; do not imply cross-City shared storage.
+- Permission assertions can be brittle across OS/container environments; keep permission tests focused and skip only where the platform makes them unreliable.

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -278,9 +278,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "Lemming deletion is not available because safety cannot yet be proven."
 
-#: lib/lemmings_os/artifacts/artifact.ex:105
-#: lib/lemmings_os/artifacts/artifact.ex:106
-#: lib/lemmings_os/artifacts/artifact.ex:211
+#: lib/lemmings_os/artifacts/artifact.ex:107
+#: lib/lemmings_os/artifacts/artifact.ex:108
+#: lib/lemmings_os/artifacts/artifact.ex:204
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -296,7 +296,7 @@ msgstr "Lemming deletion is not available because safety cannot yet be proven."
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:179
+#: lib/lemmings_os/artifacts/artifact.ex:181
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -305,7 +305,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:104
+#: lib/lemmings_os/artifacts/artifact.ex:106
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -322,9 +322,10 @@ msgstr ""
 msgid ".required"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:109
-#: lib/lemmings_os/artifacts/artifact.ex:151
-#: lib/lemmings_os/artifacts/artifact.ex:203
+#: lib/lemmings_os/artifacts/artifact.ex:111
+#: lib/lemmings_os/artifacts/artifact.ex:153
+#: lib/lemmings_os/artifacts/artifact.ex:196
+#: lib/lemmings_os/artifacts/artifact.ex:225
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -275,9 +275,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:105
-#: lib/lemmings_os/artifacts/artifact.ex:106
-#: lib/lemmings_os/artifacts/artifact.ex:211
+#: lib/lemmings_os/artifacts/artifact.ex:107
+#: lib/lemmings_os/artifacts/artifact.ex:108
+#: lib/lemmings_os/artifacts/artifact.ex:204
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -293,7 +293,7 @@ msgstr ""
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:179
+#: lib/lemmings_os/artifacts/artifact.ex:181
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -302,7 +302,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:104
+#: lib/lemmings_os/artifacts/artifact.ex:106
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -319,9 +319,10 @@ msgstr ""
 msgid ".required"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:109
-#: lib/lemmings_os/artifacts/artifact.ex:151
-#: lib/lemmings_os/artifacts/artifact.ex:203
+#: lib/lemmings_os/artifacts/artifact.ex:111
+#: lib/lemmings_os/artifacts/artifact.ex:153
+#: lib/lemmings_os/artifacts/artifact.ex:196
+#: lib/lemmings_os/artifacts/artifact.ex:225
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -278,9 +278,9 @@ msgstr ""
 msgid ".lemming_delete_denied_safety_indeterminate"
 msgstr "La eliminacion del lemming no esta disponible porque todavia no se puede demostrar que sea segura."
 
-#: lib/lemmings_os/artifacts/artifact.ex:105
-#: lib/lemmings_os/artifacts/artifact.ex:106
-#: lib/lemmings_os/artifacts/artifact.ex:211
+#: lib/lemmings_os/artifacts/artifact.ex:107
+#: lib/lemmings_os/artifacts/artifact.ex:108
+#: lib/lemmings_os/artifacts/artifact.ex:204
 #: lib/lemmings_os/connections/connection.ex:68
 #: lib/lemmings_os/connections/connection.ex:104
 #: lib/lemmings_os/events/event.ex:115
@@ -296,7 +296,7 @@ msgstr "La eliminacion del lemming no esta disponible porque todavia no se puede
 msgid ".invalid_choice"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:179
+#: lib/lemmings_os/artifacts/artifact.ex:181
 #: lib/lemmings_os/connections/connection.ex:134
 #: lib/lemmings_os/events/event.ex:128
 #: lib/lemmings_os/lemming_instances/lemming_instance.ex:102
@@ -305,7 +305,7 @@ msgstr ""
 msgid ".invalid_value_type"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:104
+#: lib/lemmings_os/artifacts/artifact.ex:106
 #: lib/lemmings_os/connections/connection.ex:67
 #: lib/lemmings_os/events/event.ex:113
 #: lib/lemmings_os/lemming_calls/lemming_call.ex:107
@@ -322,9 +322,10 @@ msgstr ""
 msgid ".required"
 msgstr ""
 
-#: lib/lemmings_os/artifacts/artifact.ex:109
-#: lib/lemmings_os/artifacts/artifact.ex:151
-#: lib/lemmings_os/artifacts/artifact.ex:203
+#: lib/lemmings_os/artifacts/artifact.ex:111
+#: lib/lemmings_os/artifacts/artifact.ex:153
+#: lib/lemmings_os/artifacts/artifact.ex:196
+#: lib/lemmings_os/artifacts/artifact.ex:225
 #: lib/lemmings_os/connections/connection.ex:95
 #: lib/lemmings_os/connections/connection.ex:118
 #: lib/lemmings_os/events/event.ex:139

--- a/test/lemmings_os/artifacts/artifact_test.exs
+++ b/test/lemmings_os/artifacts/artifact_test.exs
@@ -154,6 +154,52 @@ defmodule LemmingsOs.Artifacts.ArtifactTest do
       assert ".invalid_choice" in errors_on(changeset).metadata
     end
 
+    test "accepts safe storage error metadata with optional source" do
+      changeset =
+        Artifact.changeset(%Artifact{}, %{
+          world_id: Ecto.UUID.generate(),
+          filename: "artifact.md",
+          type: "markdown",
+          content_type: "text/markdown",
+          storage_ref: "local://artifacts/world/artifact.md",
+          size_bytes: 128,
+          checksum: String.duplicate("a", 64),
+          status: "error",
+          metadata: %{
+            "source" => "manual_promotion",
+            "storage_error_reason" => "not_found",
+            "storage_error_operation" => "open",
+            "storage_error_at" => "2026-05-01T12:00:00Z"
+          }
+        })
+
+      assert changeset.valid?
+    end
+
+    test "rejects unsafe storage error metadata values" do
+      for value <- ["/tmp/artifact.md", "C:\\tmp\\artifact.md", "line\nbreak", :not_found] do
+        changeset =
+          Artifact.changeset(%Artifact{}, %{
+            world_id: Ecto.UUID.generate(),
+            filename: "artifact.md",
+            type: "markdown",
+            content_type: "text/markdown",
+            storage_ref: "local://artifacts/world/artifact.md",
+            size_bytes: 128,
+            checksum: String.duplicate("a", 64),
+            status: "error",
+            metadata: %{
+              "storage_error_reason" => value,
+              "storage_error_operation" => "open",
+              "storage_error_at" => "2026-05-01T12:00:00Z"
+            }
+          })
+
+        refute changeset.valid?
+        assert ".invalid_value" in errors_on(changeset).metadata
+      end
+    end
+
     test "rejects invalid scope shape when lemming_id is set without department_id" do
       changeset =
         Artifact.changeset(%Artifact{}, %{

--- a/test/lemmings_os/artifacts/local_storage_test.exs
+++ b/test/lemmings_os/artifacts/local_storage_test.exs
@@ -1,7 +1,21 @@
 defmodule LemmingsOs.Artifacts.LocalStorageTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias LemmingsOs.Artifacts.LocalStorage
+
+  @moduletag capture_log: true
+
+  @storage_events [
+    [:lemmings_os, :artifact_storage, :write, :start],
+    [:lemmings_os, :artifact_storage, :write, :stop],
+    [:lemmings_os, :artifact_storage, :write, :exception],
+    [:lemmings_os, :artifact_storage, :open, :stop],
+    [:lemmings_os, :artifact_storage, :open, :exception],
+    [:lemmings_os, :artifact_storage, :health_check, :stop],
+    [:lemmings_os, :artifact_storage, :health_check, :exception]
+  ]
 
   doctest LocalStorage
 
@@ -30,6 +44,17 @@ defmodule LemmingsOs.Artifacts.LocalStorageTest do
   end
 
   describe "build_storage_ref/3" do
+    test "storage adapter behavior exposes v1 callbacks without physical delete" do
+      callbacks = LemmingsOs.Artifacts.Storage.Adapter.behaviour_info(:callbacks)
+
+      assert {:put, 4} in callbacks
+      assert {:open, 2} in callbacks
+      assert {:path_for, 2} in callbacks
+      assert {:exists?, 2} in callbacks
+      assert {:health_check, 1} in callbacks
+      refute Enum.any?(callbacks, fn {name, _arity} -> name == :delete end)
+    end
+
     test "builds a local artifact storage ref" do
       world_id = Ecto.UUID.generate()
       artifact_id = Ecto.UUID.generate()
@@ -52,7 +77,11 @@ defmodule LemmingsOs.Artifacts.LocalStorageTest do
             "nested\\file.txt",
             "line\nbreak.txt",
             "line\rbreak.txt",
-            "bad\0name.txt"
+            "bad\0name.txt",
+            "",
+            ".",
+            "..",
+            "~/.ssh"
           ] do
         assert {:error, :invalid_filename} =
                  LocalStorage.build_storage_ref(world_id, artifact_id, filename)
@@ -82,6 +111,10 @@ defmodule LemmingsOs.Artifacts.LocalStorageTest do
             "local://artifacts/#{world_id}/#{artifact_id}/nested/file.txt",
             "local://artifacts/#{world_id}/#{artifact_id}/C:\\temp\\file.txt",
             "local://artifacts/#{world_id}/#{artifact_id}/bad\0name.txt",
+            "local://artifacts/not-a-uuid/#{artifact_id}/artifact.md",
+            "local://artifacts/#{world_id}/not-a-uuid/artifact.md",
+            "local://artifacts/#{world_id}/#{artifact_id}/artifact.md?download=1",
+            "local://artifacts/#{world_id}/#{artifact_id}/artifact.md#fragment",
             "local://wrong/#{world_id}/#{artifact_id}/artifact.md",
             "s3://artifacts/#{world_id}/#{artifact_id}/artifact.md"
           ] do
@@ -134,5 +167,304 @@ defmodule LemmingsOs.Artifacts.LocalStorageTest do
       assert {:error, :invalid_storage_ref} =
                LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
     end
+
+    test "applies best-effort private permissions", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "workspace-source.md")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "safe")
+
+      assert {:ok, _stored} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
+
+      directory_path = Path.join([root_path, world_id, artifact_id])
+      file_path = Path.join(directory_path, "artifact.md")
+
+      assert {:ok, directory_stat} = File.stat(directory_path)
+      assert {:ok, file_stat} = File.stat(file_path)
+
+      assert permission_bits(directory_stat) == 0o700
+      assert permission_bits(file_stat) == 0o600
+    end
+
+    test "rejects oversized source file and does not leave final or temp files", %{
+      root_path: root_path
+    } do
+      old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+      Application.put_env(:lemmings_os, :artifact_storage,
+        backend: :local,
+        root_path: root_path,
+        max_file_size_bytes: 4
+      )
+
+      on_exit(fn ->
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      end)
+
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+
+      source_path = Path.join(root_path, "workspace-source.md")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+
+      assert {:error, :file_too_large} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
+
+      final_path = Path.join([root_path, world_id, artifact_id, "artifact.md"])
+      refute File.exists?(final_path)
+
+      assert [] == Path.wildcard(Path.join([root_path, world_id, artifact_id, ".*.tmp-*"]))
+    end
+
+    test "successful copy does not leave temp files", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "workspace-source.md")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+
+      assert {:ok, _stored} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.md")
+
+      assert [] == Path.wildcard(Path.join([root_path, world_id, artifact_id, ".*.tmp-*"]))
+    end
   end
+
+  describe "adapter callbacks" do
+    test "put/4 delegates to storage copy", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+
+      assert {:ok, stored} = LocalStorage.put(world_id, artifact_id, source_path, "artifact.txt")
+      assert stored.storage_ref == "local://artifacts/#{world_id}/#{artifact_id}/artifact.txt"
+    end
+
+    test "path_for/2 and exists?/2 resolve trusted refs", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+      {:ok, stored} = LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+
+      assert {:ok, managed_path} = LocalStorage.path_for(stored.storage_ref)
+      assert {:ok, true} = LocalStorage.exists?(stored.storage_ref)
+      assert managed_path == Path.join([root_path, world_id, artifact_id, "artifact.txt"])
+    end
+
+    test "path_for/2, exists?/2, and open/2 reject symlink escapes", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      storage_ref = "local://artifacts/#{world_id}/#{artifact_id}/artifact.txt"
+
+      outside_path = Path.join(root_path, "outside")
+      linked_world_path = Path.join(root_path, world_id)
+      :ok = File.mkdir_p(outside_path)
+      :ok = File.ln_s(outside_path, linked_world_path)
+
+      assert {:error, :invalid_storage_ref} = LocalStorage.path_for(storage_ref)
+      assert {:error, :invalid_storage_ref} = LocalStorage.exists?(storage_ref)
+      assert {:error, :invalid_storage_ref} = LocalStorage.open(storage_ref)
+    end
+
+    test "open/2 returns internal open shape", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+      {:ok, stored} = LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+
+      assert {:ok, result} =
+               LocalStorage.open(stored.storage_ref,
+                 filename: "artifact.txt",
+                 content_type: "text/plain"
+               )
+
+      assert result.filename == "artifact.txt"
+      assert result.content_type == "text/plain"
+      assert result.size_bytes == 5
+      assert result.path == Path.join([root_path, world_id, artifact_id, "artifact.txt"])
+    end
+
+    test "health_check/1 succeeds when root exists", %{root_path: root_path} do
+      assert :ok = File.mkdir_p(root_path)
+      assert :ok = LocalStorage.health_check()
+    end
+
+    test "health_check/1 creates missing root and verifies writable path", %{root_path: root_path} do
+      refute File.exists?(root_path)
+      assert :ok = LocalStorage.health_check()
+      assert File.dir?(root_path)
+    end
+
+    test "open/2 returns not_found for missing managed file", %{root_path: root_path} do
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      :ok = File.mkdir_p(root_path)
+
+      assert {:ok, storage_ref} =
+               LocalStorage.build_storage_ref(world_id, artifact_id, "artifact.txt")
+
+      assert {:error, :not_found} = LocalStorage.open(storage_ref, filename: "artifact.txt")
+    end
+  end
+
+  describe "config" do
+    test "max_file_size_bytes/0 defaults to 100 MB" do
+      assert LocalStorage.max_file_size_bytes() == 100 * 1024 * 1024
+    end
+  end
+
+  describe "observability" do
+    test "write emits safe start and stop telemetry", %{root_path: root_path} do
+      attach_storage_telemetry()
+
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+
+      assert {:ok, stored} =
+               LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :write, :start],
+                      %{count: 1}, start_metadata}
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :write, :stop],
+                      stop_measurements, stop_metadata}
+
+      assert start_metadata.world_id == world_id
+      assert start_metadata.artifact_id == artifact_id
+      assert start_metadata.filename == "artifact.txt"
+      assert start_metadata.operation == :write
+
+      assert stop_metadata.checksum == stored.checksum
+      assert stop_metadata.size_bytes == stored.size_bytes
+      assert stop_measurements.size_bytes == stored.size_bytes
+
+      metadata_text = inspect(stop_metadata)
+      refute metadata_text =~ root_path
+      refute metadata_text =~ source_path
+      refute metadata_text =~ stored.storage_ref
+    end
+
+    test "open failure emits safe exception telemetry" do
+      attach_storage_telemetry()
+
+      assert {:error, :invalid_storage_ref} =
+               LocalStorage.open("s3://bucket/path", filename: "artifact\r\n.txt")
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :open, :exception],
+                      %{count: 1}, metadata}
+
+      assert metadata.reason == "invalid_storage_ref"
+      assert metadata.operation == :open
+      assert metadata.filename == "artifact.txt"
+      refute inspect(metadata) =~ "s3://bucket/path"
+      refute inspect(metadata) =~ "\r"
+      refute inspect(metadata) =~ "\n"
+    end
+
+    test "open telemetry sanitizes persisted filename metadata", %{root_path: root_path} do
+      attach_storage_telemetry()
+
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "hello")
+      {:ok, stored} = LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+
+      assert {:ok, _opened} =
+               LocalStorage.open(stored.storage_ref,
+                 filename: "safe\r\nname.txt",
+                 content_type: "text/plain"
+               )
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :write, :start], _, _}
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :write, :stop], _, _}
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :open, :stop], _,
+                      metadata}
+
+      assert metadata.filename == "safename.txt"
+      refute inspect(metadata) =~ "\r"
+      refute inspect(metadata) =~ "\n"
+    end
+
+    test "health check emits stop telemetry", %{root_path: root_path} do
+      attach_storage_telemetry()
+      assert :ok = File.mkdir_p(root_path)
+
+      assert :ok = LocalStorage.health_check()
+
+      assert_receive {:telemetry_event, [:lemmings_os, :artifact_storage, :health_check, :stop],
+                      %{count: 1}, metadata}
+
+      assert metadata.operation == :health_check
+      assert metadata.status == :ok
+      refute inspect(metadata) =~ root_path
+    end
+
+    test "failure logs omit storage roots, source paths, and file contents", %{
+      root_path: root_path
+    } do
+      old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+      Application.put_env(:lemmings_os, :artifact_storage,
+        backend: :local,
+        root_path: root_path,
+        max_file_size_bytes: 3
+      )
+
+      on_exit(fn ->
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      end)
+
+      world_id = Ecto.UUID.generate()
+      artifact_id = Ecto.UUID.generate()
+      source_path = Path.join(root_path, "source.txt")
+      :ok = File.mkdir_p(root_path)
+      :ok = File.write(source_path, "secret content")
+
+      log =
+        capture_log([level: :warning], fn ->
+          assert {:error, :file_too_large} =
+                   LocalStorage.store_copy(world_id, artifact_id, source_path, "artifact.txt")
+        end)
+
+      assert log =~ "artifact storage write failed"
+      assert log =~ "reason=file_too_large"
+      refute log =~ root_path
+      refute log =~ source_path
+      refute log =~ "secret content"
+    end
+  end
+
+  defp attach_storage_telemetry do
+    test_pid = self()
+    handler_id = "local-storage-telemetry-test-#{System.unique_integer([:positive])}"
+
+    :telemetry.attach_many(
+      handler_id,
+      @storage_events,
+      fn event_name, measurements, metadata, _config ->
+        send(test_pid, {:telemetry_event, event_name, measurements, metadata})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  defp permission_bits(%File.Stat{mode: mode}), do: Bitwise.band(mode, 0o777)
 end

--- a/test/lemmings_os/artifacts/promotion_test.exs
+++ b/test/lemmings_os/artifacts/promotion_test.exs
@@ -9,6 +9,8 @@ defmodule LemmingsOs.Artifacts.PromotionTest do
   alias LemmingsOs.Artifacts.Promotion
   alias LemmingsOs.Repo
 
+  @moduletag capture_log: true
+
   doctest Promotion
 
   setup do
@@ -104,6 +106,35 @@ defmodule LemmingsOs.Artifacts.PromotionTest do
                )
     end
 
+    test "oversized first write returns error without creating ready artifact", %{
+      workspace_root: workspace_root
+    } do
+      old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+      root_path = Keyword.fetch!(old_artifact_storage, :root_path)
+
+      Application.put_env(:lemmings_os, :artifact_storage,
+        backend: :local,
+        root_path: root_path,
+        max_file_size_bytes: 3
+      )
+
+      on_exit(fn ->
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      end)
+
+      instance = insert_scoped_instance()
+      relative_path = "reports/too-large.txt"
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "large")
+
+      assert {:error, :file_too_large} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      assert [] = Repo.all(Artifact)
+    end
+
     test "requires explicit mode when same-scope filename already exists", %{
       workspace_root: workspace_root
     } do
@@ -162,6 +193,52 @@ defmodule LemmingsOs.Artifacts.PromotionTest do
       assert {:ok, managed_path} = LocalStorage.resolve_storage_ref(persisted.storage_ref)
       assert {:ok, managed_content} = File.read(managed_path)
       assert managed_content == "new content"
+    end
+
+    test "failed update_existing before replacement preserves row and managed file", %{
+      workspace_root: workspace_root
+    } do
+      instance = insert_scoped_instance()
+      relative_path = "reports/keep.txt"
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "old")
+
+      assert {:ok, first} =
+               Promotion.promote_workspace_file(
+                 promotion_scope(instance),
+                 %{relative_path: relative_path, lemming_instance_id: instance.id}
+               )
+
+      persisted_before = Repo.get!(Artifact, first.id)
+      {:ok, managed_path} = LocalStorage.resolve_storage_ref(persisted_before.storage_ref)
+      assert {:ok, "old"} = File.read(managed_path)
+
+      old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+      root_path = Keyword.fetch!(old_artifact_storage, :root_path)
+
+      Application.put_env(:lemmings_os, :artifact_storage,
+        backend: :local,
+        root_path: root_path,
+        max_file_size_bytes: 3
+      )
+
+      on_exit(fn ->
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      end)
+
+      _source_path = write_workspace_file(workspace_root, instance, relative_path, "new content")
+
+      assert {:error, :file_too_large} =
+               Promotion.promote_workspace_file(promotion_scope(instance), %{
+                 relative_path: relative_path,
+                 lemming_instance_id: instance.id,
+                 mode: :update_existing
+               })
+
+      persisted_after = Repo.get!(Artifact, first.id)
+      assert persisted_after.status == persisted_before.status
+      assert persisted_after.checksum == persisted_before.checksum
+      assert persisted_after.size_bytes == persisted_before.size_bytes
+      assert {:ok, "old"} = File.read(managed_path)
     end
 
     test "mode promote_as_new keeps existing row and creates new artifact", %{

--- a/test/lemmings_os/artifacts_test.exs
+++ b/test/lemmings_os/artifacts_test.exs
@@ -76,6 +76,11 @@ defmodule LemmingsOs.ArtifactsTest do
 
       assert {:error, :scope_mismatch} = Artifacts.create_artifact(world, attrs)
     end
+
+    test "rejects invalid input shapes" do
+      assert {:error, :invalid_scope} = Artifacts.create_artifact(%{}, %{})
+      assert {:error, :invalid_scope} = Artifacts.create_artifact(insert(:world), [])
+    end
   end
 
   describe "get_artifact/2 and get_artifact/3" do
@@ -101,6 +106,40 @@ defmodule LemmingsOs.ArtifactsTest do
 
       other_world = insert(:world)
       assert {:error, :not_found} = Artifacts.get_artifact(other_world, ready_artifact.id)
+    end
+
+    test "supports explicit single status filter" do
+      lemming = insert_scoped_lemming()
+      archived_artifact = insert_artifact_for_lemming(lemming, status: "archived")
+
+      assert {:ok, found} =
+               Artifacts.get_artifact(lemming, archived_artifact.id, status: "archived")
+
+      assert found.id == archived_artifact.id
+    end
+
+    test "rejects invalid get input" do
+      assert {:error, :invalid_scope} = Artifacts.get_artifact(%{}, Ecto.UUID.generate())
+      assert {:error, :invalid_scope} = Artifacts.get_artifact(insert(:world), 123)
+    end
+  end
+
+  describe "get_artifact_download/2" do
+    test "returns internal download metadata only for ready artifacts" do
+      artifact = insert_artifact_for_lemming(insert_scoped_lemming(), status: "ready")
+
+      assert {:ok, download} = Artifacts.get_artifact_download(artifact.lemming, artifact.id)
+      assert download.id == artifact.id
+      assert download.filename == artifact.filename
+      assert download.content_type == artifact.content_type
+      assert download.storage_ref == artifact.storage_ref
+    end
+
+    test "rejects invalid download input" do
+      assert {:error, :invalid_scope} =
+               Artifacts.get_artifact_download(%{}, Ecto.UUID.generate())
+
+      assert {:error, :invalid_scope} = Artifacts.get_artifact_download(insert(:world), 123)
     end
   end
 
@@ -141,6 +180,13 @@ defmodule LemmingsOs.ArtifactsTest do
       refute inspect(repaired.metadata) =~ root_path
       refute inspect(repaired.metadata) =~ managed_path
     end
+
+    test "rejects invalid open input" do
+      assert {:error, :invalid_scope} =
+               Artifacts.open_artifact_download(%{}, Ecto.UUID.generate())
+
+      assert {:error, :invalid_scope} = Artifacts.open_artifact_download(insert(:world), 123)
+    end
   end
 
   describe "list_artifacts_for_scope/2" do
@@ -163,6 +209,14 @@ defmodule LemmingsOs.ArtifactsTest do
     test "returns invalid_scope for malformed map scope" do
       assert {:error, :invalid_scope} =
                Artifacts.list_artifacts_for_scope(%{city_id: Ecto.UUID.generate()})
+    end
+
+    test "returns empty list for unsupported options rather than broadening query" do
+      lemming = insert_scoped_lemming()
+      _artifact = insert_artifact_for_lemming(lemming, status: "ready")
+
+      assert {:ok, listed} = Artifacts.list_artifacts_for_scope(lemming, unknown: "ignored")
+      assert length(listed) == 1
     end
   end
 
@@ -193,6 +247,17 @@ defmodule LemmingsOs.ArtifactsTest do
 
       assert MapSet.new(Enum.map(listed_with_archived, & &1.id)) ==
                MapSet.new([archived_artifact.id, ready_artifact.id])
+    end
+
+    test "rejects mismatched instance scope and invalid input" do
+      lemming = insert_scoped_lemming()
+      instance = insert_scoped_instance(lemming)
+      other_instance = insert_scoped_instance(lemming)
+
+      assert {:error, :invalid_scope} =
+               Artifacts.list_artifacts_for_instance(instance, other_instance.id)
+
+      assert {:error, :invalid_scope} = Artifacts.list_artifacts_for_instance(lemming, 123)
     end
   end
 
@@ -227,6 +292,14 @@ defmodule LemmingsOs.ArtifactsTest do
                Artifacts.update_artifact_status(artifact.world, artifact.id, "pending")
     end
 
+    test "rejects invalid update input" do
+      assert {:error, :invalid_scope} =
+               Artifacts.update_artifact_status(%{}, Ecto.UUID.generate(), "ready")
+
+      assert {:error, :invalid_scope} =
+               Artifacts.update_artifact_status(insert(:world), 123, "ready")
+    end
+
     test "soft delete does not physically delete managed storage", %{root_path: root_path} do
       instance = insert_scoped_instance(insert_scoped_lemming())
       artifact = insert_managed_artifact(instance, root_path, "artifact.txt", "hello")
@@ -248,6 +321,23 @@ defmodule LemmingsOs.ArtifactsTest do
       refute Map.has_key?(descriptor, :storage_ref)
       assert descriptor.id == artifact.id
       assert descriptor.filename == artifact.filename
+    end
+  end
+
+  describe "decorate_scope_slugs/1" do
+    test "adds scope slugs for known city, department, and lemming ids" do
+      lemming = insert_scoped_lemming()
+      artifact = insert_artifact_for_lemming(lemming)
+      descriptor = Artifacts.artifact_descriptor(artifact)
+
+      assert [decorated] = Artifacts.decorate_scope_slugs([descriptor])
+      assert decorated.city_slug == lemming.city.slug
+      assert decorated.department_slug == lemming.department.slug
+      assert decorated.lemming_slug == lemming.slug
+    end
+
+    test "returns empty list for invalid rows input" do
+      assert [] = Artifacts.decorate_scope_slugs(:invalid)
     end
   end
 

--- a/test/lemmings_os/artifacts_test.exs
+++ b/test/lemmings_os/artifacts_test.exs
@@ -5,9 +5,36 @@ defmodule LemmingsOs.ArtifactsTest do
 
   alias LemmingsOs.Artifacts
   alias LemmingsOs.Artifacts.Artifact
+  alias LemmingsOs.Artifacts.LocalStorage
   alias LemmingsOs.Repo
 
+  @moduletag capture_log: true
+
   doctest Artifacts
+
+  setup do
+    old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+    root_path =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_artifacts_context_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: root_path)
+
+    on_exit(fn ->
+      if old_artifact_storage do
+        Application.put_env(:lemmings_os, :artifact_storage, old_artifact_storage)
+      else
+        Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+
+      File.rm_rf(root_path)
+    end)
+
+    {:ok, root_path: root_path}
+  end
 
   describe "create_artifact/2" do
     test "creates an artifact descriptor in explicit world scope" do
@@ -74,6 +101,45 @@ defmodule LemmingsOs.ArtifactsTest do
 
       other_world = insert(:world)
       assert {:error, :not_found} = Artifacts.get_artifact(other_world, ready_artifact.id)
+    end
+  end
+
+  describe "open_artifact_download/2" do
+    test "opens a ready artifact after scope checks", %{root_path: root_path} do
+      instance = insert_scoped_instance(insert_scoped_lemming())
+      artifact = insert_managed_artifact(instance, root_path, "artifact.txt", "hello")
+
+      assert {:ok, opened} = Artifacts.open_artifact_download(instance, artifact.id)
+      assert opened.filename == "artifact.txt"
+      assert opened.content_type == "text/plain"
+      assert opened.size_bytes == 5
+      assert String.starts_with?(opened.path, Path.expand(root_path) <> "/")
+    end
+
+    test "does not open non-ready artifacts", %{root_path: root_path} do
+      instance = insert_scoped_instance(insert_scoped_lemming())
+      artifact = insert_managed_artifact(instance, root_path, "artifact.txt", "hello")
+
+      assert {:ok, _descriptor} =
+               Artifacts.update_artifact_status(instance, artifact.id, "archived")
+
+      assert {:error, :not_found} = Artifacts.open_artifact_download(instance, artifact.id)
+    end
+
+    test "marks missing ready storage as error with safe metadata", %{root_path: root_path} do
+      instance = insert_scoped_instance(insert_scoped_lemming())
+      artifact = insert_managed_artifact(instance, root_path, "artifact.txt", "hello")
+      {:ok, managed_path} = LocalStorage.resolve_storage_ref(artifact.storage_ref)
+      File.rm!(managed_path)
+
+      assert {:error, :not_found} = Artifacts.open_artifact_download(instance, artifact.id)
+
+      repaired = Repo.get!(Artifact, artifact.id)
+      assert repaired.status == "error"
+      assert repaired.metadata["storage_error_reason"] == "not_found"
+      assert repaired.metadata["storage_error_operation"] == "open"
+      refute inspect(repaired.metadata) =~ root_path
+      refute inspect(repaired.metadata) =~ managed_path
     end
   end
 
@@ -160,6 +226,18 @@ defmodule LemmingsOs.ArtifactsTest do
       assert {:error, :invalid_status} =
                Artifacts.update_artifact_status(artifact.world, artifact.id, "pending")
     end
+
+    test "soft delete does not physically delete managed storage", %{root_path: root_path} do
+      instance = insert_scoped_instance(insert_scoped_lemming())
+      artifact = insert_managed_artifact(instance, root_path, "artifact.txt", "hello")
+      {:ok, managed_path} = LocalStorage.resolve_storage_ref(artifact.storage_ref)
+
+      assert {:ok, descriptor} =
+               Artifacts.update_artifact_status(instance, artifact.id, "deleted")
+
+      assert descriptor.status == "deleted"
+      assert File.exists?(managed_path)
+    end
   end
 
   describe "artifact_descriptor/1" do
@@ -210,6 +288,34 @@ defmodule LemmingsOs.ArtifactsTest do
       city: lemming.city,
       department: lemming.department
     )
+  end
+
+  defp insert_managed_artifact(instance, root_path, filename, content) do
+    artifact_id = Ecto.UUID.generate()
+    source_path = Path.join(root_path, "source-#{artifact_id}.txt")
+    :ok = File.mkdir_p(root_path)
+    :ok = File.write(source_path, content)
+
+    {:ok, stored} =
+      LocalStorage.store_copy(instance.world_id, artifact_id, source_path, filename)
+
+    %Artifact{id: artifact_id}
+    |> Artifact.changeset(%{
+      world_id: instance.world_id,
+      city_id: instance.city_id,
+      department_id: instance.department_id,
+      lemming_id: instance.lemming_id,
+      lemming_instance_id: instance.id,
+      filename: filename,
+      type: "text",
+      content_type: "text/plain",
+      storage_ref: stored.storage_ref,
+      size_bytes: stored.size_bytes,
+      checksum: stored.checksum,
+      status: "ready",
+      metadata: %{"source" => "manual_promotion"}
+    })
+    |> Repo.insert!()
   end
 
   defp insert_artifact_for_lemming(lemming, attrs \\ []) do

--- a/test/lemmings_os/config/runtime_artifact_storage_config_test.exs
+++ b/test/lemmings_os/config/runtime_artifact_storage_config_test.exs
@@ -1,0 +1,48 @@
+defmodule LemmingsOs.Config.RuntimeArtifactStorageConfigTest do
+  use ExUnit.Case, async: false
+
+  @runtime_config_path Path.expand("../../../config/runtime.exs", __DIR__)
+
+  describe "artifact storage runtime env contract" do
+    test "uses LEMMINGS_ARTIFACT_STORAGE_ROOT when set" do
+      with_env(
+        %{
+          "LEMMINGS_ARTIFACT_STORAGE_ROOT" => "/tmp/artifacts-root"
+        },
+        fn ->
+          storage = runtime_artifact_storage_config()
+          assert Keyword.get(storage, :root_path) == "/tmp/artifacts-root"
+        end
+      )
+    end
+
+    test "keeps the default max file size when not overridden" do
+      storage = runtime_artifact_storage_config()
+      assert Keyword.get(storage, :max_file_size_bytes) == 100 * 1024 * 1024
+    end
+  end
+
+  defp runtime_artifact_storage_config do
+    {config, _imports} = Config.Reader.read_imports!(@runtime_config_path, env: :test)
+    lemmings_os_config = Keyword.get(config, :lemmings_os, [])
+    Keyword.get(lemmings_os_config, :artifact_storage, [])
+  end
+
+  defp with_env(changes, fun) do
+    previous = Map.new(changes, fn {key, _value} -> {key, System.get_env(key)} end)
+
+    try do
+      Enum.each(changes, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+
+      fun.()
+    after
+      Enum.each(previous, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+    end
+  end
+end

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -239,6 +239,48 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
       assert repaired.metadata["storage_error_reason"] == "invalid_storage_ref"
       assert repaired.metadata["storage_error_operation"] == "open"
     end
+
+    test "returns world not found for unknown world", %{
+      conn: conn,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} = insert_managed_artifact(instance, test_root)
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{artifact.id}/download?#{%{world: Ecto.UUID.generate()}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "World not found"
+    end
+
+    test "returns artifact not found for unknown instance", %{
+      conn: conn,
+      world: world,
+      instance: instance,
+      test_root: test_root
+    } do
+      %{artifact: artifact} = insert_managed_artifact(instance, test_root)
+
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{Ecto.UUID.generate()}/artifacts/#{artifact.id}/download?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
+
+    test "falls back to artifact not found for non-download params", %{conn: conn} do
+      response = LemmingsOsWeb.InstanceArtifactController.download(conn, %{})
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
   end
 
   describe "show/2 workspace route compatibility" do
@@ -260,6 +302,71 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
       assert response.resp_body == "# Runtime workspace artifact\n"
       assert get_resp_header(response, "content-type") == ["application/octet-stream"]
       assert get_resp_header(response, "x-content-type-options") == ["nosniff"]
+    end
+
+    test "returns world not found for unknown world", %{
+      conn: conn,
+      instance: instance
+    } do
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "runtime.md"]}?#{%{world: Ecto.UUID.generate()}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "World not found"
+    end
+
+    test "returns instance not found for unknown instance", %{
+      conn: conn,
+      world: world
+    } do
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{Ecto.UUID.generate()}/artifacts/#{["reports", "runtime.md"]}?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Instance not found"
+    end
+
+    test "returns artifact not found for missing workspace file", %{
+      conn: conn,
+      world: world,
+      instance: instance
+    } do
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{["reports", "missing.md"]}?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
+
+    test "returns artifact not found for unsafe workspace traversal", %{
+      conn: conn,
+      world: world,
+      instance: instance
+    } do
+      response =
+        conn
+        |> get(
+          ~p"/lemmings/instances/#{instance.id}/artifacts/#{["..", "secret.md"]}?#{%{world: world.id}}"
+        )
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
+    end
+
+    test "falls back to artifact not found for non-show params", %{conn: conn} do
+      response = LemmingsOsWeb.InstanceArtifactController.show(conn, %{})
+
+      assert response.status == 404
+      assert response.resp_body == "Artifact not found"
     end
   end
 

--- a/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
+++ b/test/lemmings_os_web/controllers/instance_artifact_controller_test.exs
@@ -8,6 +8,8 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
   alias LemmingsOs.LemmingInstances
   alias LemmingsOs.Repo
 
+  @moduletag capture_log: true
+
   setup do
     old_artifact_storage = Application.get_env(:lemmings_os, :artifact_storage)
 
@@ -205,6 +207,13 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
       refute headers_blob =~ stored_path
       refute headers_blob =~ artifact.storage_ref
       refute headers_blob =~ "artifact_storage"
+
+      repaired = Repo.get!(Artifact, artifact.id)
+      assert repaired.status == "error"
+      assert repaired.metadata["source"] == "manual_promotion"
+      assert repaired.metadata["storage_error_reason"] == "not_found"
+      assert repaired.metadata["storage_error_operation"] == "open"
+      assert is_binary(repaired.metadata["storage_error_at"])
     end
 
     test "DL05: invalid storage ref returns safe not found", %{
@@ -224,6 +233,11 @@ defmodule LemmingsOsWeb.InstanceArtifactControllerTest do
 
       assert response.status == 404
       assert response.resp_body == "Artifact not found"
+
+      repaired = Repo.get!(Artifact, artifact.id)
+      assert repaired.status == "error"
+      assert repaired.metadata["storage_error_reason"] == "invalid_storage_ref"
+      assert repaired.metadata["storage_error_operation"] == "open"
     end
   end
 


### PR DESCRIPTION
## Summary

Implements and hardens the local filesystem storage backend used by Artifacts.

This PR builds on the existing Artifact domain model and local storage baseline. It formalizes the storage adapter boundary, standardizes local storage configuration, hardens filesystem writes and path resolution, moves trusted download/open behavior behind the Artifact context/storage boundary, and adds documentation and validation coverage for self-hosted local storage deployments.

## Scope

* [ ] Bug fix
* [x] Feature
* [x] Refactor
* [x] Docs
* [ ] Chore

## Linked Issues

Closes #35
Related #27

## Technical Notes

* Key implementation details:

  * Adds a storage adapter contract for Artifact storage operations.
  * Hardens the existing `LemmingsOs.Artifacts.LocalStorage` implementation instead of creating a parallel backend.
  * Keeps canonical Artifact storage refs as `local://artifacts/<world_id>/<artifact_id>/<safe_filename>`.
  * Stores local Artifact bytes under `<artifact_storage_root>/<world_id>/<artifact_id>/<safe_filename>`.
  * Replaces direct final-destination copies with temp-file-in-target-directory plus atomic rename.
  * Computes `size_bytes` and SHA-256 checksum from managed storage.
  * Adds/uses trusted storage APIs for `open`, `path_for`, `exists?`, and `health_check`.
  * Moves durable Artifact download/open behavior through the Artifact context/storage boundary instead of direct controller `File.read/1`.
  * Handles missing/unreadable storage with structured errors and safe Artifact error metadata where applicable.
  * Emits safe Logger/telemetry observability without using durable `LemmingsOs.Events` audit rows.

* Data model / migration impact:

  * No migration expected for the local storage backend itself.
  * Artifact metadata validation is extended narrowly to allow safe storage error metadata keys.
  * Artifact soft-delete remains logical only; physical files are not purged by this PR.

* Config/env var changes:

  * Standardizes `LEMMINGS_ARTIFACT_STORAGE_ROOT` as the canonical local Artifact storage root env var.
  * Keeps `LEMMINGS_ARTIFACT_STORAGE_PATH` only as a deprecated fallback if implemented.
  * Adds/uses configurable max file size for local Artifact storage, defaulting to `100 * 1024 * 1024` bytes.

* Security/privacy considerations:

  * Artifact bytes remain outside Postgres.
  * Absolute filesystem paths are not stored in DB, public descriptors, logs, telemetry, or controller responses.
  * Storage root paths and raw workspace paths are not exposed.
  * File contents are not logged or emitted in telemetry.
  * Unsafe filenames, path traversal, absolute paths, null bytes, control characters, separators, and symlink escapes are rejected.
  * Local file permissions are restrictive where supported.
  * Artifact storage does not access Secret Bank.
  * No physical cleanup/sweeper or object-storage backend is introduced.

## Validation

* [ ] `mix format`
* [ ] `mix test`
* [ ] `mix precommit`
* [ ] Manual validation completed

### Manual validation notes

Suggested validation performed / to be confirmed:

1. Promote or create an Artifact backed by a local file.
2. Confirm the file is stored under the configured Artifact storage root using `<world_id>/<artifact_id>/<safe_filename>`.
3. Confirm the persisted `storage_ref` uses `local://artifacts/...` and does not expose an absolute filesystem path.
4. Confirm checksum and `size_bytes` are computed correctly.
5. Update an existing Artifact and confirm the managed file is atomically replaced while keeping the same Artifact row.
6. Confirm failed replacement does not corrupt existing valid Artifact metadata.
7. Attempt unsafe filenames/path traversal and confirm they are rejected.
8. Simulate missing/unreadable managed storage and confirm the controller returns a safe response without path leakage.
9. Confirm ready Artifacts are marked `error` with safe metadata when missing/unreadable storage is detected where applicable.
10. Confirm logs/telemetry do not include file contents, absolute paths, root paths, raw workspace paths, notes, or secrets.
11. Confirm no durable Artifact storage audit rows are written through `LemmingsOs.Events`.

## Screenshots / Recordings (if UI changes)

N/A — backend/storage-focused change. No operator-facing UI changes expected.

## Rollout / Rollback

* Rollout notes:

  * Ensure `LEMMINGS_ARTIFACT_STORAGE_ROOT` points to a writable persistent directory.
  * For Docker/self-host deployments, mount the Artifact storage root as a persistent volume.
  * Backups must include both Postgres and the Artifact storage volume; a DB-only backup does not preserve Artifact files.
  * Existing local envs using `LEMMINGS_ARTIFACT_STORAGE_PATH` should migrate to `LEMMINGS_ARTIFACT_STORAGE_ROOT` if the fallback was kept.

* Rollback notes:

  * Revert this PR if storage regressions are found.
  * Artifact metadata rows may remain in Postgres.
  * Files written to the local Artifact storage root are not automatically cleaned up by rollback.
  * Manual cleanup may be required for local files created during testing or rollout.

## Checklist

* [x] Tests added/updated for changed behavior
* [x] Docs updated (README/docs/ADR/runbook) when needed
* [x] No secrets or sensitive data committed
* [x] Backward compatibility considered

## Changed-file coverage
---------------------
 100.0%  lib/lemmings_os/artifacts/storage/adapter.ex  relevant=0  missed=0
  89.1%  lib/lemmings_os/artifacts.ex  relevant=137  missed=15
  86.5%  lib/lemmings_os/artifacts/artifact.ex  relevant=37  missed=5
  80.4%  lib/lemmings_os/artifacts/local_storage.ex  relevant=230  missed=45
  75.7%  lib/lemmings_os_web/controllers/instance_artifact_controller.ex  relevant=37  missed=9

