### PR TITLE
Add Gmail OAuth onboarding and draft creation tool

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -19,4 +19,7 @@ export LEMMINGS_KNOWLEDGE_SOURCE_FILE_STORAGE_ROOT="~/.lemmings/knowledge_source
 export LEMMINGS_KNOWLEDGE_REFERENCE_FILE_STORAGE_ROOT="~/.lemmings/knowledge_references_files"
 export LEMMINGS_GOTENBERG_URL="http://127.0.0.1:3000"
 
+export GMAIL_CLIENT_ID="xxxx"
+export GMAIL_CLIENT_SECRET="GOCXXX-xxx"
+
 [ -f .envrc.custom ] && source .envrc.custom

--- a/.envrc
+++ b/.envrc
@@ -19,7 +19,8 @@ export LEMMINGS_KNOWLEDGE_SOURCE_FILE_STORAGE_ROOT="~/.lemmings/knowledge_source
 export LEMMINGS_KNOWLEDGE_REFERENCE_FILE_STORAGE_ROOT="~/.lemmings/knowledge_references_files"
 export LEMMINGS_GOTENBERG_URL="http://127.0.0.1:3000"
 
-export GMAIL_CLIENT_ID="xxxx"
-export GMAIL_CLIENT_SECRET="GOCXXX-xxx"
+# Optional Gmail OAuth credentials belong in .envrc.custom, not in this tracked file.
+# export GMAIL_CLIENT_ID="..."
+# export GMAIL_CLIENT_SECRET="..."
 
 [ -f .envrc.custom ] && source .envrc.custom

--- a/config/config.exs
+++ b/config/config.exs
@@ -20,6 +20,12 @@ config :lemmings_os, :artifact_storage,
   root_path: Path.expand("../priv/runtime/storage", __DIR__),
   max_file_size_bytes: 100 * 1024 * 1024
 
+config :lemmings_os, :email_draft,
+  max_attachment_count: 5,
+  max_attachment_megabytes: 10,
+  max_total_attachment_megabytes: 20,
+  max_body_megabytes: 0.2
+
 config :lemmings_os, :knowledge_source_file_storage,
   backend: :local,
   root_path: Path.expand("../priv/runtime/knowledge_storage", __DIR__),

--- a/config/config.exs
+++ b/config/config.exs
@@ -75,11 +75,23 @@ end
 config :lemmings_os, LemmingsOs.SecretBank,
   allowed_env_vars: [
     "$GITHUB_TOKEN",
-    "$OPENROUTER_API_KEY"
+    "$OPENROUTER_API_KEY",
+    "$GMAIL_CLIENT_ID",
+    "$GMAIL_CLIENT_SECRET",
+    "$GOOGLE_OAUTH_CLIENT_ID",
+    "$GOOGLE_OAUTH_CLIENT_SECRET",
+    "$GMAIL_OAUTH_CLIENT_ID",
+    "$GMAIL_OAUTH_CLIENT_SECRET"
   ],
   env_fallbacks: [
     "$GITHUB_TOKEN",
-    {"OPENROUTER_API_KEY", "$OPENROUTER_API_KEY"}
+    {"OPENROUTER_API_KEY", "$OPENROUTER_API_KEY"},
+    "$GMAIL_CLIENT_ID",
+    "$GMAIL_CLIENT_SECRET",
+    "$GOOGLE_OAUTH_CLIENT_ID",
+    "$GOOGLE_OAUTH_CLIENT_SECRET",
+    "$GMAIL_OAUTH_CLIENT_ID",
+    "$GMAIL_OAUTH_CLIENT_SECRET"
   ]
 
 # TODO: temporary default selection

--- a/docs/features/connections.md
+++ b/docs/features/connections.md
@@ -277,16 +277,21 @@ set:
 
 ### Environment And Secret Bank Setup
 
-Required deployment env vars:
+Recommended deployment env vars when using Secret Bank env fallbacks:
 
-- `GOOGLE_OAUTH_CLIENT_ID`
-- `GOOGLE_OAUTH_CLIENT_SECRET`
-- `GOOGLE_OAUTH_REDIRECT_URI`
+- `GMAIL_CLIENT_ID`
+- `GMAIL_CLIENT_SECRET`
 
 Recommended Secret Bank mapping for the UI flow:
 
 - `$GMAIL_CLIENT_ID` -> OAuth client id value
 - `$GMAIL_CLIENT_SECRET` -> OAuth client secret value
+
+The default Secret Bank policy also allows `$GOOGLE_OAUTH_CLIENT_ID`,
+`$GOOGLE_OAUTH_CLIENT_SECRET`, `$GMAIL_OAUTH_CLIENT_ID`, and
+`$GMAIL_OAUTH_CLIENT_SECRET` refs if operators prefer those names. The
+authorized redirect URI is the app callback URL:
+`/connections/gmail/oauth/callback`.
 
 You can provide those refs either by:
 

--- a/docs/features/connections.md
+++ b/docs/features/connections.md
@@ -14,6 +14,13 @@ provider configuration and to choose where that configuration is owned.
 Connections are resolved by `type`, can be inherited down the hierarchy, and can
 be tested through a deterministic mock provider.
 
+This slice also ships Gmail onboarding for draft creation through the normal
+Connections create/manage form:
+
+- `Connections -> + Create -> Type: Gmail -> Connect Gmail`
+- scope-local Connection create/update (`type = gmail`)
+- refresh token storage through Secret Bank refs only
+
 This document describes the shipped behavior only.
 
 ## What A Connection Is
@@ -132,6 +139,14 @@ For the shipped `mock` type, the `api_key` field must be a Secret Bank style
 reference such as `$MOCK_API_KEY`. A raw string like `super-secret-token` is
 rejected as invalid config.
 
+For `gmail`, the config stores only safe metadata plus refs:
+
+- `client_id` (for example `$GMAIL_CLIENT_ID`)
+- `client_secret` (for example `$GMAIL_CLIENT_SECRET`)
+- `refresh_token` only after OAuth callback (generated Secret Bank ref such as
+  `$GMAIL_REFRESH_TOKEN_WORLD_<scope-id>`)
+- `account_email` only after OAuth profile lookup succeeds
+
 This means Connection rows are safe configuration carriers, not credential
 vaults.
 
@@ -164,6 +179,9 @@ Current split of responsibility:
 - `LemmingsOs.Connections.Runtime` resolves identity and visibility
 - `LemmingsOs.Connections.Providers.MockCaller` validates mock config, resolves
   secret refs just in time through Secret Bank, and returns sanitized results
+- `LemmingsOs.Connections.Providers.GmailCaller` validates Gmail config contract
+- `LemmingsOs.Connections.GmailOAuth` handles OAuth start/callback validation,
+  refresh-token persistence, and Gmail Connection upsert
 
 This separation is deliberate. Runtime resolution decides which Connection is
 usable. Provider callers decide how credentials are consumed.
@@ -176,6 +194,7 @@ labels, default config examples, config validation, and test dispatch.
 Shipped registry entries:
 
 - `mock` -> `LemmingsOs.Connections.Providers.MockCaller`
+- `gmail` -> `LemmingsOs.Connections.Providers.GmailCaller`
 
 The UI reads registry metadata to:
 
@@ -183,11 +202,9 @@ The UI reads registry metadata to:
 - prefill editable config examples
 - validate that the selected type is supported
 
-Real provider integrations are not shipped in this MVP.
-
 ## Mock Provider Behavior
 
-`mock` is the only deterministic provider behavior in this slice.
+`mock` is the deterministic provider test path in this slice.
 
 Required config shape:
 
@@ -220,6 +237,66 @@ Successful test result shape is intentionally narrow and safe:
 No raw secret values are returned, persisted into `last_test`, or written to
 safe event payloads.
 
+## Gmail OAuth Onboarding (Draft Creation Only)
+
+Gmail onboarding is available from Connections panels at:
+
+- `/world` (World scope)
+- `/cities?city=<city_id>` (City scope)
+- `/departments?city=<city_id>&dept=<department_id>` (Department scope)
+
+The flow is:
+
+1. Open the scope's Connections tab.
+2. Use `+ Create`.
+3. Select `Gmail`.
+4. Edit `Client ID secret ref` and `Client Secret secret ref` if this scope
+   should use non-default OAuth app credentials.
+5. Use `Save config` to persist refs without starting OAuth, or `Connect Gmail`
+   to persist refs and start OAuth.
+6. Complete Google OAuth consent.
+7. Return to the same Connections tab with a safe success or failure flash.
+8. A local `gmail` Connection is created or updated at that scope.
+
+If a local Gmail Connection already exists at the current scope, selecting
+`Gmail` manages that row instead of creating a duplicate.
+
+### Google Cloud Setup
+
+Before using `Connect Gmail`, set up Google once per deployment or credential
+set:
+
+1. Create or select a Google Cloud project.
+2. Enable **Gmail API**.
+3. Configure the OAuth consent screen.
+4. Create **OAuth client ID** credentials with application type **Web
+   application**.
+5. Add authorized redirect URI:
+   - `https://<your-host>/connections/gmail/oauth/callback`
+   - local dev example: `http://localhost:4000/connections/gmail/oauth/callback`
+
+### Environment And Secret Bank Setup
+
+Required deployment env vars:
+
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+- `GOOGLE_OAUTH_REDIRECT_URI`
+
+Recommended Secret Bank mapping for the UI flow:
+
+- `$GMAIL_CLIENT_ID` -> OAuth client id value
+- `$GMAIL_CLIENT_SECRET` -> OAuth client secret value
+
+You can provide those refs either by:
+
+- storing local Secret Bank values directly at the target scope; or
+- mapping env values through Secret Bank env fallback policy.
+
+OAuth-generated refresh tokens are stored through Secret Bank during callback.
+Connection rows store only the generated refresh-token ref, not raw token
+values. Operators never paste refresh tokens into the UI.
+
 ## Operator Flows
 
 Connections UI surfaces exist on World, City, and Department pages.
@@ -240,8 +317,14 @@ Operators can open a create form at the current scope.
 Behavior:
 
 - type options come from the registry
-- changing the selected type refills the example config for that type
-- config can be entered as JSON or YAML text
+- selecting `mock` or other non-Gmail types keeps the generic JSON/YAML config
+  textarea
+- selecting `gmail` switches the form to a Gmail-specific setup panel
+- the Gmail panel exposes editable `client_id` and `client_secret` Secret Bank
+  refs and shows the compose-only OAuth scope as read-only help text
+- the Gmail panel shows connected account state when OAuth has completed
+- the Gmail panel may show the generated refresh-token Secret Bank ref in an
+  advanced/debug section, but never the raw token value
 - new rows are created as local rows at the current scope
 - the create form submits `status = enabled`
 
@@ -339,7 +422,9 @@ test summaries. They must not contain raw credentials.
 
 The following are explicitly not shipped by this MVP:
 
-- real provider integrations beyond deterministic `mock`
+- sending email from LemmingsOS (draft creation only)
+- Gmail read, sync, watch, reply parsing, mailbox ingestion, or approval-record
+  workflows
 - Tool Runtime refactors or generic provider execution unification
 - application authentication or RBAC around Connection management
 - approval workflows for creating, changing, testing, enabling, disabling, or

--- a/docs/features/secret_bank.md
+++ b/docs/features/secret_bank.md
@@ -87,11 +87,15 @@ Bank may read. `env_fallbacks` maps bank keys to those env vars:
 
 The process environment is never treated as an open keyspace.
 
-For Gmail onboarding, deployments commonly map OAuth env vars into the refs
-used by Connections:
+For Gmail onboarding, deployments commonly map OAuth env vars into the default
+refs used by Connections:
 
-- `GOOGLE_OAUTH_CLIENT_ID` -> `$GMAIL_CLIENT_ID`
-- `GOOGLE_OAUTH_CLIENT_SECRET` -> `$GMAIL_CLIENT_SECRET`
+- `GMAIL_CLIENT_ID` -> `$GMAIL_CLIENT_ID`
+- `GMAIL_CLIENT_SECRET` -> `$GMAIL_CLIENT_SECRET`
+
+The default allowlist also permits `$GOOGLE_OAUTH_CLIENT_ID`,
+`$GOOGLE_OAUTH_CLIENT_SECRET`, `$GMAIL_OAUTH_CLIENT_ID`, and
+`$GMAIL_OAUTH_CLIENT_SECRET` refs for deployments that prefer those names.
 
 ## Key and Reference Format
 

--- a/docs/features/secret_bank.md
+++ b/docs/features/secret_bank.md
@@ -87,6 +87,12 @@ Bank may read. `env_fallbacks` maps bank keys to those env vars:
 
 The process environment is never treated as an open keyspace.
 
+For Gmail onboarding, deployments commonly map OAuth env vars into the refs
+used by Connections:
+
+- `GOOGLE_OAUTH_CLIENT_ID` -> `$GMAIL_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET` -> `$GMAIL_CLIENT_SECRET`
+
 ## Key and Reference Format
 
 Current bank keys must match:
@@ -125,6 +131,10 @@ Without `allowed_hosts` or `secret_header_allowed_hosts`, a resolved secret
 header is blocked before the outbound request is made. The allowlist is exact
 host matching and exists to prevent model-supplied URLs from receiving
 credentials intended for another provider.
+
+Gmail OAuth callback handling also writes generated refresh tokens to Secret
+Bank using scoped keys such as `GMAIL_REFRESH_TOKEN_WORLD_<UUID>`. Connection
+rows persist only the resulting `$...` ref.
 
 ## Hierarchy and Resolution
 

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -264,6 +264,7 @@ Runtime config lives in `config/runtime.exs` under `:lemmings_os, :documents`.
 ### `email.create_draft`
 
 Creates a Gmail draft using a scoped `gmail` Connection and optional Artifact attachments.
+The resulting draft is intended for human review in Gmail before manual send.
 
 Required inputs:
 
@@ -309,3 +310,10 @@ Safety notes:
 - Rejects raw local file paths; attachments must be Artifact IDs.
 - Resolves Secret Bank refs only during adapter execution.
 - Does not expose raw Gmail API responses or OAuth credentials.
+- Timeline rendering should remain limited to safe summary/preview/result fields.
+
+Email non-goals in this MVP:
+
+- no `email.send` runtime tool
+- no Gmail read/sync/watch flows
+- no mailbox ingestion, reply parsing, or approval-record automation

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -23,6 +23,7 @@ Catalog scope:
 | `knowledge.store` | Knowledge | Store a scoped memory note for future use | Stored memory ID + scope |
 | `documents.markdown_to_html` | Documents | Convert WorkArea Markdown file to WorkArea HTML file | `text/html` file + byte size |
 | `documents.print_to_pdf` | Documents | Print supported WorkArea source file to WorkArea PDF via Gotenberg | `application/pdf` file + byte size |
+| `email.create_draft` | Email | Create a Gmail draft from prepared content and optional Artifacts | Draft descriptor (no send) |
 
 ## Global Tool Boundaries
 
@@ -257,3 +258,54 @@ Runtime config lives in `config/runtime.exs` under `:lemmings_os, :documents`.
 - No templates (`EEx`, `HEEx`, `Liquid`)
 - No email/e-signature/legal validation flow
 - No advanced image layout engine
+
+## Email
+
+### `email.create_draft`
+
+Creates a Gmail draft using a scoped `gmail` Connection and optional Artifact attachments.
+
+Required inputs:
+
+- `connection_ref`: must be `gmail`
+- `to`: non-empty recipient list
+- `subject`: non-empty string
+- `body`: non-empty string
+- `body_format`: `text/plain` or `text/html`
+
+Optional inputs:
+
+- `cc`: recipient list (default `[]`)
+- `bcc`: recipient list (default `[]`)
+- `artifact_ids`: Artifact id list (default `[]`)
+
+Minimal call:
+
+```json
+{
+  "connection_ref": "gmail",
+  "to": ["customer@example.com"],
+  "subject": "Quotation",
+  "body": "Attached quotation draft.",
+  "body_format": "text/plain",
+  "artifact_ids": []
+}
+```
+
+Result details include:
+
+- `status` (`draft_created`)
+- `provider` (`gmail`)
+- `connection_ref`
+- `draft_id`
+- optional `message_id`
+- recipients (`to`, `cc`, `bcc`)
+- `subject`
+- `artifact_ids`
+
+Safety notes:
+
+- Creates drafts only; it does not send email.
+- Rejects raw local file paths; attachments must be Artifact IDs.
+- Resolves Secret Bank refs only during adapter execution.
+- Does not expose raw Gmail API responses or OAuth credentials.

--- a/docs/features/tools.md
+++ b/docs/features/tools.md
@@ -269,15 +269,18 @@ The resulting draft is intended for human review in Gmail before manual send.
 Required inputs:
 
 - `connection_ref`: must be `gmail`
-- `to`: non-empty recipient list
+- `to`: non-empty recipient email string, comma-separated recipient string, or
+  recipient list
 - `subject`: non-empty string
 - `body`: non-empty string
-- `body_format`: `text/plain` or `text/html`
 
 Optional inputs:
 
-- `cc`: recipient list (default `[]`)
-- `bcc`: recipient list (default `[]`)
+- `cc`: recipient email string, comma-separated string, list, `null`, or blank
+  string (default `[]`)
+- `bcc`: recipient email string, comma-separated string, list, `null`, or blank
+  string (default `[]`)
+- `body_format`: `text/plain` or `text/html` (default `text/plain`)
 - `artifact_ids`: Artifact id list (default `[]`)
 
 Minimal call:

--- a/lib/lemmings_os/connections.ex
+++ b/lib/lemmings_os/connections.ex
@@ -32,7 +32,7 @@ defmodule LemmingsOs.Connections do
 
   ## Examples
 
-      iex> [type] = LemmingsOs.Connections.list_connection_types()
+      iex> [type | _] = LemmingsOs.Connections.list_connection_types()
       iex> type.id
       "mock"
   """

--- a/lib/lemmings_os/connections/gmail_oauth.ex
+++ b/lib/lemmings_os/connections/gmail_oauth.ex
@@ -1,0 +1,346 @@
+defmodule LemmingsOs.Connections.GmailOAuth do
+  @moduledoc """
+  Gmail OAuth onboarding boundary for scope-local connection creation/update.
+  """
+
+  alias LemmingsOs.Cities.City
+  alias LemmingsOs.Connections
+  alias LemmingsOs.Connections.Connection
+  alias LemmingsOs.Connections.GmailOAuth.Client
+  alias LemmingsOs.Connections.Providers.GmailCaller
+  alias LemmingsOs.Departments.Department
+  alias LemmingsOs.Events
+  alias LemmingsOs.SecretBank
+  alias LemmingsOs.Worlds.World
+
+  @session_ttl_seconds 600
+
+  @type scope_t :: World.t() | City.t() | Department.t()
+
+  @doc """
+  Builds Google OAuth authorization URL and safe session state.
+
+  ## Parameters
+
+  - `scope`:
+    `%LemmingsOs.Worlds.World{}`, `%LemmingsOs.Cities.City{}`, or
+    `%LemmingsOs.Departments.Department{}`.
+  - `attrs`:
+    - `"client_id"` (required): Secret Bank ref string (for example `"$GMAIL_CLIENT_ID"`).
+    - `"client_secret"` (required): Secret Bank ref string (for example `"$GMAIL_CLIENT_SECRET"`).
+    - `"account_email"` (optional): safe display label string. Default: `nil`.
+  - `opts`:
+    - `:redirect_uri` (required): OAuth callback URL.
+    - default value for `opts`: `[]`.
+
+  ## OAuth Request Defaults
+
+  - `response_type = "code"`
+  - `scope = "https://www.googleapis.com/auth/gmail.compose"`
+  - `access_type = "offline"`
+  - `prompt = "consent"`
+
+  ## Examples
+
+      iex> LemmingsOs.Connections.GmailOAuth.start(%{}, %{}, redirect_uri: "https://example.test/callback")
+      {:error, :invalid_scope}
+  """
+  @spec start(scope_t(), map(), keyword()) ::
+          {:ok, %{authorize_url: String.t(), session_state: map()}} | {:error, atom()}
+  def start(scope, attrs, opts \\ []) when is_map(attrs) and is_list(opts) do
+    with {:ok, scope_data} <- scope_data(scope),
+         {:ok, client_id_ref} <- fetch_secret_ref(attrs, "client_id"),
+         {:ok, client_secret_ref} <- fetch_secret_ref(attrs, "client_secret"),
+         {:ok, redirect_uri} <- fetch_nonempty(opts, :redirect_uri),
+         {:ok, client_id} <- SecretBank.resolve_runtime_secret(scope, client_id_ref) do
+      state = Base.url_encode64(:crypto.strong_rand_bytes(24), padding: false)
+
+      expires_at_unix =
+        DateTime.utc_now() |> DateTime.add(@session_ttl_seconds, :second) |> DateTime.to_unix()
+
+      query =
+        URI.encode_query(%{
+          response_type: "code",
+          client_id: client_id.value,
+          redirect_uri: redirect_uri,
+          scope: GmailCaller.compose_scope(),
+          access_type: "offline",
+          prompt: "consent",
+          state: state
+        })
+
+      {:ok,
+       %{
+         authorize_url: "https://accounts.google.com/o/oauth2/v2/auth?#{query}",
+         session_state: %{
+           "state" => state,
+           "expires_at_unix" => expires_at_unix,
+           "scope" => scope_data,
+           "config" => %{
+             "client_id" => client_id_ref,
+             "client_secret" => client_secret_ref,
+             "account_email" => safe_string(Map.get(attrs, "account_email"))
+           }
+         }
+       }}
+    end
+  end
+
+  @doc """
+  Completes OAuth callback and upserts a scope-local Gmail connection.
+
+  The returned temporary access token is used only for profile lookup and is
+  never persisted.
+
+  When profile lookup succeeds, `account_email` is populated from Gmail
+  `users.getProfile`. When lookup fails, OAuth still succeeds and
+  `account_email` falls back to the provided safe label (or blank).
+
+  Returns `{:error, :oauth_failed}` for invalid or expired state, failed token
+  exchange, or malformed callback payload.
+
+  ## Parameters
+
+  - `scope`:
+    `%LemmingsOs.Worlds.World{}`, `%LemmingsOs.Cities.City{}`, or
+    `%LemmingsOs.Departments.Department{}`.
+  - `params`:
+    - `"code"` (required): OAuth authorization code from Google callback.
+    - `"state"` (required): callback state nonce; must match session nonce.
+  - `session_state`:
+    Map stored from `start/3`, containing:
+    - `"state"` nonce
+    - `"expires_at_unix"` unix timestamp
+    - `"scope"` scope identity map
+    - `"config"` map with `"client_id"`, `"client_secret"`, optional `"account_email"`
+  - `opts`:
+    - `:redirect_uri` (required): same callback URL used at `start/3`.
+    - `:oauth_client` (optional): token exchange module implementing
+      `exchange_code/5`.
+      Default: `LemmingsOs.Connections.GmailOAuth.Client`.
+    - default value for `opts`: `[]`.
+  """
+  @spec complete(scope_t(), map(), map(), keyword()) ::
+          {:ok, Connection.t()} | {:error, atom() | Ecto.Changeset.t()}
+  def complete(scope, params, session_state, opts \\ [])
+      when is_map(params) and is_map(session_state) and is_list(opts) do
+    oauth_client = Keyword.get(opts, :oauth_client, Client)
+
+    with :ok <- validate_session_state(params, session_state),
+         {:ok, code} <- fetch_nonempty_map(params, "code"),
+         {:ok, redirect_uri} <- fetch_nonempty(opts, :redirect_uri),
+         {:ok, config} <- fetch_oauth_config(session_state),
+         {:ok, client_id} <- SecretBank.resolve_runtime_secret(scope, config.client_id_ref),
+         {:ok, client_secret} <-
+           SecretBank.resolve_runtime_secret(scope, config.client_secret_ref),
+         {:ok, token_payload} <-
+           oauth_client.exchange_code(
+             client_id.value,
+             client_secret.value,
+             code,
+             redirect_uri
+           ),
+         {:ok, refresh_token} <- fetch_nonempty_map(token_payload, "refresh_token"),
+         {:ok, refresh_ref} <- upsert_refresh_token(scope, refresh_token),
+         profile_email = resolve_profile_email(scope, oauth_client, token_payload),
+         {:ok, connection} <-
+           upsert_gmail_connection(scope, config, refresh_ref, profile_email) do
+      {:ok, connection}
+    else
+      {:error, :invalid_state} -> {:error, :invalid_state}
+      {:error, :invalid_config} -> {:error, :invalid_config}
+      {:error, :oauth_exchange_failed} -> {:error, :oauth_exchange_failed}
+      {:error, :missing_secret} -> {:error, :missing_secret}
+      {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
+      _ -> {:error, :oauth_failed}
+    end
+  end
+
+  defp validate_session_state(params, session_state) do
+    with {:ok, session_nonce} <- fetch_nonempty_map(session_state, "state"),
+         {:ok, callback_nonce} <- fetch_nonempty_map(params, "state"),
+         true <- session_nonce == callback_nonce,
+         {:ok, expires_at_unix} <- fetch_integer_map(session_state, "expires_at_unix"),
+         true <- DateTime.to_unix(DateTime.utc_now()) <= expires_at_unix do
+      :ok
+    else
+      _ -> {:error, :invalid_state}
+    end
+  end
+
+  defp fetch_oauth_config(session_state) do
+    with %{} = config <- Map.get(session_state, "config"),
+         {:ok, client_id_ref} <- fetch_secret_ref(config, "client_id"),
+         {:ok, client_secret_ref} <- fetch_secret_ref(config, "client_secret") do
+      {:ok,
+       %{
+         client_id_ref: client_id_ref,
+         client_secret_ref: client_secret_ref,
+         account_email: safe_string(Map.get(config, "account_email"))
+       }}
+    else
+      _ -> {:error, :invalid_session}
+    end
+  end
+
+  defp upsert_refresh_token(scope, refresh_token) do
+    key = "GMAIL_REFRESH_TOKEN_" <> scope_key_suffix(scope)
+
+    case SecretBank.upsert_secret(scope, key, refresh_token) do
+      {:ok, _metadata} -> {:ok, "$#{key}"}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_profile_email(scope, oauth_client, token_payload) do
+    with {:ok, access_token} <- fetch_nonempty_map(token_payload, "access_token"),
+         {:ok, email} <- fetch_profile_email(oauth_client, access_token),
+         {:ok, safe_email} <- normalize_email(email) do
+      safe_email
+    else
+      {:error, reason} ->
+        maybe_record_profile_lookup_failure(scope, reason)
+        nil
+
+      _ ->
+        maybe_record_profile_lookup_failure(scope, :profile_lookup_failed)
+        nil
+    end
+  end
+
+  defp fetch_profile_email(oauth_client, access_token) do
+    if function_exported?(oauth_client, :fetch_profile, 1) do
+      oauth_client.fetch_profile(access_token)
+    else
+      {:error, :profile_lookup_failed}
+    end
+  end
+
+  defp normalize_email(email) when is_binary(email) do
+    case safe_string(email) do
+      nil -> {:error, :profile_lookup_failed}
+      "" -> {:error, :profile_lookup_failed}
+      value -> {:ok, value}
+    end
+  end
+
+  defp normalize_email(_email), do: {:error, :profile_lookup_failed}
+
+  defp maybe_record_profile_lookup_failure(scope, reason) do
+    _ =
+      Events.record_event(
+        "connection.gmail.oauth_profile_lookup_failed",
+        event_scope_data(scope),
+        "Gmail OAuth profile lookup failed",
+        payload: Map.put(event_scope_data(scope), :reason, safe_reason(reason))
+      )
+
+    :ok
+  end
+
+  defp safe_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp safe_reason(_reason), do: "profile_lookup_failed"
+
+  defp upsert_gmail_connection(scope, config, refresh_ref, profile_email) do
+    existing = Connections.get_connection_by_type(scope, "gmail")
+    existing_email = existing && existing.config && existing.config["account_email"]
+
+    account_email =
+      profile_email ||
+        config.account_email ||
+        safe_string(existing_email) ||
+        ""
+
+    attrs = %{
+      type: "gmail",
+      status: "enabled",
+      config: %{
+        "provider" => "gmail",
+        "scopes" => [GmailCaller.compose_scope()],
+        "client_id" => config.client_id_ref,
+        "client_secret" => config.client_secret_ref,
+        "refresh_token" => refresh_ref,
+        "account_email" => account_email
+      }
+    }
+
+    case existing do
+      nil -> Connections.create_connection(scope, attrs)
+      connection -> Connections.update_connection(scope, connection, attrs)
+    end
+  end
+
+  defp event_scope_data(%World{id: world_id}),
+    do: %{world_id: world_id, city_id: nil, department_id: nil}
+
+  defp event_scope_data(%City{id: city_id, world_id: world_id}),
+    do: %{world_id: world_id, city_id: city_id, department_id: nil}
+
+  defp event_scope_data(%Department{id: department_id, city_id: city_id, world_id: world_id}),
+    do: %{world_id: world_id, city_id: city_id, department_id: department_id}
+
+  defp scope_key_suffix(%World{id: world_id}), do: "WORLD_" <> sanitize_uuid(world_id)
+  defp scope_key_suffix(%City{id: city_id}), do: "CITY_" <> sanitize_uuid(city_id)
+
+  defp scope_key_suffix(%Department{id: department_id}),
+    do: "DEPARTMENT_" <> sanitize_uuid(department_id)
+
+  defp sanitize_uuid(id), do: id |> String.replace("-", "_") |> String.upcase()
+
+  defp scope_data(%World{id: world_id}) when is_binary(world_id) do
+    {:ok, %{"kind" => "world", "world_id" => world_id}}
+  end
+
+  defp scope_data(%City{id: city_id, world_id: world_id})
+       when is_binary(city_id) and is_binary(world_id) do
+    {:ok, %{"kind" => "city", "world_id" => world_id, "city_id" => city_id}}
+  end
+
+  defp scope_data(%Department{id: department_id, city_id: city_id, world_id: world_id})
+       when is_binary(department_id) and is_binary(city_id) and is_binary(world_id) do
+    {:ok,
+     %{
+       "kind" => "department",
+       "world_id" => world_id,
+       "city_id" => city_id,
+       "department_id" => department_id
+     }}
+  end
+
+  defp scope_data(_scope), do: {:error, :invalid_scope}
+
+  defp fetch_secret_ref(map, key) do
+    with {:ok, value} <- fetch_nonempty_map(map, key),
+         "$" <> rest <- value,
+         true <- rest != "" do
+      {:ok, value}
+    else
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  defp fetch_nonempty(list, key) do
+    case Keyword.get(list, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  defp fetch_nonempty_map(map, key) do
+    case Map.get(map, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  defp fetch_integer_map(map, key) do
+    case Map.get(map, key) do
+      value when is_integer(value) -> {:ok, value}
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  defp safe_string(nil), do: nil
+  defp safe_string(value) when is_binary(value), do: String.trim(value)
+  defp safe_string(_value), do: nil
+end

--- a/lib/lemmings_os/connections/gmail_oauth.ex
+++ b/lib/lemmings_os/connections/gmail_oauth.ex
@@ -3,6 +3,9 @@ defmodule LemmingsOs.Connections.GmailOAuth do
   Gmail OAuth onboarding boundary for scope-local connection creation/update.
   """
 
+  import Ecto.Query, warn: false
+
+  alias Ecto.Multi
   alias LemmingsOs.Cities.City
   alias LemmingsOs.Connections
   alias LemmingsOs.Connections.Connection
@@ -10,7 +13,9 @@ defmodule LemmingsOs.Connections.GmailOAuth do
   alias LemmingsOs.Connections.Providers.GmailCaller
   alias LemmingsOs.Departments.Department
   alias LemmingsOs.Events
+  alias LemmingsOs.Repo
   alias LemmingsOs.SecretBank
+  alias LemmingsOs.SecretBank.Secret
   alias LemmingsOs.Worlds.World
 
   @session_ttl_seconds 600
@@ -143,10 +148,9 @@ defmodule LemmingsOs.Connections.GmailOAuth do
              redirect_uri
            ),
          {:ok, refresh_token} <- fetch_nonempty_map(token_payload, "refresh_token"),
-         {:ok, refresh_ref} <- upsert_refresh_token(scope, refresh_token),
          profile_email = resolve_profile_email(scope, oauth_client, token_payload),
          {:ok, connection} <-
-           upsert_gmail_connection(scope, config, refresh_ref, profile_email) do
+           persist_connection_and_refresh_token(scope, config, refresh_token, profile_email) do
       {:ok, connection}
     else
       {:error, :invalid_state} -> {:error, :invalid_state}
@@ -193,15 +197,6 @@ defmodule LemmingsOs.Connections.GmailOAuth do
        }}
     else
       _ -> {:error, :invalid_session}
-    end
-  end
-
-  defp upsert_refresh_token(scope, refresh_token) do
-    key = "GMAIL_REFRESH_TOKEN_" <> scope_key_suffix(scope)
-
-    case SecretBank.upsert_secret(scope, key, refresh_token) do
-      {:ok, _metadata} -> {:ok, "$#{key}"}
-      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -254,11 +249,29 @@ defmodule LemmingsOs.Connections.GmailOAuth do
   defp safe_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
   defp safe_reason(_reason), do: "profile_lookup_failed"
 
-  defp upsert_gmail_connection(scope, config, refresh_ref, profile_email) do
+  defp persist_connection_and_refresh_token(scope, config, refresh_token, profile_email) do
     existing =
       scoped_connection(scope, config.connection_id) ||
         Connections.get_connection_by_type(scope, "gmail")
 
+    refresh_key = refresh_token_key(scope)
+    refresh_ref = "$#{refresh_key}"
+    previous_refresh_ref = existing && existing.config && existing.config["refresh_token"]
+    operation = if existing, do: :updated, else: :created
+
+    upsert_gmail_connection_attrs(scope, config, existing, refresh_ref, profile_email)
+    |> build_connection_changeset(existing)
+    |> persist_oauth_completion(
+      scope,
+      refresh_key,
+      refresh_token,
+      previous_refresh_ref,
+      operation
+    )
+  end
+
+  defp upsert_gmail_connection_attrs(scope, config, existing, refresh_ref, profile_email) do
+    {:ok, scope_data} = connection_scope_data(scope)
     existing_email = existing && existing.config && existing.config["account_email"]
 
     account_email =
@@ -267,7 +280,7 @@ defmodule LemmingsOs.Connections.GmailOAuth do
         safe_string(existing_email) ||
         ""
 
-    attrs = %{
+    %{
       type: "gmail",
       status: "enabled",
       config: %{
@@ -279,12 +292,149 @@ defmodule LemmingsOs.Connections.GmailOAuth do
         "account_email" => account_email
       }
     }
+    |> Map.put(:world_id, scope_data.world_id)
+    |> Map.put(:city_id, scope_data.city_id)
+    |> Map.put(:department_id, scope_data.department_id)
+  end
 
-    case existing do
-      nil -> Connections.create_connection(scope, attrs)
-      connection -> Connections.update_connection(scope, connection, attrs)
+  defp build_connection_changeset(attrs, nil), do: Connection.changeset(%Connection{}, attrs)
+
+  defp build_connection_changeset(attrs, %Connection{} = connection),
+    do: Connection.changeset(connection, attrs)
+
+  defp persist_oauth_completion(
+         %Ecto.Changeset{} = connection_changeset,
+         scope,
+         refresh_key,
+         refresh_token,
+         previous_refresh_ref,
+         operation
+       ) do
+    with {:ok, secret_scope_data} <- secret_scope_data(scope),
+         {:ok, connection_scope_data} <- connection_scope_data(scope) do
+      Multi.new()
+      |> Multi.insert(
+        :refresh_secret,
+        refresh_secret_changeset(secret_scope_data, refresh_key, refresh_token)
+      )
+      |> Multi.run(:refresh_secret_event, fn _repo, %{refresh_secret: secret} ->
+        record_secret_created_event(secret, secret_scope_data)
+      end)
+      |> Multi.insert_or_update(:connection, connection_changeset)
+      |> Multi.run(:connection_event, fn _repo, %{connection: connection} ->
+        record_connection_persisted_event(connection, connection_scope_data, operation)
+      end)
+      |> Multi.run(:previous_refresh_secret, fn repo, _changes ->
+        delete_previous_refresh_secret(repo, secret_scope_data, previous_refresh_ref, refresh_key)
+      end)
+      |> Repo.transaction()
+      |> oauth_completion_result()
     end
   end
+
+  defp oauth_completion_result({:ok, %{connection: %Connection{} = connection}}),
+    do: {:ok, connection}
+
+  defp oauth_completion_result({:error, _operation, reason, _changes}), do: {:error, reason}
+
+  defp refresh_secret_changeset(scope_data, refresh_key, refresh_token) do
+    %Secret{}
+    |> struct(scope_data)
+    |> Secret.changeset(%{bank_key: refresh_key, value: refresh_token})
+  end
+
+  defp record_secret_created_event(%Secret{} = secret, scope_data) do
+    Events.record_event(
+      "secret.created",
+      scope_data,
+      "Secret #{secret.bank_key} created",
+      payload: %{
+        secret_ref: "$#{secret.bank_key}",
+        bank_key: secret.bank_key,
+        scope: secret_scope_name(scope_data),
+        source: "local"
+      }
+    )
+  end
+
+  defp record_secret_deleted_event(scope_data, bank_key) do
+    Events.record_event(
+      "secret.deleted",
+      scope_data,
+      "Secret #{bank_key} deleted",
+      payload: %{
+        secret_ref: "$#{bank_key}",
+        bank_key: bank_key,
+        scope: secret_scope_name(scope_data),
+        source: "local"
+      }
+    )
+  end
+
+  defp record_connection_persisted_event(%Connection{} = connection, scope_data, operation) do
+    action = Atom.to_string(operation)
+    event_type = "connection.#{action}"
+
+    Events.record_event(
+      event_type,
+      scope_data,
+      "Connection #{connection.type} #{action}",
+      action: action,
+      status: connection.status,
+      resource_type: "connection",
+      resource_id: connection.id,
+      payload: %{
+        connection_id: connection.id,
+        connection_type: connection.type,
+        status: connection.status,
+        world_id: connection.world_id,
+        city_id: connection.city_id,
+        department_id: connection.department_id,
+        config_keys: Map.keys(connection.config || %{}) |> Enum.map(&to_string/1) |> Enum.sort(),
+        last_test: connection.last_test
+      }
+    )
+  end
+
+  defp delete_previous_refresh_secret(_repo, _scope_data, nil, _refresh_key), do: {:ok, :skipped}
+  defp delete_previous_refresh_secret(_repo, _scope_data, "", _refresh_key), do: {:ok, :skipped}
+
+  defp delete_previous_refresh_secret(_repo, _scope_data, "$" <> refresh_key, refresh_key),
+    do: {:ok, :skipped}
+
+  defp delete_previous_refresh_secret(repo, scope_data, "$" <> previous_key, _refresh_key) do
+    if String.starts_with?(previous_key, "GMAIL_REFRESH_TOKEN_") do
+      {count, _rows} =
+        Secret
+        |> filter_secret_scope(scope_data)
+        |> where([secret], secret.bank_key == ^previous_key)
+        |> repo.delete_all()
+
+      case count do
+        0 -> {:ok, :skipped}
+        _count -> record_secret_deleted_event(scope_data, previous_key)
+      end
+    else
+      {:ok, :skipped}
+    end
+  end
+
+  defp delete_previous_refresh_secret(_repo, _scope_data, _previous_ref, _refresh_key),
+    do: {:ok, :skipped}
+
+  defp filter_secret_scope(query, scope_data) do
+    query
+    |> filter_secret_scope_field(:world_id, scope_data.world_id)
+    |> filter_secret_scope_field(:city_id, scope_data.city_id)
+    |> filter_secret_scope_field(:department_id, scope_data.department_id)
+    |> filter_secret_scope_field(:lemming_id, scope_data.lemming_id)
+  end
+
+  defp filter_secret_scope_field(query, field, nil),
+    do: where(query, [secret], is_nil(field(secret, ^field)))
+
+  defp filter_secret_scope_field(query, field, value),
+    do: where(query, [secret], field(secret, ^field) == ^value)
 
   defp scoped_connection(_scope, nil), do: nil
   defp scoped_connection(_scope, ""), do: nil
@@ -312,6 +462,43 @@ defmodule LemmingsOs.Connections.GmailOAuth do
     do: "DEPARTMENT_" <> sanitize_uuid(department_id)
 
   defp sanitize_uuid(id), do: id |> String.replace("-", "_") |> String.upcase()
+
+  defp refresh_token_key(scope),
+    do:
+      "GMAIL_REFRESH_TOKEN_" <>
+        scope_key_suffix(scope) <> "_" <> sanitize_uuid(Ecto.UUID.generate())
+
+  defp connection_scope_data(%World{id: world_id}) when is_binary(world_id),
+    do: {:ok, %{world_id: world_id, city_id: nil, department_id: nil}}
+
+  defp connection_scope_data(%City{id: city_id, world_id: world_id})
+       when is_binary(city_id) and is_binary(world_id),
+       do: {:ok, %{world_id: world_id, city_id: city_id, department_id: nil}}
+
+  defp connection_scope_data(%Department{id: department_id, city_id: city_id, world_id: world_id})
+       when is_binary(department_id) and is_binary(city_id) and is_binary(world_id),
+       do: {:ok, %{world_id: world_id, city_id: city_id, department_id: department_id}}
+
+  defp connection_scope_data(_scope), do: {:error, :invalid_scope}
+
+  defp secret_scope_data(%World{id: world_id}) when is_binary(world_id),
+    do: {:ok, %{world_id: world_id, city_id: nil, department_id: nil, lemming_id: nil}}
+
+  defp secret_scope_data(%City{id: city_id, world_id: world_id})
+       when is_binary(city_id) and is_binary(world_id),
+       do: {:ok, %{world_id: world_id, city_id: city_id, department_id: nil, lemming_id: nil}}
+
+  defp secret_scope_data(%Department{id: department_id, city_id: city_id, world_id: world_id})
+       when is_binary(department_id) and is_binary(city_id) and is_binary(world_id),
+       do:
+         {:ok,
+          %{world_id: world_id, city_id: city_id, department_id: department_id, lemming_id: nil}}
+
+  defp secret_scope_data(_scope), do: {:error, :invalid_scope}
+
+  defp secret_scope_name(%{city_id: nil, department_id: nil, lemming_id: nil}), do: "world"
+  defp secret_scope_name(%{department_id: nil, lemming_id: nil}), do: "city"
+  defp secret_scope_name(%{lemming_id: nil}), do: "department"
 
   defp scope_data(%World{id: world_id}) when is_binary(world_id) do
     {:ok, %{"kind" => "world", "world_id" => world_id}}

--- a/lib/lemmings_os/connections/gmail_oauth.ex
+++ b/lib/lemmings_os/connections/gmail_oauth.ex
@@ -128,6 +128,7 @@ defmodule LemmingsOs.Connections.GmailOAuth do
     oauth_client = Keyword.get(opts, :oauth_client, Client)
 
     with :ok <- validate_session_state(params, session_state),
+         :ok <- validate_session_scope(scope, session_state),
          {:ok, code} <- fetch_nonempty_map(params, "code"),
          {:ok, redirect_uri} <- fetch_nonempty(opts, :redirect_uri),
          {:ok, config} <- fetch_oauth_config(session_state),
@@ -154,6 +155,16 @@ defmodule LemmingsOs.Connections.GmailOAuth do
       {:error, :missing_secret} -> {:error, :missing_secret}
       {:error, %Ecto.Changeset{} = changeset} -> {:error, changeset}
       _ -> {:error, :oauth_failed}
+    end
+  end
+
+  defp validate_session_scope(scope, session_state) do
+    with {:ok, scope_data} <- scope_data(scope),
+         %{} = session_scope <- Map.get(session_state, "scope"),
+         true <- session_scope == scope_data do
+      :ok
+    else
+      _ -> {:error, :invalid_state}
     end
   end
 

--- a/lib/lemmings_os/connections/gmail_oauth.ex
+++ b/lib/lemmings_os/connections/gmail_oauth.ex
@@ -79,7 +79,8 @@ defmodule LemmingsOs.Connections.GmailOAuth do
            "config" => %{
              "client_id" => client_id_ref,
              "client_secret" => client_secret_ref,
-             "account_email" => safe_string(Map.get(attrs, "account_email"))
+             "account_email" => safe_string(Map.get(attrs, "account_email")),
+             "connection_id" => safe_string(Map.get(attrs, "connection_id"))
            }
          }
        }}
@@ -176,7 +177,8 @@ defmodule LemmingsOs.Connections.GmailOAuth do
        %{
          client_id_ref: client_id_ref,
          client_secret_ref: client_secret_ref,
-         account_email: safe_string(Map.get(config, "account_email"))
+         account_email: safe_string(Map.get(config, "account_email")),
+         connection_id: safe_string(Map.get(config, "connection_id"))
        }}
     else
       _ -> {:error, :invalid_session}
@@ -242,7 +244,10 @@ defmodule LemmingsOs.Connections.GmailOAuth do
   defp safe_reason(_reason), do: "profile_lookup_failed"
 
   defp upsert_gmail_connection(scope, config, refresh_ref, profile_email) do
-    existing = Connections.get_connection_by_type(scope, "gmail")
+    existing =
+      scoped_connection(scope, config.connection_id) ||
+        Connections.get_connection_by_type(scope, "gmail")
+
     existing_email = existing && existing.config && existing.config["account_email"]
 
     account_email =
@@ -267,6 +272,16 @@ defmodule LemmingsOs.Connections.GmailOAuth do
     case existing do
       nil -> Connections.create_connection(scope, attrs)
       connection -> Connections.update_connection(scope, connection, attrs)
+    end
+  end
+
+  defp scoped_connection(_scope, nil), do: nil
+  defp scoped_connection(_scope, ""), do: nil
+
+  defp scoped_connection(scope, connection_id) do
+    case Connections.get_connection(scope, connection_id) do
+      %Connection{type: "gmail"} = connection -> connection
+      _ -> nil
     end
   end
 

--- a/lib/lemmings_os/connections/gmail_oauth/client.ex
+++ b/lib/lemmings_os/connections/gmail_oauth/client.ex
@@ -1,0 +1,92 @@
+defmodule LemmingsOs.Connections.GmailOAuth.Client do
+  @moduledoc """
+  Req-backed Google OAuth token exchange client.
+
+  This module is intentionally narrow: it exchanges an authorization code for
+  OAuth tokens, then supports a safe profile email lookup from Gmail.
+  """
+
+  @token_url "https://oauth2.googleapis.com/token"
+  @profile_url "https://gmail.googleapis.com/gmail/v1/users/me/profile"
+  @type token_payload :: map()
+
+  @doc """
+  Exchanges a Google OAuth authorization code for token payload data.
+
+  `opts` accepts `:req` to inject a Req-compatible module in tests.
+
+  ## Examples
+
+      iex> {:ok, payload} =
+      ...>   LemmingsOs.Connections.GmailOAuth.Client.exchange_code(
+      ...>     "client-id",
+      ...>     "client-secret",
+      ...>     "auth-code",
+      ...>     "https://example.test/oauth/callback",
+      ...>     req: LemmingsOs.TestSupport.GmailOAuthReqSuccess
+      ...>   )
+      iex> payload["refresh_token"]
+      "test-refresh-token"
+
+      iex> LemmingsOs.Connections.GmailOAuth.Client.exchange_code(
+      ...>   "client-id",
+      ...>   "client-secret",
+      ...>   "auth-code",
+      ...>   "https://example.test/oauth/callback",
+      ...>   req: LemmingsOs.TestSupport.GmailOAuthReqFailure
+      ...> )
+      {:error, :oauth_exchange_failed}
+  """
+  @spec exchange_code(String.t(), String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, token_payload()} | {:error, :oauth_exchange_failed}
+  def exchange_code(client_id, client_secret, code, redirect_uri, opts \\ []) do
+    req = Keyword.get(opts, :req, Req)
+
+    body = %{
+      client_id: client_id,
+      client_secret: client_secret,
+      code: code,
+      grant_type: "authorization_code",
+      redirect_uri: redirect_uri
+    }
+
+    case req.post(@token_url, form: body) do
+      {:ok, %Req.Response{status: 200, body: %{} = payload}} -> {:ok, payload}
+      _ -> {:error, :oauth_exchange_failed}
+    end
+  end
+
+  @doc """
+  Fetches the authenticated Gmail account email from `users.getProfile`.
+
+  `opts` accepts `:req` to inject a Req-compatible module in tests.
+
+  ## Examples
+
+      iex> LemmingsOs.Connections.GmailOAuth.Client.fetch_profile(
+      ...>   "test-access-token",
+      ...>   req: LemmingsOs.TestSupport.GmailOAuthReqSuccess
+      ...> )
+      {:ok, "owner@example.test"}
+
+      iex> LemmingsOs.Connections.GmailOAuth.Client.fetch_profile(
+      ...>   "test-access-token",
+      ...>   req: LemmingsOs.TestSupport.GmailOAuthReqFailure
+      ...> )
+      {:error, :profile_lookup_failed}
+  """
+  @spec fetch_profile(String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :profile_lookup_failed}
+  def fetch_profile(access_token, opts \\ []) when is_binary(access_token) do
+    req = Keyword.get(opts, :req, Req)
+
+    case req.get(@profile_url, headers: [{"authorization", "Bearer #{access_token}"}]) do
+      {:ok, %Req.Response{status: 200, body: %{"emailAddress" => email}}}
+      when is_binary(email) and email != "" ->
+        {:ok, email}
+
+      _ ->
+        {:error, :profile_lookup_failed}
+    end
+  end
+end

--- a/lib/lemmings_os/connections/providers/gmail_caller.ex
+++ b/lib/lemmings_os/connections/providers/gmail_caller.ex
@@ -1,0 +1,107 @@
+defmodule LemmingsOs.Connections.Providers.GmailCaller do
+  @moduledoc """
+  Gmail connection config contract for OAuth-backed draft creation.
+  """
+
+  alias LemmingsOs.Connections.Connection
+
+  @compose_scope "https://www.googleapis.com/auth/gmail.compose"
+  @required_keys ~w(provider scopes client_id client_secret refresh_token)
+  @optional_keys ~w(account_email)
+  @allowed_keys @required_keys ++ @optional_keys
+  @secret_ref_keys ~w(client_id client_secret refresh_token)
+
+  @doc """
+  Returns the stable type identifier handled by this provider.
+
+  ## Examples
+
+      iex> LemmingsOs.Connections.Providers.GmailCaller.type_id()
+      "gmail"
+  """
+  @spec type_id() :: String.t()
+  def type_id, do: "gmail"
+
+  @doc """
+  Returns a human label for UI surfaces.
+  """
+  @spec label() :: String.t()
+  def label, do: "Gmail"
+
+  @doc """
+  Returns an editable default config example.
+  """
+  @spec default_config_example() :: map()
+  def default_config_example do
+    %{
+      "provider" => "gmail",
+      "account_email" => "",
+      "scopes" => [@compose_scope],
+      "client_id" => "$GMAIL_OAUTH_CLIENT_ID",
+      "client_secret" => "$GMAIL_OAUTH_CLIENT_SECRET",
+      "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+    }
+  end
+
+  @doc """
+  Indicates this type does not support generic runtime connection tests.
+  """
+  @spec test_supported?() :: boolean()
+  def test_supported?, do: false
+
+  @doc """
+  Validates Gmail config structure and secret references.
+  """
+  @spec validate_config(map()) :: :ok | {:error, :invalid_config}
+  def validate_config(config) when is_map(config) do
+    with :ok <- validate_keys(config),
+         :ok <- validate_provider(config),
+         :ok <- validate_scopes(config),
+         :ok <- validate_secret_refs(config),
+         :ok <- validate_account_email(config) do
+      :ok
+    else
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  def validate_config(_config), do: {:error, :invalid_config}
+
+  @doc """
+  Gmail is exercised through dedicated OAuth and draft APIs.
+  """
+  @spec call(map(), Connection.t()) :: {:error, :unsupported_type}
+  def call(_scope, %Connection{}), do: {:error, :unsupported_type}
+
+  @spec compose_scope() :: String.t()
+  def compose_scope, do: @compose_scope
+
+  defp validate_keys(config) do
+    keys = Map.keys(config)
+
+    with true <- Enum.all?(@required_keys, &Map.has_key?(config, &1)),
+         true <- Enum.all?(keys, &(&1 in @allowed_keys)) do
+      :ok
+    else
+      _ -> {:error, :invalid_config}
+    end
+  end
+
+  defp validate_provider(%{"provider" => "gmail"}), do: :ok
+  defp validate_provider(_config), do: {:error, :invalid_config}
+
+  defp validate_scopes(%{"scopes" => [@compose_scope]}), do: :ok
+  defp validate_scopes(_config), do: {:error, :invalid_config}
+
+  defp validate_secret_refs(config) do
+    Enum.reduce_while(@secret_ref_keys, :ok, fn key, :ok ->
+      case Map.get(config, key) do
+        "$" <> rest when rest != "" -> {:cont, :ok}
+        _ -> {:halt, {:error, :invalid_config}}
+      end
+    end)
+  end
+
+  defp validate_account_email(%{"account_email" => email}) when is_binary(email), do: :ok
+  defp validate_account_email(%{}), do: :ok
+end

--- a/lib/lemmings_os/connections/providers/gmail_caller.ex
+++ b/lib/lemmings_os/connections/providers/gmail_caller.ex
@@ -6,8 +6,8 @@ defmodule LemmingsOs.Connections.Providers.GmailCaller do
   alias LemmingsOs.Connections.Connection
 
   @compose_scope "https://www.googleapis.com/auth/gmail.compose"
-  @required_keys ~w(provider scopes client_id client_secret refresh_token)
-  @optional_keys ~w(account_email)
+  @required_keys ~w(provider scopes client_id client_secret)
+  @optional_keys ~w(account_email refresh_token)
   @allowed_keys @required_keys ++ @optional_keys
   @secret_ref_keys ~w(client_id client_secret refresh_token)
 
@@ -37,9 +37,8 @@ defmodule LemmingsOs.Connections.Providers.GmailCaller do
       "provider" => "gmail",
       "account_email" => "",
       "scopes" => [@compose_scope],
-      "client_id" => "$GMAIL_OAUTH_CLIENT_ID",
-      "client_secret" => "$GMAIL_OAUTH_CLIENT_SECRET",
-      "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+      "client_id" => "$GMAIL_CLIENT_ID",
+      "client_secret" => "$GMAIL_CLIENT_SECRET"
     }
   end
 
@@ -94,8 +93,10 @@ defmodule LemmingsOs.Connections.Providers.GmailCaller do
   defp validate_scopes(_config), do: {:error, :invalid_config}
 
   defp validate_secret_refs(config) do
-    Enum.reduce_while(@secret_ref_keys, :ok, fn key, :ok ->
-      case Map.get(config, key) do
+    config
+    |> Map.take(@secret_ref_keys)
+    |> Enum.reduce_while(:ok, fn {_key, value}, :ok ->
+      case value do
         "$" <> rest when rest != "" -> {:cont, :ok}
         _ -> {:halt, {:error, :invalid_config}}
       end

--- a/lib/lemmings_os/connections/type_registry.ex
+++ b/lib/lemmings_os/connections/type_registry.ex
@@ -9,9 +9,11 @@ defmodule LemmingsOs.Connections.TypeRegistry do
   """
 
   alias LemmingsOs.Connections.Providers.MockCaller
+  alias LemmingsOs.Connections.Providers.GmailCaller
 
   @entries [
-    %{id: "mock", module: MockCaller}
+    %{id: "mock", module: MockCaller},
+    %{id: "gmail", module: GmailCaller}
   ]
 
   @doc """
@@ -19,11 +21,11 @@ defmodule LemmingsOs.Connections.TypeRegistry do
 
   ## Examples
 
-      iex> [type] = LemmingsOs.Connections.TypeRegistry.list_types()
+      iex> [type | _] = LemmingsOs.Connections.TypeRegistry.list_types()
       iex> type.id
       "mock"
 
-      iex> [type] = LemmingsOs.Connections.TypeRegistry.list_types()
+      iex> [type | _] = LemmingsOs.Connections.TypeRegistry.list_types()
       iex> type.label
       "Mock"
   """

--- a/lib/lemmings_os/lemming_tools.ex
+++ b/lib/lemmings_os/lemming_tools.ex
@@ -10,6 +10,9 @@ defmodule LemmingsOs.LemmingTools do
   alias LemmingsOs.Repo
   alias LemmingsOs.Worlds.World
 
+  @email_draft_tool "email.create_draft"
+  @subject_preview_bytes 80
+
   @doc """
   Creates a durable tool-execution record for a runtime instance in a World scope.
 
@@ -49,7 +52,9 @@ defmodule LemmingsOs.LemmingTools do
       when is_binary(instance_id) and is_map(attrs) do
     %ToolExecution{}
     |> ToolExecution.create_changeset(
-      Map.merge(attrs, %{lemming_instance_id: instance_id, world_id: world_id})
+      attrs
+      |> sanitize_tool_execution_attrs()
+      |> Map.merge(%{lemming_instance_id: instance_id, world_id: world_id})
     )
     |> Repo.insert()
   end
@@ -214,11 +219,151 @@ defmodule LemmingsOs.LemmingTools do
       )
       when is_binary(tool_execution_id) and is_map(attrs) do
     tool_execution
-    |> ToolExecution.update_changeset(attrs)
+    |> ToolExecution.update_changeset(sanitize_tool_execution_attrs(tool_execution, attrs))
     |> Repo.update()
   end
 
   def update_tool_execution(_, _, _, _), do: {:error, :not_found}
+
+  defp sanitize_tool_execution_attrs(%{"tool_name" => @email_draft_tool} = attrs),
+    do: sanitize_email_draft_attrs(attrs)
+
+  defp sanitize_tool_execution_attrs(%{tool_name: @email_draft_tool} = attrs),
+    do: sanitize_email_draft_attrs(attrs)
+
+  defp sanitize_tool_execution_attrs(attrs), do: attrs
+
+  defp sanitize_tool_execution_attrs(%ToolExecution{tool_name: @email_draft_tool}, attrs),
+    do: sanitize_email_draft_attrs(attrs)
+
+  defp sanitize_tool_execution_attrs(_tool_execution, attrs), do: attrs
+
+  defp sanitize_email_draft_attrs(attrs) do
+    attrs
+    |> maybe_update_payload(:args, &safe_email_draft_args/1)
+    |> maybe_update_payload("args", &safe_email_draft_args/1)
+    |> maybe_update_payload(:result, &safe_email_draft_result/1)
+    |> maybe_update_payload("result", &safe_email_draft_result/1)
+  end
+
+  defp maybe_update_payload(attrs, key, fun) when is_map(attrs) do
+    case Map.fetch(attrs, key) do
+      {:ok, payload} when is_map(payload) -> Map.put(attrs, key, fun.(payload))
+      _missing_or_invalid -> attrs
+    end
+  end
+
+  defp safe_email_draft_args(args) do
+    %{}
+    |> maybe_put_safe_string("connection_ref", fetch_payload(args, "connection_ref"))
+    |> Map.put("to_count", recipient_count(fetch_payload(args, "to")))
+    |> Map.put("cc_count", recipient_count(fetch_payload(args, "cc")))
+    |> Map.put("bcc_count", recipient_count(fetch_payload(args, "bcc")))
+    |> maybe_put_safe_string("subject_preview", subject_preview(fetch_payload(args, "subject")))
+    |> Map.put("body_bytes", body_bytes(fetch_payload(args, "body")))
+    |> maybe_put_safe_string("body_format", fetch_payload(args, "body_format"))
+    |> Map.put("artifact_count", artifact_ids(args) |> length())
+    |> Map.put("artifact_ids", artifact_ids(args))
+  end
+
+  defp safe_email_draft_result(result) do
+    %{}
+    |> maybe_put_safe_string("status", fetch_payload(result, "status"))
+    |> maybe_put_safe_string("provider", fetch_payload(result, "provider"))
+    |> maybe_put_safe_string("connection_ref", fetch_payload(result, "connection_ref"))
+    |> maybe_put_safe_string("draft_id", fetch_payload(result, "draft_id"))
+    |> maybe_put_safe_string("message_id", fetch_payload(result, "message_id"))
+    |> Map.put("to_count", result_count(result, "to"))
+    |> Map.put("cc_count", result_count(result, "cc"))
+    |> Map.put("bcc_count", result_count(result, "bcc"))
+    |> maybe_put_safe_string("subject_preview", subject_preview(fetch_payload(result, "subject")))
+    |> maybe_put_safe_string("subject_preview", fetch_payload(result, "subject_preview"))
+    |> Map.put("artifact_count", artifact_count(result))
+    |> Map.put("artifact_ids", artifact_ids(result))
+  end
+
+  defp result_count(payload, field) do
+    case fetch_payload(payload, "#{field}_count") do
+      value when is_integer(value) and value >= 0 -> value
+      _value -> recipient_count(fetch_payload(payload, field))
+    end
+  end
+
+  defp artifact_count(payload) do
+    case fetch_payload(payload, "artifact_count") do
+      value when is_integer(value) and value >= 0 -> value
+      _value -> artifact_ids(payload) |> length()
+    end
+  end
+
+  defp recipient_count(value) when is_list(value), do: length(value)
+
+  defp recipient_count(value) when is_binary(value) do
+    value
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> length()
+  end
+
+  defp recipient_count(_value), do: 0
+
+  defp body_bytes(value) when is_binary(value), do: byte_size(value)
+  defp body_bytes(_value), do: 0
+
+  defp artifact_ids(payload) when is_map(payload) do
+    payload
+    |> fetch_payload("artifact_ids")
+    |> safe_string_list()
+  end
+
+  defp subject_preview(value) when is_binary(value) do
+    value
+    |> String.trim()
+    |> String.slice(0, @subject_preview_bytes)
+  end
+
+  defp subject_preview(_value), do: nil
+
+  defp safe_string_list(values) when is_list(values) do
+    values
+    |> Enum.filter(&is_binary/1)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp safe_string_list(_values), do: []
+
+  defp maybe_put_safe_string(map, _key, nil), do: map
+  defp maybe_put_safe_string(map, _key, ""), do: map
+  defp maybe_put_safe_string(map, key, value) when is_binary(value), do: Map.put(map, key, value)
+  defp maybe_put_safe_string(map, _key, _value), do: map
+
+  defp fetch_payload(payload, key) when is_map(payload) and is_binary(key) do
+    case payload_atom_key(key) do
+      nil -> Map.get(payload, key)
+      atom_key -> Map.get(payload, key) || Map.get(payload, atom_key)
+    end
+  end
+
+  defp payload_atom_key("connection_ref"), do: :connection_ref
+  defp payload_atom_key("to"), do: :to
+  defp payload_atom_key("cc"), do: :cc
+  defp payload_atom_key("bcc"), do: :bcc
+  defp payload_atom_key("subject"), do: :subject
+  defp payload_atom_key("body"), do: :body
+  defp payload_atom_key("body_format"), do: :body_format
+  defp payload_atom_key("artifact_ids"), do: :artifact_ids
+  defp payload_atom_key("to_count"), do: :to_count
+  defp payload_atom_key("cc_count"), do: :cc_count
+  defp payload_atom_key("bcc_count"), do: :bcc_count
+  defp payload_atom_key("subject_preview"), do: :subject_preview
+  defp payload_atom_key("artifact_count"), do: :artifact_count
+  defp payload_atom_key("status"), do: :status
+  defp payload_atom_key("provider"), do: :provider
+  defp payload_atom_key("draft_id"), do: :draft_id
+  defp payload_atom_key("message_id"), do: :message_id
+  defp payload_atom_key(_key), do: nil
 
   defp filter_query(query, [{:status, status} | rest]),
     do: filter_query(from(item in query, where: field(item, ^:status) == ^status), rest)

--- a/lib/lemmings_os/model_runtime.ex
+++ b/lib/lemmings_os/model_runtime.ex
@@ -514,6 +514,10 @@ defmodule LemmingsOs.ModelRuntime do
     "required `source_path` (WorkArea-relative supported source); optional `output_path` (defaults to same path with `.pdf`); optional `overwrite` (default `true`); optional `print_raw_file` (default `false`); optional `header_path`/`footer_path`; optional `style_paths` (list of `.css`); optional `paper_size`, `landscape`, `margin_top`, `margin_bottom`, `margin_left`, `margin_right`."
   end
 
+  defp tool_argument_contract("email.create_draft") do
+    "required `connection_ref` (`gmail`), `to` (recipient email string, comma-separated string, or list), `subject`, and `body`; optional `cc`/`bcc` (list, string, comma-separated string, nil, or blank; default []); optional `body_format` (`text/plain` default, or `text/html`); optional `artifact_ids` (list, default []). Creates a Gmail draft only; never sends email."
+  end
+
   defp tool_argument_contract(_tool_id), do: nil
 
   defp available_lemming_calls_message(config_snapshot) do

--- a/lib/lemmings_os/tools/adapters/email.ex
+++ b/lib/lemmings_os/tools/adapters/email.ex
@@ -26,6 +26,7 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   @tool_name "email.create_draft"
   @provider "gmail"
   @connection_ref "gmail"
+  @default_body_format "text/plain"
   @allowed_body_formats MapSet.new(["text/plain", "text/html"])
   @allowed_fields MapSet.new([
                     "connection_ref",
@@ -80,12 +81,16 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   - `instance`: `%LemmingsOs.LemmingInstances.LemmingInstance{}` execution scope.
   - `args`:
     - `"connection_ref"` (required): must be `"gmail"`.
-    - `"to"` (required): non-empty list of recipient email strings.
-    - `"cc"` (optional): list of recipient email strings. Default: `[]`.
-    - `"bcc"` (optional): list of recipient email strings. Default: `[]`.
+    - `"to"` (required): non-empty recipient email string, comma-separated
+      recipient email string, or list of recipient email strings.
+    - `"cc"` (optional): recipient email string, comma-separated recipient
+      email string, list of recipient email strings, `nil`, or `""`. Default: `[]`.
+    - `"bcc"` (optional): recipient email string, comma-separated recipient
+      email string, list of recipient email strings, `nil`, or `""`. Default: `[]`.
     - `"subject"` (required): non-empty string.
     - `"body"` (required): body string.
-    - `"body_format"` (required): `"text/plain"` or `"text/html"`.
+    - `"body_format"` (optional): `"text/plain"` or `"text/html"`.
+      Default: `"text/plain"`.
     - `"artifact_ids"` (optional): list of Artifact IDs. Default: `[]`.
   - `runtime_meta` (optional): runtime metadata map. Default: `%{}`.
   - `trusted_config` (optional): trusted adapter config map. Default: `%{}`.
@@ -162,12 +167,17 @@ defmodule LemmingsOs.Tools.Adapters.Email do
         trusted_config \\ %{}
       )
       when is_map(args) and is_map(runtime_meta) and is_map(trusted_config) do
-    with {:ok, parsed_args} <- validate_args(args) do
-      _ = record_requested_event(instance, parsed_args)
+    case validate_args(args) do
+      {:ok, parsed_args} ->
+        _ = record_requested_event(instance, parsed_args)
 
-      instance
-      |> run_create_draft(parsed_args, trusted_config)
-      |> finalize_with_events(instance, parsed_args)
+        instance
+        |> run_create_draft(parsed_args, trusted_config)
+        |> finalize_with_events(instance, parsed_args)
+
+      {:error, %{} = error} ->
+        _ = record_invalid_args_failed_event(instance)
+        {:error, error}
     end
   end
 
@@ -283,37 +293,52 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   end
 
   defp validate_required_recipients(args, field) do
-    case fetch_arg(args, field) do
-      values when is_list(values) and values != [] ->
-        normalize_recipients(values, field)
+    case normalize_recipient_values(fetch_arg(args, field), field) do
+      {:ok, []} ->
+        required_field_error(field)
 
-      _other ->
-        {:error,
-         %{
-           code: "tool.validation.invalid_args",
-           message: "Invalid tool arguments",
-           details: %{required: [field]}
-         }}
+      {:ok, recipients} ->
+        {:ok, recipients}
+
+      {:error, %{} = error} ->
+        {:error, error}
     end
   end
 
   defp validate_optional_recipients(args, field) do
-    case fetch_arg(args, field) do
-      nil ->
-        {:ok, []}
+    case normalize_recipient_values(fetch_arg(args, field), field) do
+      {:ok, recipients} ->
+        {:ok, recipients}
 
-      values when is_list(values) ->
-        normalize_recipients(values, field)
-
-      _other ->
-        {:error,
-         %{
-           code: "tool.validation.invalid_args",
-           message: "Invalid tool arguments",
-           details: %{field: field}
-         }}
+      {:error, %{} = error} ->
+        {:error, error}
     end
   end
+
+  defp normalize_recipient_values(nil, _field), do: {:ok, []}
+
+  defp normalize_recipient_values(value, field) when is_binary(value) do
+    value
+    |> recipient_candidates()
+    |> normalize_recipients(field)
+  end
+
+  defp normalize_recipient_values(values, field) when is_list(values) do
+    values
+    |> Enum.flat_map(&recipient_candidates/1)
+    |> normalize_recipients(field)
+  end
+
+  defp normalize_recipient_values(_values, field), do: {:error, invalid_args_error(field)}
+
+  defp recipient_candidates(value) when is_binary(value) do
+    value
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  defp recipient_candidates(value), do: [value]
 
   defp normalize_recipients(values, field) do
     values
@@ -369,27 +394,48 @@ defmodule LemmingsOs.Tools.Adapters.Email do
 
   defp validate_body_format(args) do
     case fetch_arg(args, "body_format") do
+      nil ->
+        {:ok, @default_body_format}
+
       value when is_binary(value) ->
-        if MapSet.member?(@allowed_body_formats, value) do
-          {:ok, value}
-        else
-          {:error, invalid_body_format_error(value)}
+        normalized = String.trim(value)
+
+        cond do
+          normalized == "" ->
+            {:ok, @default_body_format}
+
+          MapSet.member?(@allowed_body_formats, normalized) ->
+            {:ok, normalized}
+
+          true ->
+            {:error, invalid_body_format_error(normalized)}
         end
 
       _other ->
-        {:error,
-         %{
-           code: "tool.validation.invalid_args",
-           message: "Invalid tool arguments",
-           details: %{required: ["body_format"]}
-         }}
+        {:error, invalid_args_error("body_format")}
     end
+  end
+
+  defp required_field_error(field) do
+    {:error,
+     %{
+       code: "tool.validation.invalid_args",
+       message: "Invalid tool arguments",
+       details: %{required: [field]}
+     }}
   end
 
   defp validate_artifact_ids(args) do
     case fetch_arg(args, "artifact_ids") do
       nil ->
         {:ok, []}
+
+      value when is_binary(value) ->
+        if String.trim(value) == "" do
+          {:ok, []}
+        else
+          {:error, invalid_args_error("artifact_ids")}
+        end
 
       values when is_list(values) ->
         normalize_artifact_ids(values)
@@ -783,6 +829,20 @@ defmodule LemmingsOs.Tools.Adapters.Email do
       base_event_payload(instance, parsed_args, connection_id)
       |> Map.put(:status, "failed")
       |> Map.put(:error_code, Map.get(error, :code))
+
+    record_event(instance, "email.draft_failed", "Email draft failed", payload)
+  end
+
+  defp record_invalid_args_failed_event(instance) do
+    payload = %{
+      world_id: instance.world_id,
+      city_id: instance.city_id,
+      department_id: instance.department_id,
+      lemming_instance_id: instance.id,
+      tool_name: @tool_name,
+      status: "failed",
+      error_code: "invalid_args"
+    }
 
     record_event(instance, "email.draft_failed", "Email draft failed", payload)
   end

--- a/lib/lemmings_os/tools/adapters/email.ex
+++ b/lib/lemmings_os/tools/adapters/email.ex
@@ -1,0 +1,981 @@
+defmodule LemmingsOs.Tools.Adapters.Email do
+  @moduledoc """
+  Email adapter boundary for Tool Runtime.
+
+  Supported tool:
+  - `email.create_draft`
+
+  This adapter currently supports Gmail draft creation only. It validates
+  tool input, resolves a scoped Gmail Connection, resolves Secret Bank refs
+  only at execution time, builds a MIME message, and creates a Gmail draft.
+  It never sends email.
+  """
+
+  alias LemmingsOs.Artifacts
+  alias LemmingsOs.Cities.City
+  alias LemmingsOs.Connections.Providers.GmailCaller
+  alias LemmingsOs.Connections.Runtime, as: ConnectionsRuntime
+  alias LemmingsOs.Departments.Department
+  alias LemmingsOs.Events
+  alias LemmingsOs.LemmingInstances.LemmingInstance
+  alias LemmingsOs.Lemmings.Lemming
+  alias LemmingsOs.SecretBank
+  alias LemmingsOs.Tools.Adapters.Email.GmailClient
+  alias LemmingsOs.Worlds.World
+
+  @tool_name "email.create_draft"
+  @provider "gmail"
+  @connection_ref "gmail"
+  @allowed_body_formats MapSet.new(["text/plain", "text/html"])
+  @allowed_fields MapSet.new([
+                    "connection_ref",
+                    "to",
+                    "cc",
+                    "bcc",
+                    "subject",
+                    "body",
+                    "body_format",
+                    "artifact_ids"
+                  ])
+  @email_regex ~r/^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+  @type runtime_meta :: %{
+          optional(:actor_instance_id) => String.t(),
+          optional(:work_area_ref) => String.t(),
+          optional(:world_id) => String.t(),
+          optional(:city_id) => String.t(),
+          optional(:department_id) => String.t()
+        }
+
+  @type success_result :: %{
+          summary: String.t(),
+          preview: String.t() | nil,
+          result: map()
+        }
+
+  @type error_result :: %{
+          code: String.t(),
+          message: String.t(),
+          details: map()
+        }
+
+  @type trusted_config :: map()
+
+  @type parsed_args :: %{
+          connection_ref: String.t(),
+          to: [String.t()],
+          cc: [String.t()],
+          bcc: [String.t()],
+          subject: String.t(),
+          body: String.t(),
+          body_format: String.t(),
+          artifact_ids: [Ecto.UUID.t()]
+        }
+
+  @doc """
+  Creates one Gmail draft from prepared content and optional Artifact attachments.
+
+  ## Parameters
+
+  - `instance`: `%LemmingsOs.LemmingInstances.LemmingInstance{}` execution scope.
+  - `args`:
+    - `"connection_ref"` (required): must be `"gmail"`.
+    - `"to"` (required): non-empty list of recipient email strings.
+    - `"cc"` (optional): list of recipient email strings. Default: `[]`.
+    - `"bcc"` (optional): list of recipient email strings. Default: `[]`.
+    - `"subject"` (required): non-empty string.
+    - `"body"` (required): body string.
+    - `"body_format"` (required): `"text/plain"` or `"text/html"`.
+    - `"artifact_ids"` (optional): list of Artifact IDs. Default: `[]`.
+  - `runtime_meta` (optional): runtime metadata map. Default: `%{}`.
+  - `trusted_config` (optional): trusted adapter config map. Default: `%{}`.
+
+    Supported trusted config keys:
+    - `"gmail_client"` / `:gmail_client` (optional): module implementing Gmail HTTP boundary.
+      Default: `LemmingsOs.Tools.Adapters.Email.GmailClient`.
+    - `"gmail_client_opts"` / `:gmail_client_opts` (optional): map/keyword forwarded to Gmail client.
+      Default: `%{}`.
+
+  ## Examples
+
+      iex> world = insert(:world)
+      iex> city = insert(:city, world: world)
+      iex> department = insert(:department, world: world, city: city)
+      iex> lemming = insert(:lemming, world: world, city: city, department: department)
+      iex> instance =
+      ...>   insert(:lemming_instance,
+      ...>     world: world,
+      ...>     city: city,
+      ...>     department: department,
+      ...>     lemming: lemming
+      ...>   )
+      iex> {:ok, _} = LemmingsOs.SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "client-id")
+      iex> {:ok, _} = LemmingsOs.SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET", "client-secret")
+      iex> {:ok, _} = LemmingsOs.SecretBank.upsert_secret(world, "GMAIL_REFRESH_TOKEN", "refresh-token")
+      iex> insert(:world_connection,
+      ...>   world: world,
+      ...>   type: "gmail",
+      ...>   status: "enabled",
+      ...>   config: %{
+      ...>     "provider" => "gmail",
+      ...>     "account_email" => "ops@example.test",
+      ...>     "scopes" => [LemmingsOs.Connections.Providers.GmailCaller.compose_scope()],
+      ...>     "client_id" => "$GMAIL_CLIENT_ID",
+      ...>     "client_secret" => "$GMAIL_CLIENT_SECRET",
+      ...>     "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+      ...>   }
+      ...> )
+      iex> {:ok, result} =
+      ...>   LemmingsOs.Tools.Adapters.Email.create_draft(
+      ...>     instance,
+      ...>     %{
+      ...>       "connection_ref" => "gmail",
+      ...>       "to" => ["customer@example.test"],
+      ...>       "subject" => "Quotation",
+      ...>       "body" => "Draft body",
+      ...>       "body_format" => "text/plain"
+      ...>     },
+      ...>     %{},
+      ...>     %{
+      ...>       "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientSuccess,
+      ...>       "gmail_client_opts" => %{"access_token" => "test-access-token"}
+      ...>     }
+      ...>   )
+      iex> result.result["status"]
+      "draft_created"
+
+      iex> instance = %LemmingsOs.LemmingInstances.LemmingInstance{id: Ecto.UUID.generate()}
+      iex> {:error, error} =
+      ...>   LemmingsOs.Tools.Adapters.Email.create_draft(
+      ...>     instance,
+      ...>     %{"to" => ["ops@example.com"]}
+      ...>   )
+      iex> error.code
+      "tool.validation.invalid_args"
+  """
+  @spec create_draft(LemmingInstance.t(), map(), runtime_meta(), trusted_config()) ::
+          {:ok, success_result()} | {:error, error_result()}
+  def create_draft(
+        %LemmingInstance{} = instance,
+        args,
+        runtime_meta \\ %{},
+        trusted_config \\ %{}
+      )
+      when is_map(args) and is_map(runtime_meta) and is_map(trusted_config) do
+    with {:ok, parsed_args} <- validate_args(args) do
+      _ = record_requested_event(instance, parsed_args)
+
+      instance
+      |> run_create_draft(parsed_args, trusted_config)
+      |> finalize_with_events(instance, parsed_args)
+    end
+  end
+
+  defp run_create_draft(%LemmingInstance{} = instance, parsed_args, trusted_config) do
+    case resolve_gmail_connection(instance, parsed_args.connection_ref) do
+      {:ok, connection_scope, descriptor} ->
+        connection_id = descriptor.connection_id
+
+        with {:ok, attachments} <- load_attachments(instance, parsed_args.artifact_ids),
+             {:ok, resolved_secrets} <-
+               resolve_connection_secrets(connection_scope, descriptor.config),
+             {:ok, access_token} <- exchange_refresh_token(resolved_secrets, trusted_config),
+             raw_message <- build_raw_message(parsed_args, attachments),
+             {:ok, draft} <- create_gmail_draft(access_token, raw_message, trusted_config) do
+          {:ok, success_payload(parsed_args, draft),
+           %{connection_id: connection_id, draft_id: draft.draft_id}}
+        else
+          {:error, %{} = error} ->
+            {:error, error, %{connection_id: connection_id}}
+        end
+
+      {:error, %{} = error} ->
+        {:error, error, %{connection_id: nil}}
+    end
+  end
+
+  defp finalize_with_events(
+         {:ok, payload, %{connection_id: connection_id, draft_id: draft_id}},
+         instance,
+         parsed_args
+       ) do
+    _ = record_created_event(instance, parsed_args, connection_id, draft_id)
+    {:ok, payload}
+  end
+
+  defp finalize_with_events(
+         {:error, error, %{connection_id: connection_id}},
+         instance,
+         parsed_args
+       ) do
+    _ = record_failed_event(instance, parsed_args, connection_id, error)
+    {:error, error}
+  end
+
+  defp validate_args(args) do
+    with :ok <- validate_allowed_fields(args),
+         {:ok, connection_ref} <- validate_connection_ref(args),
+         {:ok, to} <- validate_required_recipients(args, "to"),
+         {:ok, cc} <- validate_optional_recipients(args, "cc"),
+         {:ok, bcc} <- validate_optional_recipients(args, "bcc"),
+         {:ok, subject} <- validate_required_text(args, "subject"),
+         {:ok, body} <- validate_required_text(args, "body"),
+         {:ok, body_format} <- validate_body_format(args),
+         {:ok, artifact_ids} <- validate_artifact_ids(args) do
+      {:ok,
+       %{
+         connection_ref: connection_ref,
+         to: to,
+         cc: cc,
+         bcc: bcc,
+         subject: subject,
+         body: body,
+         body_format: body_format,
+         artifact_ids: artifact_ids
+       }}
+    end
+  end
+
+  defp validate_allowed_fields(args) when is_map(args) do
+    unsupported_fields =
+      args
+      |> Map.keys()
+      |> Enum.map(&normalize_arg_key/1)
+      |> Enum.reject(&MapSet.member?(@allowed_fields, &1))
+      |> Enum.uniq()
+      |> Enum.sort()
+
+    case unsupported_fields do
+      [] ->
+        :ok
+
+      _ ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{unsupported_fields: unsupported_fields}
+         }}
+    end
+  end
+
+  defp validate_connection_ref(args) do
+    case fetch_arg(args, "connection_ref") do
+      @connection_ref ->
+        {:ok, @connection_ref}
+
+      value when is_binary(value) ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{field: "connection_ref", allowed: [@connection_ref]}
+         }}
+
+      _missing ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{required: ["connection_ref"]}
+         }}
+    end
+  end
+
+  defp validate_required_recipients(args, field) do
+    case fetch_arg(args, field) do
+      values when is_list(values) and values != [] ->
+        normalize_recipients(values, field)
+
+      _other ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{required: [field]}
+         }}
+    end
+  end
+
+  defp validate_optional_recipients(args, field) do
+    case fetch_arg(args, field) do
+      nil ->
+        {:ok, []}
+
+      values when is_list(values) ->
+        normalize_recipients(values, field)
+
+      _other ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{field: field}
+         }}
+    end
+  end
+
+  defp normalize_recipients(values, field) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case normalize_recipient(value) do
+        {:ok, recipient} -> {:cont, {:ok, [recipient | acc]}}
+        :error -> {:halt, {:error, invalid_recipient_error(field)}}
+      end
+    end)
+    |> case do
+      {:ok, recipients} -> {:ok, Enum.reverse(recipients)}
+      {:error, %{} = error} -> {:error, error}
+    end
+  end
+
+  defp normalize_recipient(value) when is_binary(value) do
+    normalized = String.trim(value)
+
+    if normalized != "" and Regex.match?(@email_regex, normalized) do
+      {:ok, normalized}
+    else
+      :error
+    end
+  end
+
+  defp normalize_recipient(_value), do: :error
+
+  defp validate_required_text(args, field) do
+    case fetch_arg(args, field) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" ->
+            {:error,
+             %{
+               code: "tool.validation.invalid_args",
+               message: "Invalid tool arguments",
+               details: %{required: [field]}
+             }}
+
+          normalized ->
+            {:ok, normalized}
+        end
+
+      _other ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{required: [field]}
+         }}
+    end
+  end
+
+  defp validate_body_format(args) do
+    case fetch_arg(args, "body_format") do
+      value when is_binary(value) ->
+        if MapSet.member?(@allowed_body_formats, value) do
+          {:ok, value}
+        else
+          {:error, invalid_body_format_error(value)}
+        end
+
+      _other ->
+        {:error,
+         %{
+           code: "tool.validation.invalid_args",
+           message: "Invalid tool arguments",
+           details: %{required: ["body_format"]}
+         }}
+    end
+  end
+
+  defp validate_artifact_ids(args) do
+    case fetch_arg(args, "artifact_ids") do
+      nil ->
+        {:ok, []}
+
+      values when is_list(values) ->
+        normalize_artifact_ids(values)
+
+      _other ->
+        {:error, invalid_args_error("artifact_ids")}
+    end
+  end
+
+  defp normalize_artifact_ids(values) do
+    values
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case Ecto.UUID.cast(value) do
+        {:ok, uuid} -> {:cont, {:ok, [uuid | acc]}}
+        :error -> {:halt, {:error, invalid_args_error("artifact_ids")}}
+      end
+    end)
+    |> normalize_artifact_ids_result()
+  end
+
+  defp normalize_artifact_ids_result({:ok, artifact_ids}), do: {:ok, Enum.reverse(artifact_ids)}
+  defp normalize_artifact_ids_result({:error, %{} = error}), do: {:error, error}
+
+  defp resolve_gmail_connection(instance, @connection_ref) do
+    with {:ok, connection_scope} <- connection_scope(instance),
+         {:ok, descriptor} <- resolve_connection_descriptor(connection_scope),
+         :ok <- validate_connection_descriptor(descriptor) do
+      {:ok, connection_scope, descriptor}
+    end
+  end
+
+  defp resolve_connection_descriptor(connection_scope) do
+    case ConnectionsRuntime.resolve_connection(connection_scope, @connection_ref) do
+      {:ok, descriptor} ->
+        {:ok, descriptor}
+
+      {:error, :missing} ->
+        {:error, connection_not_found_error()}
+
+      {:error, _reason} ->
+        {:error, connection_not_allowed_error()}
+    end
+  end
+
+  defp validate_connection_descriptor(%ConnectionsRuntime{type: @connection_ref, config: config})
+       when is_map(config) do
+    case GmailCaller.validate_config(config) do
+      :ok -> :ok
+      {:error, _reason} -> {:error, connection_not_allowed_error()}
+    end
+  end
+
+  defp validate_connection_descriptor(_descriptor), do: {:error, connection_not_allowed_error()}
+
+  defp resolve_connection_secrets(connection_scope, config) when is_map(config) do
+    with {:ok, client_id_ref} <- fetch_secret_ref(config, "client_id"),
+         {:ok, client_secret_ref} <- fetch_secret_ref(config, "client_secret"),
+         {:ok, refresh_token_ref} <- fetch_secret_ref(config, "refresh_token"),
+         {:ok, client_id} <- resolve_secret_value(connection_scope, client_id_ref),
+         {:ok, client_secret} <- resolve_secret_value(connection_scope, client_secret_ref),
+         {:ok, refresh_token} <- resolve_secret_value(connection_scope, refresh_token_ref) do
+      {:ok,
+       %{
+         client_id: client_id,
+         client_secret: client_secret,
+         refresh_token: refresh_token
+       }}
+    end
+  end
+
+  defp fetch_secret_ref(config, key) do
+    case Map.get(config, key) do
+      "$" <> rest = value when rest != "" -> {:ok, value}
+      _other -> {:error, connection_auth_failed_error()}
+    end
+  end
+
+  defp resolve_secret_value(scope, ref) do
+    case SecretBank.resolve_runtime_secret(scope, ref, tool_name: @tool_name) do
+      {:ok, %{value: value}} when is_binary(value) and value != "" ->
+        {:ok, value}
+
+      {:error, _reason} ->
+        {:error, connection_auth_failed_error()}
+
+      _other ->
+        {:error, connection_auth_failed_error()}
+    end
+  end
+
+  defp exchange_refresh_token(resolved_secrets, trusted_config) do
+    gmail_client = gmail_client_module(trusted_config)
+    gmail_client_opts = gmail_client_opts(trusted_config)
+
+    case gmail_client.exchange_refresh_token(
+           resolved_secrets.client_id,
+           resolved_secrets.client_secret,
+           resolved_secrets.refresh_token,
+           gmail_client_opts
+         ) do
+      {:ok, access_token} when is_binary(access_token) and access_token != "" ->
+        {:ok, access_token}
+
+      _other ->
+        {:error, connection_auth_failed_error()}
+    end
+  end
+
+  defp create_gmail_draft(access_token, raw_message, trusted_config) do
+    gmail_client = gmail_client_module(trusted_config)
+    gmail_client_opts = gmail_client_opts(trusted_config)
+
+    case gmail_client.create_draft(access_token, raw_message, gmail_client_opts) do
+      {:ok, %{draft_id: draft_id} = draft} when is_binary(draft_id) and draft_id != "" ->
+        {:ok, draft}
+
+      _other ->
+        {:error, draft_create_failed_error()}
+    end
+  end
+
+  defp gmail_client_module(trusted_config) do
+    case fetch_trusted(trusted_config, "gmail_client") do
+      module when is_atom(module) and not is_nil(module) -> module
+      _other -> GmailClient
+    end
+  end
+
+  defp gmail_client_opts(trusted_config) do
+    trusted_config
+    |> fetch_trusted("gmail_client_opts")
+    |> normalize_client_opts()
+  end
+
+  defp normalize_client_opts(opts) when is_list(opts), do: opts
+
+  defp normalize_client_opts(opts) when is_map(opts) do
+    []
+    |> maybe_put_opt(:req, fetch_trusted(opts, "req"))
+    |> maybe_put_opt(:token_url, fetch_trusted(opts, "token_url"))
+    |> maybe_put_opt(:drafts_url, fetch_trusted(opts, "drafts_url"))
+    |> maybe_put_opt(:test_pid, fetch_trusted(opts, "test_pid"))
+    |> maybe_put_opt(:mode, fetch_trusted(opts, "mode"))
+    |> maybe_put_opt(:access_token, fetch_trusted(opts, "access_token"))
+  end
+
+  defp normalize_client_opts(_opts), do: []
+
+  defp maybe_put_opt(opts, _key, nil), do: opts
+  defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp load_attachments(_instance, []), do: {:ok, []}
+
+  defp load_attachments(%LemmingInstance{} = instance, artifact_ids) when is_list(artifact_ids) do
+    with {:ok, artifact_scope} <- artifact_scope(instance),
+         {:ok, world_scope} <- world_scope(instance) do
+      load_attachment_list(artifact_ids, artifact_scope, world_scope)
+    end
+  end
+
+  defp load_attachment_list(artifact_ids, artifact_scope, world_scope) do
+    artifact_ids
+    |> Enum.reduce_while({:ok, []}, fn artifact_id, {:ok, acc} ->
+      case load_attachment(artifact_scope, world_scope, artifact_id) do
+        {:ok, attachment} -> {:cont, {:ok, [attachment | acc]}}
+        {:error, %{} = error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> normalize_attachment_list_result()
+  end
+
+  defp normalize_attachment_list_result({:ok, attachments}), do: {:ok, Enum.reverse(attachments)}
+  defp normalize_attachment_list_result({:error, %{} = error}), do: {:error, error}
+
+  defp load_attachment(artifact_scope, world_scope, artifact_id) do
+    case Artifacts.get_artifact(artifact_scope, artifact_id, include_non_ready: true) do
+      {:ok, artifact} ->
+        if artifact.status != "ready" do
+          {:error, artifact_not_found_error(artifact_id)}
+        else
+          open_attachment(artifact_scope, artifact_id)
+        end
+
+      {:error, :not_found} ->
+        classify_artifact_visibility(world_scope, artifact_id)
+
+      {:error, _reason} ->
+        {:error, artifact_not_allowed_error(artifact_id)}
+    end
+  end
+
+  defp open_attachment(artifact_scope, artifact_id) do
+    with {:ok, opened} <- Artifacts.open_artifact_download(artifact_scope, artifact_id),
+         {:ok, content} <- File.read(opened.path) do
+      {:ok,
+       %{
+         artifact_id: artifact_id,
+         filename: sanitize_filename(opened.filename),
+         content_type: sanitize_content_type(opened.content_type),
+         content: content
+       }}
+    else
+      _other ->
+        {:error, artifact_not_found_error(artifact_id)}
+    end
+  end
+
+  defp classify_artifact_visibility(world_scope, artifact_id) do
+    case Artifacts.get_artifact(world_scope, artifact_id, include_non_ready: true) do
+      {:ok, _artifact} -> {:error, artifact_not_allowed_error(artifact_id)}
+      {:error, :not_found} -> {:error, artifact_not_found_error(artifact_id)}
+      {:error, _reason} -> {:error, artifact_not_found_error(artifact_id)}
+    end
+  end
+
+  defp success_payload(parsed_args, draft) do
+    base_result = %{
+      "status" => "draft_created",
+      "provider" => @provider,
+      "connection_ref" => parsed_args.connection_ref,
+      "draft_id" => draft.draft_id,
+      "to" => parsed_args.to,
+      "cc" => parsed_args.cc,
+      "bcc" => parsed_args.bcc,
+      "subject" => parsed_args.subject,
+      "artifact_ids" => parsed_args.artifact_ids
+    }
+
+    result =
+      case Map.get(draft, :message_id) do
+        message_id when is_binary(message_id) and message_id != "" ->
+          Map.put(base_result, "message_id", message_id)
+
+        _other ->
+          base_result
+      end
+
+    %{
+      summary: draft_summary(parsed_args),
+      preview: "Subject: #{parsed_args.subject}",
+      result: result
+    }
+  end
+
+  defp draft_summary(parsed_args) do
+    recipient = List.first(parsed_args.to)
+    attachment_count = length(parsed_args.artifact_ids)
+
+    attachment_label =
+      if attachment_count == 1, do: "1 attachment", else: "#{attachment_count} attachments"
+
+    "Created Gmail draft for #{recipient} with #{attachment_label}"
+  end
+
+  defp build_raw_message(parsed_args, attachments) do
+    parsed_args
+    |> mime_message(attachments)
+    |> Base.url_encode64(padding: false)
+  end
+
+  defp mime_message(parsed_args, []) do
+    headers = base_headers(parsed_args)
+
+    [
+      headers,
+      "Content-Type: #{parsed_args.body_format}; charset=\"UTF-8\"",
+      "Content-Transfer-Encoding: base64",
+      "",
+      encode_base64_lines(parsed_args.body),
+      ""
+    ]
+    |> List.flatten()
+    |> Enum.join("\r\n")
+  end
+
+  defp mime_message(parsed_args, attachments) do
+    headers = base_headers(parsed_args)
+    boundary = "lemmings-os-#{Base.encode16(:crypto.strong_rand_bytes(12), case: :lower)}"
+
+    body_part = [
+      "Content-Type: #{parsed_args.body_format}; charset=\"UTF-8\"",
+      "Content-Transfer-Encoding: base64",
+      "",
+      encode_base64_lines(parsed_args.body)
+    ]
+
+    attachment_parts =
+      Enum.map(attachments, fn attachment ->
+        [
+          "Content-Type: #{attachment.content_type}; name=\"#{attachment.filename}\"",
+          "Content-Disposition: attachment; filename=\"#{attachment.filename}\"",
+          "Content-Transfer-Encoding: base64",
+          "",
+          encode_base64_lines(attachment.content)
+        ]
+      end)
+
+    [
+      headers,
+      "Content-Type: multipart/mixed; boundary=\"#{boundary}\"",
+      "",
+      "--#{boundary}",
+      body_part,
+      Enum.map(attachment_parts, fn part -> ["--#{boundary}", part] end),
+      "--#{boundary}--",
+      ""
+    ]
+    |> List.flatten()
+    |> Enum.join("\r\n")
+  end
+
+  defp base_headers(parsed_args) do
+    []
+    |> maybe_put_header("To", recipient_header(parsed_args.to))
+    |> maybe_put_header("Cc", recipient_header(parsed_args.cc))
+    |> maybe_put_header("Bcc", recipient_header(parsed_args.bcc))
+    |> maybe_put_header("Subject", sanitize_header_value(parsed_args.subject))
+    |> maybe_put_header("MIME-Version", "1.0")
+  end
+
+  defp maybe_put_header(headers, _name, nil), do: headers
+  defp maybe_put_header(headers, _name, ""), do: headers
+  defp maybe_put_header(headers, name, value), do: headers ++ ["#{name}: #{value}"]
+
+  defp recipient_header([]), do: nil
+
+  defp recipient_header(recipients) when is_list(recipients) do
+    recipients
+    |> Enum.map(&sanitize_header_value/1)
+    |> Enum.reject(&(&1 == ""))
+    |> case do
+      [] -> nil
+      values -> Enum.join(values, ", ")
+    end
+  end
+
+  defp encode_base64_lines(content) when is_binary(content) do
+    content
+    |> Base.encode64()
+    |> String.replace(~r/.{1,76}/, "\\0\r\n")
+    |> String.trim_trailing()
+  end
+
+  defp sanitize_header_value(value) when is_binary(value) do
+    value
+    |> String.replace(~r/[\r\n]+/, " ")
+    |> String.trim()
+  end
+
+  defp sanitize_header_value(_value), do: ""
+
+  defp sanitize_filename(filename) when is_binary(filename) do
+    filename
+    |> String.replace(~r/[\r\n"]+/, "_")
+    |> String.trim()
+    |> case do
+      "" -> "attachment.bin"
+      sanitized -> sanitized
+    end
+  end
+
+  defp sanitize_content_type(content_type) when is_binary(content_type) do
+    normalized = String.trim(content_type)
+
+    if String.contains?(normalized, "/") and not String.contains?(normalized, ["\r", "\n"]) do
+      normalized
+    else
+      "application/octet-stream"
+    end
+  end
+
+  defp record_requested_event(instance, parsed_args) do
+    payload =
+      base_event_payload(instance, parsed_args, nil)
+      |> Map.put(:status, "requested")
+
+    record_event(instance, "email.draft_requested", "Email draft requested", payload)
+  end
+
+  defp record_created_event(instance, parsed_args, connection_id, draft_id) do
+    payload =
+      base_event_payload(instance, parsed_args, connection_id)
+      |> Map.put(:status, "draft_created")
+      |> Map.put(:draft_id, draft_id)
+
+    record_event(instance, "email.draft_created", "Email draft created", payload)
+  end
+
+  defp record_failed_event(instance, parsed_args, connection_id, error) do
+    payload =
+      base_event_payload(instance, parsed_args, connection_id)
+      |> Map.put(:status, "failed")
+      |> Map.put(:error_code, Map.get(error, :code))
+
+    record_event(instance, "email.draft_failed", "Email draft failed", payload)
+  end
+
+  defp base_event_payload(instance, parsed_args, connection_id) do
+    %{
+      world_id: instance.world_id,
+      city_id: instance.city_id,
+      department_id: instance.department_id,
+      lemming_id: instance.lemming_id,
+      lemming_instance_id: instance.id,
+      tool_name: @tool_name,
+      provider: @provider,
+      connection_ref: parsed_args.connection_ref,
+      connection_id: connection_id,
+      recipient_count: length(parsed_args.to) + length(parsed_args.cc) + length(parsed_args.bcc),
+      attachment_count: length(parsed_args.artifact_ids),
+      artifact_ids: parsed_args.artifact_ids
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  defp record_event(instance, event_type, message, payload) do
+    Events.record_event(
+      event_type,
+      event_scope(instance),
+      message,
+      payload: payload,
+      event_family: "audit"
+    )
+  end
+
+  defp event_scope(%LemmingInstance{} = instance) do
+    %{
+      world_id: instance.world_id,
+      city_id: instance.city_id,
+      department_id: instance.department_id,
+      lemming_id: instance.lemming_id
+    }
+  end
+
+  defp connection_scope(%LemmingInstance{} = instance)
+       when is_binary(instance.world_id) and is_binary(instance.city_id) and
+              is_binary(instance.department_id) do
+    {:ok,
+     %Department{
+       id: instance.department_id,
+       city_id: instance.city_id,
+       world_id: instance.world_id
+     }}
+  end
+
+  defp connection_scope(%LemmingInstance{} = instance)
+       when is_binary(instance.world_id) and is_binary(instance.city_id) do
+    {:ok, %City{id: instance.city_id, world_id: instance.world_id}}
+  end
+
+  defp connection_scope(%LemmingInstance{} = instance) when is_binary(instance.world_id) do
+    {:ok, %World{id: instance.world_id}}
+  end
+
+  defp connection_scope(_instance), do: {:error, connection_not_allowed_error()}
+
+  defp artifact_scope(%LemmingInstance{} = instance)
+       when is_binary(instance.world_id) and is_binary(instance.city_id) and
+              is_binary(instance.department_id) and is_binary(instance.lemming_id) do
+    {:ok,
+     %Lemming{
+       id: instance.lemming_id,
+       world_id: instance.world_id,
+       city_id: instance.city_id,
+       department_id: instance.department_id
+     }}
+  end
+
+  defp artifact_scope(_instance), do: {:error, artifact_not_allowed_error(nil)}
+
+  defp world_scope(%LemmingInstance{} = instance) when is_binary(instance.world_id),
+    do: {:ok, %World{id: instance.world_id}}
+
+  defp world_scope(_instance), do: {:error, artifact_not_found_error(nil)}
+
+  defp invalid_recipient_error(field) do
+    %{
+      code: "tool.email.invalid_recipient",
+      message: "Invalid email recipient",
+      details: %{field: field}
+    }
+  end
+
+  defp invalid_body_format_error(body_format) do
+    %{
+      code: "tool.email.invalid_body_format",
+      message: "Unsupported body format",
+      details: %{body_format: body_format, allowed: ["text/plain", "text/html"]}
+    }
+  end
+
+  defp invalid_args_error(field) do
+    %{
+      code: "tool.validation.invalid_args",
+      message: "Invalid tool arguments",
+      details: %{field: field}
+    }
+  end
+
+  defp connection_not_found_error do
+    %{
+      code: "tool.email.connection_not_found",
+      message: "Gmail connection not found",
+      details: %{connection_ref: @connection_ref}
+    }
+  end
+
+  defp connection_not_allowed_error do
+    %{
+      code: "tool.email.connection_not_allowed",
+      message: "Gmail connection is not allowed",
+      details: %{connection_ref: @connection_ref}
+    }
+  end
+
+  defp connection_auth_failed_error do
+    %{
+      code: "tool.email.connection_auth_failed",
+      message: "Gmail connection authentication failed",
+      details: %{provider: @provider}
+    }
+  end
+
+  defp artifact_not_found_error(artifact_id) do
+    %{
+      code: "tool.email.artifact_not_found",
+      message: "Attachment artifact not found",
+      details: maybe_put(%{}, :artifact_id, artifact_id)
+    }
+  end
+
+  defp artifact_not_allowed_error(artifact_id) do
+    %{
+      code: "tool.email.artifact_not_allowed",
+      message: "Attachment artifact is not allowed",
+      details: maybe_put(%{}, :artifact_id, artifact_id)
+    }
+  end
+
+  defp draft_create_failed_error do
+    %{
+      code: "tool.email.draft_create_failed",
+      message: "Failed to create Gmail draft",
+      details: %{provider: @provider}
+    }
+  end
+
+  defp fetch_arg(args, key) when is_map(args) and is_binary(key) do
+    case arg_atom_key(key) do
+      nil -> Map.get(args, key)
+      atom_key -> Map.get(args, key) || Map.get(args, atom_key)
+    end
+  end
+
+  defp fetch_trusted(map, key) when is_map(map) and is_binary(key) do
+    case trusted_atom_key(key) do
+      nil -> Map.get(map, key)
+      atom_key -> Map.get(map, key) || Map.get(map, atom_key)
+    end
+  end
+
+  defp normalize_arg_key(key) when is_binary(key), do: key
+  defp normalize_arg_key(key) when is_atom(key), do: Atom.to_string(key)
+  defp normalize_arg_key(key), do: inspect(key)
+
+  defp arg_atom_key("connection_ref"), do: :connection_ref
+  defp arg_atom_key("to"), do: :to
+  defp arg_atom_key("cc"), do: :cc
+  defp arg_atom_key("bcc"), do: :bcc
+  defp arg_atom_key("subject"), do: :subject
+  defp arg_atom_key("body"), do: :body
+  defp arg_atom_key("body_format"), do: :body_format
+  defp arg_atom_key("artifact_ids"), do: :artifact_ids
+  defp arg_atom_key(_key), do: nil
+
+  defp trusted_atom_key("gmail_client"), do: :gmail_client
+  defp trusted_atom_key("gmail_client_opts"), do: :gmail_client_opts
+  defp trusted_atom_key("req"), do: :req
+  defp trusted_atom_key("token_url"), do: :token_url
+  defp trusted_atom_key("drafts_url"), do: :drafts_url
+  defp trusted_atom_key("test_pid"), do: :test_pid
+  defp trusted_atom_key("mode"), do: :mode
+  defp trusted_atom_key("access_token"), do: :access_token
+  defp trusted_atom_key(_key), do: nil
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/lemmings_os/tools/adapters/email.ex
+++ b/lib/lemmings_os/tools/adapters/email.ex
@@ -27,6 +27,11 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   @provider "gmail"
   @connection_ref "gmail"
   @default_body_format "text/plain"
+  @default_max_attachment_count 5
+  @default_max_attachment_megabytes 10
+  @default_max_total_attachment_megabytes 20
+  @default_max_body_megabytes 0.2
+  @bytes_per_megabyte 1_000_000
   @allowed_body_formats MapSet.new(["text/plain", "text/html"])
   @allowed_fields MapSet.new([
                     "connection_ref",
@@ -182,6 +187,13 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   end
 
   defp run_create_draft(%LemmingInstance{} = instance, parsed_args, trusted_config) do
+    case validate_body_limit(parsed_args) do
+      :ok -> do_run_create_draft(instance, parsed_args, trusted_config)
+      {:error, %{} = error} -> {:error, error, %{connection_id: nil}}
+    end
+  end
+
+  defp do_run_create_draft(%LemmingInstance{} = instance, parsed_args, trusted_config) do
     case resolve_gmail_connection(instance, parsed_args.connection_ref) do
       {:ok, connection_scope, descriptor} ->
         connection_id = descriptor.connection_id
@@ -590,18 +602,48 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   defp load_attachments(_instance, []), do: {:ok, []}
 
   defp load_attachments(%LemmingInstance{} = instance, artifact_ids) when is_list(artifact_ids) do
-    with {:ok, artifact_scope} <- artifact_scope(instance),
+    with :ok <- validate_attachment_count(artifact_ids),
+         {:ok, artifact_scope} <- artifact_scope(instance),
          {:ok, world_scope} <- world_scope(instance) do
       load_attachment_list(artifact_ids, artifact_scope, world_scope)
     end
   end
 
   defp load_attachment_list(artifact_ids, artifact_scope, world_scope) do
+    with {:ok, artifacts} <- load_attachment_artifacts(artifact_ids, artifact_scope, world_scope),
+         :ok <- validate_attachment_sizes(artifacts) do
+      open_attachment_list(artifacts, artifact_scope)
+    end
+  end
+
+  defp load_attachment_artifacts(artifact_ids, artifact_scope, world_scope) do
     artifact_ids
     |> Enum.reduce_while({:ok, []}, fn artifact_id, {:ok, acc} ->
-      case load_attachment(artifact_scope, world_scope, artifact_id) do
-        {:ok, attachment} -> {:cont, {:ok, [attachment | acc]}}
-        {:error, %{} = error} -> {:halt, {:error, error}}
+      case load_attachment_artifact(artifact_scope, world_scope, artifact_id) do
+        {:ok, artifact} ->
+          {:cont, {:ok, [artifact | acc]}}
+
+        {:error, %{} = error} ->
+          {:halt, {:error, error}}
+      end
+    end)
+    |> normalize_attachment_artifacts_result()
+  end
+
+  defp normalize_attachment_artifacts_result({:ok, artifacts}),
+    do: {:ok, Enum.reverse(artifacts)}
+
+  defp normalize_attachment_artifacts_result({:error, %{} = error}), do: {:error, error}
+
+  defp open_attachment_list(artifacts, artifact_scope) do
+    artifacts
+    |> Enum.reduce_while({:ok, []}, fn artifact, {:ok, acc} ->
+      case open_attachment(artifact_scope, artifact.id) do
+        {:ok, attachment} ->
+          {:cont, {:ok, [attachment | acc]}}
+
+        {:error, %{} = error} ->
+          {:halt, {:error, error}}
       end
     end)
     |> normalize_attachment_list_result()
@@ -610,13 +652,11 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   defp normalize_attachment_list_result({:ok, attachments}), do: {:ok, Enum.reverse(attachments)}
   defp normalize_attachment_list_result({:error, %{} = error}), do: {:error, error}
 
-  defp load_attachment(artifact_scope, world_scope, artifact_id) do
+  defp load_attachment_artifact(artifact_scope, world_scope, artifact_id) do
     case Artifacts.get_artifact(artifact_scope, artifact_id, include_non_ready: true) do
       {:ok, artifact} ->
-        if artifact.status != "ready" do
-          {:error, artifact_not_found_error(artifact_id)}
-        else
-          open_attachment(artifact_scope, artifact_id)
+        with :ok <- validate_ready_artifact(artifact, artifact_id) do
+          {:ok, artifact}
         end
 
       {:error, :not_found} ->
@@ -624,6 +664,47 @@ defmodule LemmingsOs.Tools.Adapters.Email do
 
       {:error, _reason} ->
         {:error, artifact_not_allowed_error(artifact_id)}
+    end
+  end
+
+  defp validate_attachment_sizes(artifacts) do
+    artifacts
+    |> Enum.reduce_while({:ok, 0}, fn artifact, {:ok, total_bytes} ->
+      case validate_attachment_size(artifact, total_bytes) do
+        {:ok, next_total_bytes} -> {:cont, {:ok, next_total_bytes}}
+        {:error, %{} = error} -> {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, _total_bytes} -> :ok
+      {:error, %{} = error} -> {:error, error}
+    end
+  end
+
+  defp validate_ready_artifact(artifact, artifact_id) do
+    if artifact.status == "ready" do
+      :ok
+    else
+      {:error, artifact_not_found_error(artifact_id)}
+    end
+  end
+
+  defp validate_attachment_size(artifact, total_bytes) do
+    size_bytes = artifact.size_bytes
+    limits = email_draft_limits()
+
+    cond do
+      not is_integer(size_bytes) or size_bytes < 0 ->
+        {:error, artifact_not_found_error(artifact.id)}
+
+      size_bytes > limits.max_attachment_bytes ->
+        {:error, attachment_too_large_error(artifact.id)}
+
+      total_bytes + size_bytes > limits.max_total_attachment_bytes ->
+        {:error, attachment_too_large_error(artifact.id)}
+
+      true ->
+        {:ok, total_bytes + size_bytes}
     end
   end
 
@@ -657,10 +738,11 @@ defmodule LemmingsOs.Tools.Adapters.Email do
       "provider" => @provider,
       "connection_ref" => parsed_args.connection_ref,
       "draft_id" => draft.draft_id,
-      "to" => parsed_args.to,
-      "cc" => parsed_args.cc,
-      "bcc" => parsed_args.bcc,
-      "subject" => parsed_args.subject,
+      "to_count" => length(parsed_args.to),
+      "cc_count" => length(parsed_args.cc),
+      "bcc_count" => length(parsed_args.bcc),
+      "subject_preview" => subject_preview(parsed_args.subject),
+      "artifact_count" => length(parsed_args.artifact_ids),
       "artifact_ids" => parsed_args.artifact_ids
     }
 
@@ -681,13 +763,18 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   end
 
   defp draft_summary(parsed_args) do
-    recipient = List.first(parsed_args.to)
     attachment_count = length(parsed_args.artifact_ids)
 
     attachment_label =
       if attachment_count == 1, do: "1 attachment", else: "#{attachment_count} attachments"
 
-    "Created Gmail draft for #{recipient} with #{attachment_label}"
+    "Created Gmail draft for #{length(parsed_args.to)} recipient(s) with #{attachment_label}"
+  end
+
+  defp subject_preview(subject) when is_binary(subject) do
+    subject
+    |> String.trim()
+    |> String.slice(0, 80)
   end
 
   defp build_raw_message(parsed_args, attachments) do
@@ -777,6 +864,22 @@ defmodule LemmingsOs.Tools.Adapters.Email do
     |> Base.encode64()
     |> String.replace(~r/.{1,76}/, "\\0\r\n")
     |> String.trim_trailing()
+  end
+
+  defp validate_body_limit(%{body: body}) when is_binary(body) do
+    if byte_size(body) <= email_draft_limits().max_body_bytes do
+      :ok
+    else
+      {:error, body_too_large_error()}
+    end
+  end
+
+  defp validate_attachment_count(artifact_ids) do
+    if length(artifact_ids) <= email_draft_limits().max_attachment_count do
+      :ok
+    else
+      {:error, attachment_too_large_error(nil)}
+    end
   end
 
   defp sanitize_header_value(value) when is_binary(value) do
@@ -990,6 +1093,22 @@ defmodule LemmingsOs.Tools.Adapters.Email do
     }
   end
 
+  defp attachment_too_large_error(artifact_id) do
+    %{
+      code: "tool.email.attachment_too_large",
+      message: "Attachment exceeds configured draft limit",
+      details: maybe_put(%{}, :artifact_id, artifact_id)
+    }
+  end
+
+  defp body_too_large_error do
+    %{
+      code: "tool.email.body_too_large",
+      message: "Email body exceeds configured draft limit",
+      details: %{}
+    }
+  end
+
   defp draft_create_failed_error do
     %{
       code: "tool.email.draft_create_failed",
@@ -1035,6 +1154,48 @@ defmodule LemmingsOs.Tools.Adapters.Email do
   defp trusted_atom_key("mode"), do: :mode
   defp trusted_atom_key("access_token"), do: :access_token
   defp trusted_atom_key(_key), do: nil
+
+  defp email_draft_limits do
+    config = Application.get_env(:lemmings_os, :email_draft, [])
+
+    %{
+      max_attachment_count:
+        positive_integer_config(config, :max_attachment_count, @default_max_attachment_count),
+      max_attachment_bytes:
+        megabytes_config_to_bytes(
+          config,
+          :max_attachment_megabytes,
+          @default_max_attachment_megabytes
+        ),
+      max_total_attachment_bytes:
+        megabytes_config_to_bytes(
+          config,
+          :max_total_attachment_megabytes,
+          @default_max_total_attachment_megabytes
+        ),
+      max_body_bytes:
+        megabytes_config_to_bytes(config, :max_body_megabytes, @default_max_body_megabytes)
+    }
+  end
+
+  defp positive_integer_config(config, key, default) do
+    case Keyword.get(config, key, default) do
+      value when is_integer(value) and value > 0 -> value
+      _value -> default
+    end
+  end
+
+  defp megabytes_config_to_bytes(config, key, default) do
+    config
+    |> Keyword.get(key, default)
+    |> case do
+      value when is_integer(value) and value > 0 -> value
+      value when is_float(value) and value > 0.0 -> value
+      _value -> default
+    end
+    |> Kernel.*(@bytes_per_megabyte)
+    |> round()
+  end
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)

--- a/lib/lemmings_os/tools/adapters/email/gmail_client.ex
+++ b/lib/lemmings_os/tools/adapters/email/gmail_client.ex
@@ -1,0 +1,137 @@
+defmodule LemmingsOs.Tools.Adapters.Email.GmailClient do
+  @moduledoc """
+  Req-backed Gmail draft HTTP boundary for `email.create_draft`.
+
+  This client is intentionally narrow:
+  - exchange a refresh token for a short-lived access token
+  - create a Gmail draft with a prebuilt MIME payload
+  """
+
+  @token_url "https://oauth2.googleapis.com/token"
+  @drafts_url "https://gmail.googleapis.com/gmail/v1/users/me/drafts"
+
+  @doc """
+  Exchanges a Gmail refresh token for a temporary access token.
+
+  ## Parameters
+
+  - `client_id`: OAuth client id value.
+  - `client_secret`: OAuth client secret value.
+  - `refresh_token`: OAuth refresh token value.
+  - `opts` (optional):
+    - `:req` - Req-compatible module used for HTTP calls. Default: `Req`.
+    - `:token_url` - OAuth token endpoint override (test-only). Default: Google endpoint.
+
+  ## Examples
+
+      iex> {:ok, token} =
+      ...>   LemmingsOs.Tools.Adapters.Email.GmailClient.exchange_refresh_token(
+      ...>     "client-id",
+      ...>     "client-secret",
+      ...>     "refresh-token",
+      ...>     req: LemmingsOs.TestSupport.EmailDraftReqSuccess
+      ...>   )
+      iex> token
+      "test-access-token"
+
+      iex> LemmingsOs.Tools.Adapters.Email.GmailClient.exchange_refresh_token(
+      ...>   "client-id",
+      ...>   "client-secret",
+      ...>   "refresh-token",
+      ...>   req: LemmingsOs.TestSupport.EmailDraftReqFailure
+      ...> )
+      {:error, :auth_failed}
+  """
+  @spec exchange_refresh_token(String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, :auth_failed}
+  def exchange_refresh_token(client_id, client_secret, refresh_token, opts \\ [])
+      when is_binary(client_id) and is_binary(client_secret) and is_binary(refresh_token) and
+             is_list(opts) do
+    req = Keyword.get(opts, :req, Req)
+    token_url = Keyword.get(opts, :token_url, @token_url)
+
+    body = %{
+      client_id: client_id,
+      client_secret: client_secret,
+      refresh_token: refresh_token,
+      grant_type: "refresh_token"
+    }
+
+    case req.post(token_url, form: body) do
+      {:ok, %Req.Response{status: status, body: %{"access_token" => access_token}}}
+      when status in 200..299 and is_binary(access_token) and access_token != "" ->
+        {:ok, access_token}
+
+      _other ->
+        {:error, :auth_failed}
+    end
+  end
+
+  @doc """
+  Creates a Gmail draft from a base64url-encoded MIME message.
+
+  ## Parameters
+
+  - `access_token`: short-lived OAuth access token.
+  - `raw_message`: base64url-encoded RFC822 MIME payload.
+  - `opts` (optional):
+    - `:req` - Req-compatible module used for HTTP calls. Default: `Req`.
+    - `:drafts_url` - Gmail drafts endpoint override (test-only). Default: Gmail endpoint.
+
+  ## Examples
+
+      iex> {:ok, draft} =
+      ...>   LemmingsOs.Tools.Adapters.Email.GmailClient.create_draft(
+      ...>     "test-access-token",
+      ...>     "raw-message",
+      ...>     req: LemmingsOs.TestSupport.EmailDraftReqSuccess
+      ...>   )
+      iex> draft.draft_id
+      "draft-123"
+      iex> draft.message_id
+      "message-123"
+
+      iex> LemmingsOs.Tools.Adapters.Email.GmailClient.create_draft(
+      ...>   "test-access-token",
+      ...>   "raw-message",
+      ...>   req: LemmingsOs.TestSupport.EmailDraftReqFailure
+      ...> )
+      {:error, :draft_failed}
+  """
+  @spec create_draft(String.t(), String.t(), keyword()) ::
+          {:ok, %{draft_id: String.t(), message_id: String.t() | nil}}
+          | {:error, :draft_failed}
+  def create_draft(access_token, raw_message, opts \\ [])
+      when is_binary(access_token) and is_binary(raw_message) and is_list(opts) do
+    req = Keyword.get(opts, :req, Req)
+    drafts_url = Keyword.get(opts, :drafts_url, @drafts_url)
+
+    request_body = %{message: %{raw: raw_message}}
+    headers = [{"authorization", "Bearer #{access_token}"}]
+
+    case req.post(drafts_url, headers: headers, json: request_body) do
+      {:ok, %Req.Response{status: status, body: %{} = body}} when status in 200..299 ->
+        normalize_draft_response(body)
+
+      _other ->
+        {:error, :draft_failed}
+    end
+  end
+
+  defp normalize_draft_response(%{"id" => draft_id} = body)
+       when is_binary(draft_id) and draft_id != "" do
+    {:ok,
+     %{
+       draft_id: draft_id,
+       message_id: fetch_message_id(body)
+     }}
+  end
+
+  defp normalize_draft_response(_body), do: {:error, :draft_failed}
+
+  defp fetch_message_id(%{"message" => %{"id" => message_id}})
+       when is_binary(message_id) and message_id != "",
+       do: message_id
+
+  defp fetch_message_id(_body), do: nil
+end

--- a/lib/lemmings_os/tools/catalog.ex
+++ b/lib/lemmings_os/tools/catalog.ex
@@ -80,6 +80,14 @@ defmodule LemmingsOs.Tools.Catalog do
       icon: "hero-printer",
       category: "documents",
       risk: "high"
+    },
+    %{
+      id: "email.create_draft",
+      name: "Create Gmail Draft",
+      description: "Create a Gmail draft with optional artifact attachments.",
+      icon: "hero-envelope",
+      category: "email",
+      risk: "medium"
     }
   ]
 
@@ -101,7 +109,7 @@ defmodule LemmingsOs.Tools.Catalog do
 
       iex> tools = LemmingsOs.Tools.Catalog.list_tools()
       iex> Enum.map(tools, & &1.id)
-      ["fs.read_text_file", "fs.write_text_file", "web.search", "web.fetch", "knowledge.search", "knowledge.read", "knowledge.store", "documents.markdown_to_html", "documents.print_to_pdf"]
+      ["fs.read_text_file", "fs.write_text_file", "web.search", "web.fetch", "knowledge.search", "knowledge.read", "knowledge.store", "documents.markdown_to_html", "documents.print_to_pdf", "email.create_draft"]
   """
   @spec list_tools() :: [tool()]
   def list_tools, do: @tools

--- a/lib/lemmings_os/tools/runtime.ex
+++ b/lib/lemmings_os/tools/runtime.ex
@@ -4,6 +4,7 @@ defmodule LemmingsOs.Tools.Runtime do
   """
 
   alias LemmingsOs.Tools.Adapters.Documents
+  alias LemmingsOs.Tools.Adapters.Email
   alias LemmingsOs.Tools.Adapters.Knowledge
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.Tools.Adapters.Filesystem
@@ -208,6 +209,21 @@ defmodule LemmingsOs.Tools.Runtime do
       "documents.print_to_pdf",
       args,
       Documents.print_to_pdf(instance, args, runtime_meta)
+    )
+  end
+
+  defp dispatch_tool_call(
+         _world,
+         instance,
+         "email.create_draft",
+         args,
+         runtime_meta,
+         trusted_config
+       ) do
+    normalize_tool_result(
+      "email.create_draft",
+      args,
+      Email.create_draft(instance, args, runtime_meta, trusted_config)
     )
   end
 

--- a/lib/lemmings_os_web/components/connections_components.ex
+++ b/lib/lemmings_os_web/components/connections_components.ex
@@ -11,6 +11,8 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
   attr :id_prefix, :string, required: true
   attr :scope_kind, :string, required: true
   attr :scope_available?, :boolean, default: true
+  attr :gmail_oauth, :map, default: %{}
+  attr :gmail_scope_params, :map, default: %{}
   attr :types, :list, default: []
   attr :create_form, :any, required: true
   attr :create_open?, :boolean, default: false
@@ -36,6 +38,7 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
       assigns
       |> assign(:title, assigns[:title] || dgettext("layout", ".title_connections"))
       |> assign(:subtitle, assigns[:subtitle] || dgettext("layout", ".subtitle_connections"))
+      |> assign(:gmail_oauth, assigns[:gmail_oauth] || %{})
 
     ~H"""
     <.panel id={"#{@id_prefix}-connections-panel"} tone="accent">
@@ -99,14 +102,30 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
 
             <input type="hidden" name="connection_create[status]" value="enabled" />
 
+            <.gmail_connection_panel
+              :if={ConnectionsSurface.gmail_form?(@create_form)}
+              id_prefix={"#{@id_prefix}-connections-create"}
+              form={@create_form}
+              form_name="connection_create"
+              scope_kind={@scope_kind}
+              submit_button_id={"#{@id_prefix}-connections-create-submit"}
+              connect_button_id={"#{@id_prefix}-connections-create-connect-gmail"}
+              cancel_button_id={"#{@id_prefix}-connections-create-cancel"}
+              close_event={@close_create_event}
+            />
+
             <.input
+              :if={!ConnectionsSurface.gmail_form?(@create_form)}
               field={@create_form[:config]}
               id={"#{@id_prefix}-connections-create-config"}
               type="textarea"
               label={dgettext("layout", ".connections_label_config_json")}
             />
 
-            <div class="mt-3 flex justify-end gap-2">
+            <div
+              :if={!ConnectionsSurface.gmail_form?(@create_form)}
+              class="mt-3 flex justify-end gap-2"
+            >
               <button
                 id={"#{@id_prefix}-connections-create-cancel"}
                 type="button"
@@ -270,7 +289,6 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
               }
               for={@edit_form}
               id={"#{@id_prefix}-connections-edit-form-#{row.connection.id}"}
-              phx-change={@edit_type_change_event}
               phx-submit={@save_edit_event}
               class="mt-3 grid gap-2 rounded-md border border-zinc-700 bg-zinc-900/40 p-3"
             >
@@ -286,6 +304,7 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
               <select
                 id={"#{@id_prefix}-connections-edit-type-#{row.connection.id}"}
                 name="connection_edit[type]"
+                phx-change={@edit_type_change_event}
                 class="rounded border border-zinc-600 bg-zinc-950 px-3 py-2 text-zinc-100"
               >
                 <option
@@ -297,14 +316,27 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
                 </option>
               </select>
 
+              <.gmail_connection_panel
+                :if={ConnectionsSurface.gmail_form?(@edit_form)}
+                id_prefix={"#{@id_prefix}-connections-edit-#{row.connection.id}"}
+                form={@edit_form}
+                form_name="connection_edit"
+                scope_kind={@scope_kind}
+                submit_button_id={"#{@id_prefix}-connections-edit-save-#{row.connection.id}"}
+                connect_button_id={"#{@id_prefix}-connections-edit-connect-gmail-#{row.connection.id}"}
+                cancel_button_id={"#{@id_prefix}-connections-edit-cancel-#{row.connection.id}"}
+                close_event={@cancel_edit_event}
+              />
+
               <.input
+                :if={!ConnectionsSurface.gmail_form?(@edit_form)}
                 field={@edit_form[:config]}
                 type="textarea"
                 id={"#{@id_prefix}-connections-edit-config-#{row.connection.id}"}
                 label={dgettext("layout", ".connections_label_config_json")}
               />
 
-              <div class="mt-2 flex gap-2">
+              <div :if={!ConnectionsSurface.gmail_form?(@edit_form)} class="mt-2 flex gap-2">
                 <.button
                   id={"#{@id_prefix}-connections-edit-save-#{row.connection.id}"}
                   type="submit"
@@ -326,6 +358,131 @@ defmodule LemmingsOsWeb.ConnectionsComponents do
         </.panel>
       </div>
     </.panel>
+    """
+  end
+
+  attr :id_prefix, :string, required: true
+  attr :form, :any, required: true
+  attr :form_name, :string, required: true
+  attr :scope_kind, :string, required: true
+  attr :submit_button_id, :string, required: true
+  attr :connect_button_id, :string, required: true
+  attr :cancel_button_id, :string, required: true
+  attr :close_event, :string, required: true
+
+  def gmail_connection_panel(assigns) do
+    ~H"""
+    <section
+      id={"#{@id_prefix}-gmail-panel"}
+      class="mt-4 rounded-md border border-cyan-500/30 bg-cyan-950/10 p-4"
+      aria-labelledby={"#{@id_prefix}-gmail-title"}
+    >
+      <input type="hidden" name={"#{@form_name}[connection_id]"} value={@form[:connection_id].value} />
+      <input type="hidden" name={"#{@form_name}[type]"} value="gmail" />
+      <input type="hidden" name={"#{@form_name}[status]"} value={@form[:status].value || "enabled"} />
+      <input
+        type="hidden"
+        name={"#{@form_name}[account_email]"}
+        value={@form[:account_email].value || ""}
+      />
+      <input
+        type="hidden"
+        name={"#{@form_name}[refresh_token]"}
+        value={@form[:refresh_token].value || ""}
+      />
+
+      <div class="space-y-1">
+        <h3 id={"#{@id_prefix}-gmail-title"} class="text-lg font-semibold text-cyan-100">
+          Gmail
+        </h3>
+        <p class="text-sm text-zinc-300">OAuth onboarding for draft creation only</p>
+        <p id={"#{@id_prefix}-gmail-scope"} class="text-xs uppercase tracking-widest text-zinc-400">
+          Scope: {scope_title(@scope_kind)}
+        </p>
+      </div>
+
+      <div class="mt-4 grid gap-3 md:grid-cols-2">
+        <.input
+          field={@form[:client_id]}
+          id={"#{@id_prefix}-gmail-client-id"}
+          label="Client ID secret ref"
+        />
+        <.input
+          field={@form[:client_secret]}
+          id={"#{@id_prefix}-gmail-client-secret"}
+          label="Client Secret secret ref"
+        />
+      </div>
+
+      <div class="mt-4 rounded border border-zinc-700 bg-zinc-950/40 p-3 text-sm">
+        <div class="font-medium text-zinc-200">Permission summary</div>
+        <code id={"#{@id_prefix}-gmail-compose-scope"} class="mt-1 block text-xs text-cyan-200">
+          https://www.googleapis.com/auth/gmail.compose
+        </code>
+      </div>
+
+      <dl class="mt-4 grid gap-3 text-sm md:grid-cols-2">
+        <div class="rounded border border-zinc-700 bg-zinc-950/40 p-3">
+          <dt class="text-xs uppercase tracking-widest text-zinc-500">Status</dt>
+          <dd id={"#{@id_prefix}-gmail-connected-status"} class="mt-1 text-zinc-100">
+            {ConnectionsSurface.gmail_status_label(@form)}
+          </dd>
+        </div>
+        <div class="rounded border border-zinc-700 bg-zinc-950/40 p-3">
+          <dt class="text-xs uppercase tracking-widest text-zinc-500">Account</dt>
+          <dd id={"#{@id_prefix}-gmail-account"} class="mt-1 text-zinc-100">
+            {ConnectionsSurface.gmail_account_label(@form)}
+          </dd>
+        </div>
+      </dl>
+
+      <details
+        :if={ConnectionsSurface.gmail_refresh_token_ref(@form)}
+        id={"#{@id_prefix}-gmail-refresh-token-details"}
+        class="mt-3 rounded border border-zinc-700 bg-zinc-950/40 p-3 text-sm"
+      >
+        <summary class="cursor-pointer text-zinc-300">Refresh token secret ref</summary>
+        <code id={"#{@id_prefix}-gmail-refresh-token-ref"} class="mt-2 block text-xs text-zinc-300">
+          {ConnectionsSurface.gmail_refresh_token_ref(@form)}
+        </code>
+      </details>
+
+      <details
+        id={"#{@id_prefix}-gmail-advanced-json"}
+        class="mt-3 rounded border border-zinc-700 bg-zinc-950/40 p-3"
+      >
+        <summary class="cursor-pointer text-sm text-zinc-300">Advanced JSON</summary>
+        <.input
+          field={@form[:config]}
+          type="textarea"
+          id={"#{@id_prefix}-gmail-config"}
+          label="Config JSON preview"
+        />
+      </details>
+
+      <div class="mt-4 flex flex-wrap justify-end gap-2">
+        <button
+          id={@cancel_button_id}
+          type="button"
+          phx-click={@close_event}
+          class="rounded border border-zinc-600 px-3 py-2 text-sm text-zinc-300"
+        >
+          {dgettext("layout", ".connections_action_cancel")}
+        </button>
+        <.button id={@submit_button_id} type="submit" variant="secondary">
+          Save config
+        </.button>
+        <.button
+          id={@connect_button_id}
+          type="submit"
+          name={"#{@form_name}[action]"}
+          value="connect_gmail"
+          variant="secondary"
+        >
+          {ConnectionsSurface.gmail_action_label(@form)}
+        </.button>
+      </div>
+    </section>
     """
   end
 

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -8,7 +8,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
   alias LemmingsOs.Tools.ToolExecutionOutputs
 
   @default_max_retries 3
-  @email_draft_result_keys ~w(status provider connection_ref draft_id message_id to cc bcc subject artifact_ids)
+  @email_draft_result_keys ~w(status provider connection_ref draft_id message_id to_count cc_count bcc_count subject_preview artifact_count artifact_ids)
 
   attr :id, :string, default: nil
   attr :status, :string, required: true
@@ -1184,11 +1184,11 @@ defmodule LemmingsOsWeb.InstanceComponents do
   defp tool_result_payload_json(_tool_execution), do: "{}"
 
   defp email_draft_summary(%{result: result}) when is_map(result) do
-    recipient = result |> Map.get("to", []) |> safe_string_list() |> List.first() || "recipient"
-    attachment_count = result |> Map.get("artifact_ids", []) |> safe_string_list() |> length()
+    recipient_count = safe_count(Map.get(result, "to_count"))
+    attachment_count = safe_count(Map.get(result, "artifact_count"))
     attachment_label = if attachment_count == 1, do: "attachment", else: "attachments"
 
-    "Created Gmail draft for #{recipient} with #{attachment_count} #{attachment_label}"
+    "Created Gmail draft for #{recipient_count} recipient(s) with #{attachment_count} #{attachment_label}"
   end
 
   defp email_draft_summary(_tool_execution), do: nil
@@ -1203,7 +1203,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
     do: dgettext("lemmings", "Gmail draft creation recorded.")
 
   defp email_draft_preview(%{result: result}) when is_map(result) do
-    case safe_string(Map.get(result, "subject")) do
+    case safe_string(Map.get(result, "subject_preview")) do
       nil -> nil
       subject -> "Subject: #{subject}"
     end
@@ -1214,17 +1214,21 @@ defmodule LemmingsOsWeb.InstanceComponents do
   defp email_draft_safe_result(result) when is_map(result) do
     result
     |> Map.take(@email_draft_result_keys)
-    |> Map.put("to", safe_string_list(Map.get(result, "to", [])))
-    |> Map.put("cc", safe_string_list(Map.get(result, "cc", [])))
-    |> Map.put("bcc", safe_string_list(Map.get(result, "bcc", [])))
     |> Map.put("artifact_ids", safe_string_list(Map.get(result, "artifact_ids", [])))
+    |> Map.put("to_count", safe_count(Map.get(result, "to_count")))
+    |> Map.put("cc_count", safe_count(Map.get(result, "cc_count")))
+    |> Map.put("bcc_count", safe_count(Map.get(result, "bcc_count")))
+    |> Map.put("artifact_count", safe_count(Map.get(result, "artifact_count")))
     |> maybe_put_safe_string("status", Map.get(result, "status"))
     |> maybe_put_safe_string("provider", Map.get(result, "provider"))
     |> maybe_put_safe_string("connection_ref", Map.get(result, "connection_ref"))
     |> maybe_put_safe_string("draft_id", Map.get(result, "draft_id"))
     |> maybe_put_safe_string("message_id", Map.get(result, "message_id"))
-    |> maybe_put_safe_string("subject", Map.get(result, "subject"))
+    |> maybe_put_safe_string("subject_preview", Map.get(result, "subject_preview"))
   end
+
+  defp safe_count(value) when is_integer(value) and value >= 0, do: value
+  defp safe_count(_value), do: 0
 
   defp maybe_put_safe_string(payload, key, value) do
     case safe_string(value) do

--- a/lib/lemmings_os_web/components/instance_components.ex
+++ b/lib/lemmings_os_web/components/instance_components.ex
@@ -8,6 +8,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
   alias LemmingsOs.Tools.ToolExecutionOutputs
 
   @default_max_retries 3
+  @email_draft_result_keys ~w(status provider connection_ref draft_id message_id to cc bcc subject artifact_ids)
 
   attr :id, :string, default: nil
   attr :status, :string, required: true
@@ -231,7 +232,7 @@ defmodule LemmingsOsWeb.InstanceComponents do
       |> assign(:tool_status, status)
       |> assign(:tool_details_id, "tool-execution-details-#{assigns.tool_execution.id}")
       |> assign(:args_payload, tool_payload_json(assigns.tool_execution.args))
-      |> assign(:result_payload, tool_payload_json(assigns.tool_execution.result))
+      |> assign(:result_payload, tool_result_payload_json(assigns.tool_execution))
       |> assign(:error_payload, tool_payload_json(assigns.tool_execution.error))
       |> assign(:artifact_link, tool_artifact_link(assigns.tool_execution, assigns.world_id))
       |> assign(:promotion_form_id, "artifact-promotion-form-#{assigns.tool_execution.id}")
@@ -1018,6 +1019,13 @@ defmodule LemmingsOsWeb.InstanceComponents do
   defp tool_status_label("error"), do: dgettext("lemmings", "Failed")
   defp tool_status_label(status), do: status
 
+  defp tool_summary(%{tool_name: "email.create_draft"} = tool_execution) do
+    case email_draft_summary(tool_execution) do
+      nil -> email_draft_fallback_summary(tool_execution)
+      summary -> summary
+    end
+  end
+
   defp tool_summary(%{summary: summary}) when is_binary(summary) and summary != "", do: summary
 
   defp tool_summary(%{status: "running"}),
@@ -1062,6 +1070,10 @@ defmodule LemmingsOsWeb.InstanceComponents do
 
   defp tool_summary_prefix(tool_execution),
     do: ensure_trailing_space(tool_summary(tool_execution))
+
+  defp tool_preview(%{tool_name: "email.create_draft"} = tool_execution) do
+    email_draft_preview(tool_execution)
+  end
 
   defp tool_preview(%{preview: preview}) when is_binary(preview) and preview != "", do: preview
 
@@ -1160,6 +1172,81 @@ defmodule LemmingsOsWeb.InstanceComponents do
   end
 
   defp tool_payload_json(payload), do: inspect(payload, pretty: true)
+
+  defp tool_result_payload_json(%{tool_name: "email.create_draft", result: result})
+       when is_map(result) do
+    result
+    |> email_draft_safe_result()
+    |> tool_payload_json()
+  end
+
+  defp tool_result_payload_json(%{result: result}), do: tool_payload_json(result)
+  defp tool_result_payload_json(_tool_execution), do: "{}"
+
+  defp email_draft_summary(%{result: result}) when is_map(result) do
+    recipient = result |> Map.get("to", []) |> safe_string_list() |> List.first() || "recipient"
+    attachment_count = result |> Map.get("artifact_ids", []) |> safe_string_list() |> length()
+    attachment_label = if attachment_count == 1, do: "attachment", else: "attachments"
+
+    "Created Gmail draft for #{recipient} with #{attachment_count} #{attachment_label}"
+  end
+
+  defp email_draft_summary(_tool_execution), do: nil
+
+  defp email_draft_fallback_summary(%{status: "running"}),
+    do: dgettext("lemmings", "Gmail draft creation is still running.")
+
+  defp email_draft_fallback_summary(%{status: "error"}),
+    do: dgettext("lemmings", "Gmail draft creation failed.")
+
+  defp email_draft_fallback_summary(_tool_execution),
+    do: dgettext("lemmings", "Gmail draft creation recorded.")
+
+  defp email_draft_preview(%{result: result}) when is_map(result) do
+    case safe_string(Map.get(result, "subject")) do
+      nil -> nil
+      subject -> "Subject: #{subject}"
+    end
+  end
+
+  defp email_draft_preview(_tool_execution), do: nil
+
+  defp email_draft_safe_result(result) when is_map(result) do
+    result
+    |> Map.take(@email_draft_result_keys)
+    |> Map.put("to", safe_string_list(Map.get(result, "to", [])))
+    |> Map.put("cc", safe_string_list(Map.get(result, "cc", [])))
+    |> Map.put("bcc", safe_string_list(Map.get(result, "bcc", [])))
+    |> Map.put("artifact_ids", safe_string_list(Map.get(result, "artifact_ids", [])))
+    |> maybe_put_safe_string("status", Map.get(result, "status"))
+    |> maybe_put_safe_string("provider", Map.get(result, "provider"))
+    |> maybe_put_safe_string("connection_ref", Map.get(result, "connection_ref"))
+    |> maybe_put_safe_string("draft_id", Map.get(result, "draft_id"))
+    |> maybe_put_safe_string("message_id", Map.get(result, "message_id"))
+    |> maybe_put_safe_string("subject", Map.get(result, "subject"))
+  end
+
+  defp maybe_put_safe_string(payload, key, value) do
+    case safe_string(value) do
+      nil -> Map.delete(payload, key)
+      safe_value -> Map.put(payload, key, safe_value)
+    end
+  end
+
+  defp safe_string_list(values) when is_list(values) do
+    values
+    |> Enum.map(&safe_string/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp safe_string_list(_values), do: []
+
+  defp safe_string(value) when is_binary(value) do
+    trimmed = String.trim(value)
+    if trimmed == "", do: nil, else: trimmed
+  end
+
+  defp safe_string(_value), do: nil
 
   defp assistant_metadata?(role) when role in ["assistant", :assistant], do: true
   defp assistant_metadata?(_role), do: false

--- a/lib/lemmings_os_web/components/world_components.ex
+++ b/lib/lemmings_os_web/components/world_components.ex
@@ -22,6 +22,8 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, default: []
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :connection_gmail_oauth, :map, default: %{}
+  attr :connection_scope_params, :map, default: %{}
   attr :artifact_rows, :list, default: []
 
   def world_page(assigns) do
@@ -62,6 +64,8 @@ defmodule LemmingsOsWeb.WorldComponents do
         connection_rows={@connection_rows}
         connection_editing_id={@connection_editing_id}
         connection_edit_form={@connection_edit_form}
+        connection_gmail_oauth={@connection_gmail_oauth}
+        connection_scope_params={@connection_scope_params}
         artifact_rows={@artifact_rows}
       />
     </.content_container>
@@ -89,6 +93,8 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, required: true
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :connection_gmail_oauth, :map, default: %{}
+  attr :connection_scope_params, :map, default: %{}
   attr :artifact_rows, :list, default: []
 
   defp world_snapshot(assigns) do
@@ -517,6 +523,8 @@ defmodule LemmingsOsWeb.WorldComponents do
       rows={@connection_rows}
       editing_connection_id={@connection_editing_id}
       edit_form={@connection_edit_form}
+      gmail_oauth={@connection_gmail_oauth}
+      gmail_scope_params={@connection_scope_params}
       create_submit_event="create_world_connection"
       create_type_change_event="change_world_connection_create_type"
       open_create_event="open_world_connection_create"
@@ -774,6 +782,8 @@ defmodule LemmingsOsWeb.WorldComponents do
   attr :connection_rows, :list, default: []
   attr :connection_editing_id, :string, default: nil
   attr :connection_edit_form, :any, default: nil
+  attr :connection_gmail_oauth, :map, default: %{}
+  attr :connection_scope_params, :map, default: %{}
   attr :artifact_rows, :list, default: []
 
   def department_detail_page(assigns) do
@@ -1245,6 +1255,8 @@ defmodule LemmingsOsWeb.WorldComponents do
         rows={@connection_rows}
         editing_connection_id={@connection_editing_id}
         edit_form={@connection_edit_form}
+        gmail_oauth={@connection_gmail_oauth}
+        gmail_scope_params={@connection_scope_params}
         create_submit_event="create_department_connection"
         create_type_change_event="change_department_connection_create_type"
         open_create_event="open_department_connection_create"

--- a/lib/lemmings_os_web/connections_surface.ex
+++ b/lib/lemmings_os_web/connections_surface.ex
@@ -6,6 +6,22 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
   use Gettext, backend: LemmingsOs.Gettext
 
   alias LemmingsOs.Connections
+  alias LemmingsOs.Connections.Connection
+  alias LemmingsOs.Connections.Providers.GmailCaller
+  alias LemmingsOs.SecretBank
+
+  @gmail_client_id_refs [
+    "$GMAIL_CLIENT_ID",
+    "$GOOGLE_OAUTH_CLIENT_ID",
+    "$GMAIL_OAUTH_CLIENT_ID"
+  ]
+  @gmail_client_secret_refs [
+    "$GMAIL_CLIENT_SECRET",
+    "$GOOGLE_OAUTH_CLIENT_SECRET",
+    "$GMAIL_OAUTH_CLIENT_SECRET"
+  ]
+  @gmail_default_client_id_ref "$GMAIL_CLIENT_ID"
+  @gmail_default_client_secret_ref "$GMAIL_CLIENT_SECRET"
 
   def create_form(types, params \\ %{}) do
     default_type =
@@ -14,17 +30,26 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
         _ -> default_type(types)
       end
 
-    default_config = default_config_text(types, default_type)
-
-    form_params = %{
-      "type" => default_type,
-      "status" => "enabled",
-      "config" => Map.get(params, "config", default_config)
-    }
+    form_params =
+      params
+      |> Map.put_new("type", default_type)
+      |> Map.put_new("status", "enabled")
+      |> Map.put_new("config", default_config_text(types, default_type))
+      |> normalize_gmail_form_params()
 
     form_params
     |> connection_form_changeset()
     |> Phoenix.Component.to_form(as: :connection_create)
+  end
+
+  def create_form_for_type(types, type, rows) when is_list(rows) do
+    params =
+      case find_local_connection_by_type(rows, type) do
+        {:ok, connection} -> params_from_connection(connection)
+        :error -> %{"type" => type}
+      end
+
+    create_form(types, params)
   end
 
   def edit_form(connection_or_params) do
@@ -34,31 +59,71 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
           params
 
         connection ->
-          %{
-            "connection_id" => connection.id,
-            "type" => connection.type,
-            "status" => connection.status,
-            "config" => encode_config(connection.config || %{})
-          }
+          params_from_connection(connection)
       end
 
     params
+    |> normalize_gmail_form_params()
     |> connection_form_changeset()
     |> Phoenix.Component.to_form(as: :connection_edit)
   end
 
   def parse_connection_form_params(params) when is_map(params) do
     with type when is_binary(type) and type != "" <- String.trim(Map.get(params, "type", "")),
-         status when is_binary(status) and status != "" <-
-           String.trim(Map.get(params, "status", "enabled")),
-         {:ok, config} <- parse_config_payload(Map.get(params, "config", "{}")) do
-      {:ok, %{type: type, status: status, config: config}}
+         {:ok, status} <- fetch_status(params) do
+      parse_connection_config(type, status, params)
     else
       _ -> {:error, :invalid_payload}
     end
   end
 
   def parse_connection_form_params(_params), do: {:error, :invalid_payload}
+
+  def connection_form_action(%{"action" => "connect_gmail"}), do: :connect_gmail
+  def connection_form_action(_params), do: :save
+
+  def upsert_gmail_connection(scope, attrs, "") when is_map(attrs),
+    do: upsert_gmail_connection(scope, attrs, nil)
+
+  def upsert_gmail_connection(scope, attrs, connection_id)
+      when is_map(attrs) and is_binary(connection_id) do
+    existing = Connections.get_connection(scope, connection_id)
+
+    cond do
+      match?(%Connection{type: "gmail"}, existing) ->
+        Connections.update_connection(scope, existing, attrs)
+
+      is_nil(existing) ->
+        upsert_gmail_connection(scope, attrs, nil)
+
+      true ->
+        {:error, :invalid_type}
+    end
+  end
+
+  def upsert_gmail_connection(scope, attrs, _connection_id) when is_map(attrs) do
+    case Connections.get_connection_by_type(scope, "gmail") do
+      %Connection{} = connection -> Connections.update_connection(scope, connection, attrs)
+      nil -> Connections.create_connection(scope, attrs)
+    end
+  end
+
+  def gmail_oauth_state(scope) do
+    client_id_ref = first_available_ref(scope, @gmail_client_id_refs)
+    client_secret_ref = first_available_ref(scope, @gmail_client_secret_refs)
+
+    missing_refs =
+      []
+      |> maybe_add_missing_ref(client_id_ref, List.first(@gmail_client_id_refs))
+      |> maybe_add_missing_ref(client_secret_ref, List.first(@gmail_client_secret_refs))
+
+    %{
+      enabled?: missing_refs == [],
+      client_id_ref: client_id_ref || List.first(@gmail_client_id_refs),
+      client_secret_ref: client_secret_ref || List.first(@gmail_client_secret_refs),
+      missing_refs: missing_refs
+    }
+  end
 
   def default_config_text(types, type) do
     config =
@@ -69,6 +134,44 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
   end
 
   def encode_config(config) when is_map(config), do: Jason.encode!(config, pretty: true)
+
+  def gmail_form?(form), do: form_value(form, :type) == "gmail"
+
+  def gmail_connected?(form) do
+    form
+    |> gmail_refresh_token_ref()
+    |> present?()
+  end
+
+  def gmail_account_label(form) do
+    case form_value(form, :account_email) do
+      value when is_binary(value) and value != "" -> value
+      _ -> dgettext("layout", "Not available")
+    end
+  end
+
+  def gmail_refresh_token_ref(form) do
+    case form_value(form, :refresh_token) do
+      "$" <> _rest = ref -> ref
+      _ -> nil
+    end
+  end
+
+  def gmail_status_label(form) do
+    if gmail_connected?(form) do
+      dgettext("layout", "Connected")
+    else
+      dgettext("layout", "Not connected")
+    end
+  end
+
+  def gmail_action_label(form) do
+    if gmail_connected?(form) do
+      dgettext("layout", "Reconnect Gmail")
+    else
+      dgettext("layout", "Connect Gmail")
+    end
+  end
 
   def connection_label(%{connection: connection, source_scope: source_scope}) do
     "#{String.capitalize(source_scope)} / #{connection.type}"
@@ -96,6 +199,13 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
     end
   end
 
+  def find_local_connection_by_type(rows, type) when is_list(rows) and is_binary(type) do
+    case Enum.find(rows, &(&1.local? and &1.connection.type == type)) do
+      nil -> :error
+      row -> {:ok, row.connection}
+    end
+  end
+
   def run_connection_lifecycle(scope, connection, "enable"),
     do: Connections.enable_connection(scope, connection)
 
@@ -109,12 +219,149 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
   end
 
   defp connection_form_changeset(params) do
-    types = %{type: :string, status: :string, config: :string, connection_id: :string}
+    types = %{
+      type: :string,
+      status: :string,
+      config: :string,
+      connection_id: :string,
+      client_id: :string,
+      client_secret: :string,
+      account_email: :string,
+      refresh_token: :string
+    }
 
     {%{}, types}
     |> Ecto.Changeset.cast(params, Map.keys(types))
     |> Ecto.Changeset.validate_required([:type, :status, :config])
   end
+
+  defp params_from_connection(%Connection{} = connection) do
+    %{
+      "connection_id" => connection.id,
+      "type" => connection.type,
+      "status" => connection.status,
+      "config" => encode_config(connection.config || %{})
+    }
+  end
+
+  defp normalize_gmail_form_params(%{"type" => "gmail"} = params) do
+    config = parse_config_payload(Map.get(params, "config", "{}")) |> parsed_config_or_empty()
+
+    client_id =
+      first_present([
+        Map.get(params, "client_id"),
+        Map.get(config, "client_id"),
+        @gmail_default_client_id_ref
+      ])
+
+    client_secret =
+      first_present([
+        Map.get(params, "client_secret"),
+        Map.get(config, "client_secret"),
+        @gmail_default_client_secret_ref
+      ])
+
+    account_email =
+      first_present([Map.get(params, "account_email"), Map.get(config, "account_email"), ""])
+
+    refresh_token =
+      first_present([Map.get(params, "refresh_token"), Map.get(config, "refresh_token"), ""])
+
+    gmail_config =
+      gmail_config(client_id, client_secret, account_email, refresh_token)
+
+    params
+    |> Map.put("client_id", client_id)
+    |> Map.put("client_secret", client_secret)
+    |> Map.put("account_email", account_email)
+    |> Map.put("refresh_token", refresh_token)
+    |> Map.put("config", Map.get(params, "config") || encode_config(gmail_config))
+  end
+
+  defp normalize_gmail_form_params(params), do: params
+
+  defp parsed_config_or_empty({:ok, config}), do: config
+  defp parsed_config_or_empty(_result), do: %{}
+
+  defp first_present(values) do
+    Enum.find_value(values, "", fn
+      value when is_binary(value) ->
+        trimmed = String.trim(value)
+        if trimmed == "", do: nil, else: trimmed
+
+      _ ->
+        nil
+    end)
+  end
+
+  defp fetch_status(params) do
+    case String.trim(Map.get(params, "status", "enabled")) do
+      "" -> {:error, :invalid_payload}
+      status -> {:ok, status}
+    end
+  end
+
+  defp parse_connection_config("gmail", status, params) do
+    with {:ok, client_id_ref} <- fetch_secret_ref(params, "client_id"),
+         {:ok, client_secret_ref} <- fetch_secret_ref(params, "client_secret") do
+      account_email = params |> Map.get("account_email", "") |> safe_string()
+      refresh_token = params |> Map.get("refresh_token", "") |> safe_string()
+
+      {:ok,
+       %{
+         type: "gmail",
+         status: status,
+         config: gmail_config(client_id_ref, client_secret_ref, account_email, refresh_token)
+       }}
+    end
+  end
+
+  defp parse_connection_config(type, status, params) do
+    with {:ok, config} <- parse_config_payload(Map.get(params, "config", "{}")) do
+      {:ok, %{type: type, status: status, config: config}}
+    end
+  end
+
+  defp gmail_config(client_id_ref, client_secret_ref, account_email, refresh_token) do
+    %{
+      "provider" => "gmail",
+      "scopes" => [GmailCaller.compose_scope()],
+      "client_id" => client_id_ref,
+      "client_secret" => client_secret_ref,
+      "account_email" => account_email || ""
+    }
+    |> maybe_put_refresh_token(refresh_token)
+  end
+
+  defp maybe_put_refresh_token(config, "$" <> _rest = refresh_token),
+    do: Map.put(config, "refresh_token", refresh_token)
+
+  defp maybe_put_refresh_token(config, _refresh_token), do: config
+
+  defp fetch_secret_ref(map, key) do
+    with value when is_binary(value) <- Map.get(map, key),
+         "$" <> rest = ref <- String.trim(value),
+         true <- rest != "" do
+      {:ok, ref}
+    else
+      _ -> {:error, :invalid_payload}
+    end
+  end
+
+  defp safe_string(value) when is_binary(value), do: String.trim(value)
+  defp safe_string(_value), do: ""
+
+  defp form_value(form, field) do
+    value = form[field].value
+
+    case value do
+      value when is_binary(value) -> String.trim(value)
+      _ -> value
+    end
+  end
+
+  defp present?(value) when is_binary(value), do: String.trim(value) != ""
+  defp present?(_value), do: false
 
   defp parse_config_payload(payload) when is_binary(payload) do
     case YamlElixir.read_from_string(payload) do
@@ -146,6 +393,20 @@ defmodule LemmingsOsWeb.ConnectionsSurface do
 
   defp default_type([%{id: id} | _rest]), do: id
   defp default_type(_types), do: ""
+
+  defp first_available_ref(scope, refs) when is_list(refs) do
+    Enum.find(refs, &secret_configured?(scope, &1))
+  end
+
+  defp secret_configured?(scope, ref) when is_binary(ref) do
+    case SecretBank.list_effective_metadata(scope, bank_key: ref) do
+      [%{configured: true} | _rest] -> true
+      _ -> false
+    end
+  end
+
+  defp maybe_add_missing_ref(missing_refs, nil, required_ref), do: missing_refs ++ [required_ref]
+  defp maybe_add_missing_ref(missing_refs, _present_ref, _required_ref), do: missing_refs
 
   defp test_failure_reason_label(%Ecto.Changeset{}), do: "invalid changeset"
   defp test_failure_reason_label(:missing_secret), do: "missing_secret"

--- a/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
+++ b/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
@@ -231,12 +231,16 @@ defmodule LemmingsOsWeb.GmailOAuthController do
        do: ~p"/departments?#{%{city: city_id, dept: department_id, tab: "connections"}}"
 
   defp safe_return_to(%{"return_to" => return_to}, fallback) when is_binary(return_to) do
-    if String.starts_with?(return_to, ["/world", "/cities", "/departments"]) do
-      return_to
-    else
-      fallback
-    end
+    return_to
+    |> URI.parse()
+    |> safe_return_to_uri(return_to, fallback)
   end
 
   defp safe_return_to(_session_state, fallback), do: fallback
+
+  defp safe_return_to_uri(%URI{scheme: nil, host: nil, path: path}, return_to, _fallback)
+       when path in ["/world", "/cities", "/departments"],
+       do: return_to
+
+  defp safe_return_to_uri(_uri, _return_to, fallback), do: fallback
 end

--- a/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
+++ b/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
@@ -1,0 +1,199 @@
+defmodule LemmingsOsWeb.GmailOAuthController do
+  @moduledoc """
+  Browser OAuth controller for Gmail connection onboarding.
+
+  Responsibilities:
+
+  - `start/2` validates the requested target scope (`world`, `city`, or
+    `department`) and initializes a session-bound OAuth flow through
+    `LemmingsOs.Connections.GmailOAuth`.
+  - `callback/2` consumes and clears session OAuth state, validates callback
+    state/scope through the backend boundary, and creates or updates the
+    scope-local `gmail` connection.
+
+  Security and safety behavior:
+
+  - Target scope for callback completion is resolved from session state, not
+    from callback params.
+  - OAuth session state is deleted before completion handling (fail-closed for
+    replay/re-entry).
+  - The controller emits safe lifecycle events
+    (`connection.gmail.oauth_started|succeeded|failed`) and never logs tokens.
+  - User-facing failures remain generic (`"Gmail OAuth failed."`) to avoid
+    leaking provider details.
+  """
+  use LemmingsOsWeb, :controller
+
+  alias LemmingsOs.Cities
+  alias LemmingsOs.Connections.GmailOAuth
+  alias LemmingsOs.Departments
+  alias LemmingsOs.Events
+  alias LemmingsOs.Worlds
+  alias LemmingsOs.Worlds.World
+
+  @oauth_session_key "gmail_oauth_state"
+
+  def start(conn, params) do
+    with {:ok, scope} <- scope_from_params(params),
+         {:ok, %{authorize_url: url, session_state: session_state}} <-
+           GmailOAuth.start(scope, params, redirect_uri: callback_url(conn)) do
+      _ = record_event(scope, "connection.gmail.oauth_started", "Gmail OAuth started")
+
+      conn
+      |> put_session(@oauth_session_key, session_state)
+      |> redirect(external: url)
+    else
+      _ ->
+        conn
+        |> put_flash(:error, "Unable to start Gmail OAuth.")
+        |> redirect(to: ~p"/settings")
+    end
+  end
+
+  def callback(conn, params) do
+    session_state = get_session(conn, @oauth_session_key) || %{}
+    conn = delete_session(conn, @oauth_session_key)
+
+    with {:ok, scope} <- scope_from_session(session_state),
+         {:ok, connection} <-
+           GmailOAuth.complete(scope, params, session_state,
+             redirect_uri: callback_url(conn),
+             oauth_client: oauth_client()
+           ) do
+      _ =
+        record_event(scope, "connection.gmail.oauth_succeeded", "Gmail OAuth succeeded", %{
+          connection_id: connection.id
+        })
+
+      conn
+      |> put_flash(:info, "Gmail connected.")
+      |> redirect(to: ~p"/settings")
+    else
+      {:error, reason} ->
+        _ = record_safe_failure(session_state, reason)
+
+        conn
+        |> put_flash(:error, "Gmail OAuth failed.")
+        |> redirect(to: ~p"/settings")
+    end
+  end
+
+  defp oauth_client do
+    Application.get_env(
+      :lemmings_os,
+      :gmail_oauth_client,
+      LemmingsOs.Connections.GmailOAuth.Client
+    )
+  end
+
+  defp callback_url(conn), do: url(conn, ~p"/connections/gmail/oauth/callback")
+
+  defp record_safe_failure(session_state, reason) do
+    with {:ok, scope} <- scope_from_session(session_state) do
+      record_event(scope, "connection.gmail.oauth_failed", "Gmail OAuth failed", %{
+        reason: safe_reason(reason)
+      })
+    end
+  end
+
+  defp safe_reason(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp safe_reason(_reason), do: "oauth_failed"
+
+  defp record_event(scope, event_type, message, payload \\ %{}) do
+    Events.record_event(
+      event_type,
+      scope_data(scope),
+      message,
+      payload: Map.merge(scope_data(scope), payload)
+    )
+  end
+
+  defp scope_data(%World{id: world_id}),
+    do: %{world_id: world_id, city_id: nil, department_id: nil}
+
+  defp scope_data(%LemmingsOs.Cities.City{id: city_id, world_id: world_id}),
+    do: %{world_id: world_id, city_id: city_id, department_id: nil}
+
+  defp scope_data(%LemmingsOs.Departments.Department{
+         id: department_id,
+         city_id: city_id,
+         world_id: world_id
+       }),
+       do: %{world_id: world_id, city_id: city_id, department_id: department_id}
+
+  defp scope_from_session(%{"scope" => %{"kind" => "world", "world_id" => world_id}})
+       when is_binary(world_id) do
+    case Worlds.get_world(world_id) do
+      nil -> {:error, :invalid_scope}
+      world -> {:ok, world}
+    end
+  end
+
+  defp scope_from_session(%{
+         "scope" => %{"kind" => "city", "world_id" => world_id, "city_id" => city_id}
+       })
+       when is_binary(world_id) and is_binary(city_id) do
+    with %World{} = world <- Worlds.get_world(world_id),
+         %LemmingsOs.Cities.City{} = city <- Cities.get_city(world, city_id) do
+      {:ok, city}
+    else
+      _ -> {:error, :invalid_scope}
+    end
+  end
+
+  defp scope_from_session(%{
+         "scope" => %{
+           "kind" => "department",
+           "world_id" => world_id,
+           "city_id" => city_id,
+           "department_id" => department_id
+         }
+       })
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) do
+    with %World{} = world <- Worlds.get_world(world_id),
+         %LemmingsOs.Cities.City{} = city <- Cities.get_city(world, city_id),
+         %LemmingsOs.Departments.Department{} = department <-
+           Departments.get_department(department_id, world_id: world.id, city_id: city.id) do
+      {:ok, department}
+    else
+      _ -> {:error, :invalid_scope}
+    end
+  end
+
+  defp scope_from_session(_session_state), do: {:error, :invalid_scope}
+
+  defp scope_from_params(%{
+         "world_id" => world_id,
+         "city_id" => city_id,
+         "department_id" => department_id
+       })
+       when is_binary(world_id) and is_binary(city_id) and is_binary(department_id) do
+    with %World{} = world <- Worlds.get_world(world_id),
+         %LemmingsOs.Cities.City{} = city <- Cities.get_city(world, city_id),
+         %LemmingsOs.Departments.Department{} = department <-
+           Departments.get_department(department_id, world_id: world.id, city_id: city.id) do
+      {:ok, department}
+    else
+      _ -> {:error, :invalid_scope}
+    end
+  end
+
+  defp scope_from_params(%{"world_id" => world_id, "city_id" => city_id})
+       when is_binary(world_id) and is_binary(city_id) do
+    with %World{} = world <- Worlds.get_world(world_id),
+         %LemmingsOs.Cities.City{} = city <- Cities.get_city(world, city_id) do
+      {:ok, city}
+    else
+      _ -> {:error, :invalid_scope}
+    end
+  end
+
+  defp scope_from_params(%{"world_id" => world_id}) when is_binary(world_id) do
+    case Worlds.get_world(world_id) do
+      %World{} = world -> {:ok, world}
+      _ -> {:error, :invalid_scope}
+    end
+  end
+
+  defp scope_from_params(_params), do: {:error, :invalid_scope}
+end

--- a/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
+++ b/lib/lemmings_os_web/controllers/gmail_oauth_controller.ex
@@ -34,15 +34,27 @@ defmodule LemmingsOsWeb.GmailOAuthController do
   @oauth_session_key "gmail_oauth_state"
 
   def start(conn, params) do
-    with {:ok, scope} <- scope_from_params(params),
-         {:ok, %{authorize_url: url, session_state: session_state}} <-
-           GmailOAuth.start(scope, params, redirect_uri: callback_url(conn)) do
-      _ = record_event(scope, "connection.gmail.oauth_started", "Gmail OAuth started")
+    case scope_from_params(params) do
+      {:ok, scope} ->
+        case GmailOAuth.start(scope, params, redirect_uri: callback_url(conn)) do
+          {:ok, %{authorize_url: url, session_state: session_state}} ->
+            _ = record_event(scope, "connection.gmail.oauth_started", "Gmail OAuth started")
 
-      conn
-      |> put_session(@oauth_session_key, session_state)
-      |> redirect(external: url)
-    else
+            return_to = safe_return_to(params, connections_redirect_path(scope))
+
+            conn
+            |> put_session(
+              @oauth_session_key,
+              Map.put(session_state, "return_to", return_to)
+            )
+            |> redirect(external: url)
+
+          _ ->
+            conn
+            |> put_flash(:error, "Unable to start Gmail OAuth.")
+            |> redirect(to: connections_redirect_path(scope))
+        end
+
       _ ->
         conn
         |> put_flash(:error, "Unable to start Gmail OAuth.")
@@ -54,27 +66,36 @@ defmodule LemmingsOsWeb.GmailOAuthController do
     session_state = get_session(conn, @oauth_session_key) || %{}
     conn = delete_session(conn, @oauth_session_key)
 
-    with {:ok, scope} <- scope_from_session(session_state),
-         {:ok, connection} <-
-           GmailOAuth.complete(scope, params, session_state,
-             redirect_uri: callback_url(conn),
-             oauth_client: oauth_client()
-           ) do
-      _ =
-        record_event(scope, "connection.gmail.oauth_succeeded", "Gmail OAuth succeeded", %{
-          connection_id: connection.id
-        })
+    case scope_from_session(session_state) do
+      {:ok, scope} ->
+        return_to = safe_return_to(session_state, connections_redirect_path(scope))
 
-      conn
-      |> put_flash(:info, "Gmail connected.")
-      |> redirect(to: ~p"/settings")
-    else
-      {:error, reason} ->
-        _ = record_safe_failure(session_state, reason)
+        case GmailOAuth.complete(scope, params, session_state,
+               redirect_uri: callback_url(conn),
+               oauth_client: oauth_client()
+             ) do
+          {:ok, connection} ->
+            _ =
+              record_event(scope, "connection.gmail.oauth_succeeded", "Gmail OAuth succeeded", %{
+                connection_id: connection.id
+              })
 
+            conn
+            |> put_flash(:info, "Gmail connected.")
+            |> redirect(to: return_to)
+
+          {:error, reason} ->
+            _ = record_safe_failure(session_state, reason)
+
+            conn
+            |> put_flash(:error, "Gmail OAuth failed.")
+            |> redirect(to: return_to)
+        end
+
+      _ ->
         conn
         |> put_flash(:error, "Gmail OAuth failed.")
-        |> redirect(to: ~p"/settings")
+        |> redirect(to: safe_return_to(session_state, ~p"/settings"))
     end
   end
 
@@ -196,4 +217,26 @@ defmodule LemmingsOsWeb.GmailOAuthController do
   end
 
   defp scope_from_params(_params), do: {:error, :invalid_scope}
+
+  defp connections_redirect_path(%World{}),
+    do: ~p"/world?#{%{tab: "connections"}}"
+
+  defp connections_redirect_path(%LemmingsOs.Cities.City{id: city_id}),
+    do: ~p"/cities?#{%{city: city_id, tab: "connections"}}"
+
+  defp connections_redirect_path(%LemmingsOs.Departments.Department{
+         id: department_id,
+         city_id: city_id
+       }),
+       do: ~p"/departments?#{%{city: city_id, dept: department_id, tab: "connections"}}"
+
+  defp safe_return_to(%{"return_to" => return_to}, fallback) when is_binary(return_to) do
+    if String.starts_with?(return_to, ["/world", "/cities", "/departments"]) do
+      return_to
+    else
+      fallback
+    end
+  end
+
+  defp safe_return_to(_session_state, fallback), do: fallback
 end

--- a/lib/lemmings_os_web/endpoint.ex
+++ b/lib/lemmings_os_web/endpoint.ex
@@ -1,13 +1,12 @@
 defmodule LemmingsOsWeb.Endpoint do
   use Phoenix.Endpoint, otp_app: :lemmings_os
 
-  # The session will be stored in the cookie and signed,
-  # this means its contents can be read but not tampered with.
-  # Set :encryption_salt if you would also like to encrypt it.
+  # The session is stored in an encrypted and signed cookie.
   @session_options [
     store: :cookie,
     key: "_lemmings_os_key",
     signing_salt: "QNkmlQfq",
+    encryption_salt: "dev_only_session_encryption_salt",
     same_site: "Lax"
   ]
 

--- a/lib/lemmings_os_web/live/cities_live.ex
+++ b/lib/lemmings_os_web/live/cities_live.ex
@@ -61,6 +61,8 @@ defmodule LemmingsOsWeb.CitiesLive do
      |> assign(:city_connection_rows, [])
      |> assign(:city_connection_editing_id, nil)
      |> assign(:city_connection_edit_form, nil)
+     |> assign(:city_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+     |> assign(:city_connection_scope_params, %{})
      |> assign(:city_artifact_rows, [])
      |> load_snapshot(params)}
   end
@@ -242,7 +244,11 @@ defmodule LemmingsOsWeb.CitiesLive do
      assign(
        socket,
        :city_connection_create_form,
-       ConnectionsSurface.create_form(socket.assigns.city_connection_types, %{"type" => type})
+       ConnectionsSurface.create_form_for_type(
+         socket.assigns.city_connection_types,
+         type,
+         socket.assigns.city_connection_rows
+       )
      )}
   end
 
@@ -261,16 +267,24 @@ defmodule LemmingsOsWeb.CitiesLive do
   end
 
   def handle_event("create_city_connection", %{"connection_create" => params}, socket) do
+    action = ConnectionsSurface.connection_form_action(params)
+
     with {:ok, city} <- load_selected_city_scope(socket),
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.create_connection(city, attrs) do
+         {:ok, connection} <- persist_city_connection(city, attrs, params) do
       snapshot_params = city_detail_params(socket, %{city: city.id})
 
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
-       |> assign(:city_connection_create_open, false)
-       |> load_snapshot(snapshot_params)}
+      case action do
+        :connect_gmail ->
+          {:noreply, redirect(socket, to: city_gmail_oauth_start_path(city, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
+           |> assign(:city_connection_create_open, false)
+           |> load_snapshot(snapshot_params)}
+      end
     else
       {:error, :invalid_scope} ->
         {:noreply, put_flash(socket, :error, dgettext("errors", ".error_city_unavailable"))}
@@ -342,6 +356,7 @@ defmodule LemmingsOsWeb.CitiesLive do
 
   def handle_event("save_city_connection_edit", %{"connection_edit" => params}, socket) do
     connection_id = Map.get(params, "connection_id", "")
+    action = ConnectionsSurface.connection_form_action(params)
 
     with {:ok, city} <- load_selected_city_scope(socket),
          {:ok, row} <-
@@ -350,13 +365,19 @@ defmodule LemmingsOsWeb.CitiesLive do
              connection_id
            ),
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.update_connection(city, row.connection, attrs) do
+         {:ok, connection} <- Connections.update_connection(city, row.connection, attrs) do
       snapshot_params = city_detail_params(socket, %{city: city.id})
 
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
-       |> load_snapshot(snapshot_params)}
+      case action do
+        :connect_gmail ->
+          {:noreply, redirect(socket, to: city_gmail_oauth_start_path(city, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
+           |> load_snapshot(snapshot_params)}
+      end
     else
       {:error, :invalid_scope} ->
         {:noreply, put_flash(socket, :error, dgettext("errors", ".error_city_unavailable"))}
@@ -586,6 +607,8 @@ defmodule LemmingsOsWeb.CitiesLive do
       |> assign(:city_connection_create_open, false)
       |> assign(:city_connection_editing_id, nil)
       |> assign(:city_connection_edit_form, nil)
+      |> assign(:city_gmail_oauth, ConnectionsSurface.gmail_oauth_state(city))
+      |> assign(:city_connection_scope_params, %{world_id: world.id, city_id: city.id})
     else
       _ -> reset_city_connection_surface(socket)
     end
@@ -604,6 +627,8 @@ defmodule LemmingsOsWeb.CitiesLive do
     |> assign(:city_connection_create_open, false)
     |> assign(:city_connection_editing_id, nil)
     |> assign(:city_connection_edit_form, nil)
+    |> assign(:city_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+    |> assign(:city_connection_scope_params, %{})
   end
 
   defp assign_city_artifact_surface(socket, %{selected_city: nil}),
@@ -650,6 +675,19 @@ defmodule LemmingsOsWeb.CitiesLive do
   end
 
   defp load_selected_city_scope(_socket), do: {:error, :invalid_scope}
+
+  defp persist_city_connection(city, %{type: "gmail"} = attrs, params) do
+    ConnectionsSurface.upsert_gmail_connection(city, attrs, Map.get(params, "connection_id"))
+  end
+
+  defp persist_city_connection(city, attrs, _params),
+    do: Connections.create_connection(city, attrs)
+
+  defp city_gmail_oauth_start_path(%City{} = city, connection, attrs) do
+    return_to = ~p"/cities?#{%{city: city.id, tab: "connections"}}"
+
+    ~p"/connections/gmail/oauth/start?#{%{world_id: city.world_id, city_id: city.id, connection_id: connection.id, client_id: attrs.config["client_id"], client_secret: attrs.config["client_secret"], return_to: return_to}}"
+  end
 
   defp blank_secret_form, do: to_form(%{"bank_key" => "", "value" => ""}, as: :secret)
 

--- a/lib/lemmings_os_web/live/cities_live.ex
+++ b/lib/lemmings_os_web/live/cities_live.ex
@@ -298,6 +298,10 @@ defmodule LemmingsOsWeb.CitiesLive do
       {:error, :invalid_payload} ->
         {:noreply,
          put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
+
+      {:error, :invalid_type} ->
+        {:noreply,
+         put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
     end
   end
 

--- a/lib/lemmings_os_web/live/cities_live.html.heex
+++ b/lib/lemmings_os_web/live/cities_live.html.heex
@@ -325,6 +325,8 @@
             rows={@city_connection_rows}
             editing_connection_id={@city_connection_editing_id}
             edit_form={@city_connection_edit_form}
+            gmail_oauth={@city_gmail_oauth}
+            gmail_scope_params={@city_connection_scope_params}
             create_submit_event="create_city_connection"
             create_type_change_event="change_city_connection_create_type"
             open_create_event="open_city_connection_create"

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -287,6 +287,10 @@ defmodule LemmingsOsWeb.DepartmentsLive do
       {:error, :invalid_payload} ->
         {:noreply,
          put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
+
+      {:error, :invalid_type} ->
+        {:noreply,
+         put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
     end
   end
 

--- a/lib/lemmings_os_web/live/departments_live.ex
+++ b/lib/lemmings_os_web/live/departments_live.ex
@@ -51,6 +51,8 @@ defmodule LemmingsOsWeb.DepartmentsLive do
      |> assign(:department_connection_rows, [])
      |> assign(:department_connection_editing_id, nil)
      |> assign(:department_connection_edit_form, nil)
+     |> assign(:department_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+     |> assign(:department_connection_scope_params, %{})
      |> assign(:department_artifact_rows, [])}
   end
 
@@ -227,9 +229,11 @@ defmodule LemmingsOsWeb.DepartmentsLive do
      assign(
        socket,
        :department_connection_create_form,
-       ConnectionsSurface.create_form(socket.assigns.department_connection_types, %{
-         "type" => type
-       })
+       ConnectionsSurface.create_form_for_type(
+         socket.assigns.department_connection_types,
+         type,
+         socket.assigns.department_connection_rows
+       )
      )}
   end
 
@@ -248,16 +252,25 @@ defmodule LemmingsOsWeb.DepartmentsLive do
   end
 
   def handle_event("create_department_connection", %{"connection_create" => params}, socket) do
+    action = ConnectionsSurface.connection_form_action(params)
+
     with %Department{} = department <- socket.assigns.selected_department,
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.create_connection(department, attrs) do
+         {:ok, connection} <- persist_department_connection(department, attrs, params) do
       department = reload_department_detail(department)
 
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
-       |> assign(:department_connection_create_open, false)
-       |> assign_department_detail(department, socket.assigns.selected_department_tab)}
+      case action do
+        :connect_gmail ->
+          {:noreply,
+           redirect(socket, to: department_gmail_oauth_start_path(department, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
+           |> assign(:department_connection_create_open, false)
+           |> assign_department_detail(department, socket.assigns.selected_department_tab)}
+      end
     else
       nil ->
         {:noreply, put_flash(socket, :error, dgettext("errors", ".error_department_unavailable"))}
@@ -337,6 +350,7 @@ defmodule LemmingsOsWeb.DepartmentsLive do
 
   def handle_event("save_department_connection_edit", %{"connection_edit" => params}, socket) do
     connection_id = Map.get(params, "connection_id", "")
+    action = ConnectionsSurface.connection_form_action(params)
 
     with %Department{} = department <- socket.assigns.selected_department,
          {:ok, row} <-
@@ -345,13 +359,20 @@ defmodule LemmingsOsWeb.DepartmentsLive do
              connection_id
            ),
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.update_connection(department, row.connection, attrs) do
+         {:ok, connection} <- Connections.update_connection(department, row.connection, attrs) do
       department = reload_department_detail(department)
 
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
-       |> assign_department_detail(department, socket.assigns.selected_department_tab)}
+      case action do
+        :connect_gmail ->
+          {:noreply,
+           redirect(socket, to: department_gmail_oauth_start_path(department, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
+           |> assign_department_detail(department, socket.assigns.selected_department_tab)}
+      end
     else
       nil ->
         {:noreply, put_flash(socket, :error, dgettext("errors", ".error_department_unavailable"))}
@@ -558,6 +579,8 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_connection_create_open, false)
     |> assign(:department_connection_editing_id, nil)
     |> assign(:department_connection_edit_form, nil)
+    |> assign(:department_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+    |> assign(:department_connection_scope_params, %{})
   end
 
   defp assign_department_detail(socket, %Department{} = department, requested_tab) do
@@ -584,6 +607,12 @@ defmodule LemmingsOsWeb.DepartmentsLive do
     |> assign(:department_connection_create_open, false)
     |> assign(:department_connection_editing_id, nil)
     |> assign(:department_connection_edit_form, nil)
+    |> assign(:department_gmail_oauth, ConnectionsSurface.gmail_oauth_state(department))
+    |> assign(:department_connection_scope_params, %{
+      world_id: department.world_id,
+      city_id: department.city_id,
+      department_id: department.id
+    })
   end
 
   defp build_department_settings_form(%Department{} = department) do
@@ -680,6 +709,24 @@ defmodule LemmingsOsWeb.DepartmentsLive do
       end
 
     to_form(%{"city_id" => selected_city_id}, as: :city_selector)
+  end
+
+  defp persist_department_connection(department, %{type: "gmail"} = attrs, params) do
+    ConnectionsSurface.upsert_gmail_connection(
+      department,
+      attrs,
+      Map.get(params, "connection_id")
+    )
+  end
+
+  defp persist_department_connection(department, attrs, _params),
+    do: Connections.create_connection(department, attrs)
+
+  defp department_gmail_oauth_start_path(%Department{} = department, connection, attrs) do
+    return_to =
+      ~p"/departments?#{%{city: department.city_id, dept: department.id, tab: "connections"}}"
+
+    ~p"/connections/gmail/oauth/start?#{%{world_id: department.world_id, city_id: department.city_id, department_id: department.id, connection_id: connection.id, client_id: attrs.config["client_id"], client_secret: attrs.config["client_secret"], return_to: return_to}}"
   end
 
   defp blank_secret_form, do: to_form(%{"bank_key" => "", "value" => ""}, as: :secret)

--- a/lib/lemmings_os_web/live/departments_live.html.heex
+++ b/lib/lemmings_os_web/live/departments_live.html.heex
@@ -38,6 +38,8 @@
       connection_rows={@department_connection_rows}
       connection_editing_id={@department_connection_editing_id}
       connection_edit_form={@department_connection_edit_form}
+      connection_gmail_oauth={@department_gmail_oauth}
+      connection_scope_params={@department_connection_scope_params}
       artifact_rows={@department_artifact_rows}
     />
 

--- a/lib/lemmings_os_web/live/world_live.ex
+++ b/lib/lemmings_os_web/live/world_live.ex
@@ -195,6 +195,10 @@ defmodule LemmingsOsWeb.WorldLive do
         {:noreply,
          put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
 
+      {:error, :invalid_type} ->
+        {:noreply,
+         put_flash(socket, :error, dgettext("layout", ".connections_flash_invalid_payload"))}
+
       {:error, :invalid_scope} ->
         {:noreply,
          put_flash(socket, :error, dgettext("layout", ".connections_flash_scope_unavailable"))}

--- a/lib/lemmings_os_web/live/world_live.ex
+++ b/lib/lemmings_os_web/live/world_live.ex
@@ -16,13 +16,13 @@ defmodule LemmingsOsWeb.WorldLive do
   alias LemmingsOsWeb.PageData.WorldPageSnapshot
   require Logger
 
-  def mount(_params, _session, socket) do
+  def mount(params, _session, socket) do
     connection_types = Connections.list_connection_types()
 
     {:ok,
      socket
      |> assign_shell(:world, dgettext("layout", ".page_title_world"))
-     |> assign(:active_tab, "overview")
+     |> assign(:active_tab, normalize_tab(Map.get(params || %{}, "tab")))
      |> assign(:snapshot, nil)
      |> assign(:cities, [])
      |> assign(:last_import_result, nil)
@@ -36,6 +36,8 @@ defmodule LemmingsOsWeb.WorldLive do
      |> assign(:world_connection_rows, [])
      |> assign(:world_connection_editing_id, nil)
      |> assign(:world_connection_edit_form, nil)
+     |> assign(:world_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+     |> assign(:world_connection_scope_params, %{})
      |> assign(:world_artifact_rows, [])
      |> load_snapshot()}
   end
@@ -139,7 +141,11 @@ defmodule LemmingsOsWeb.WorldLive do
      assign(
        socket,
        :world_connection_create_form,
-       ConnectionsSurface.create_form(socket.assigns.world_connection_types, %{"type" => type})
+       ConnectionsSurface.create_form_for_type(
+         socket.assigns.world_connection_types,
+         type,
+         socket.assigns.world_connection_rows
+       )
      )}
   end
 
@@ -158,18 +164,26 @@ defmodule LemmingsOsWeb.WorldLive do
   end
 
   def handle_event("create_world_connection", %{"connection_create" => params}, socket) do
+    action = ConnectionsSurface.connection_form_action(params)
+
     with {:ok, world} <- load_world_scope(socket),
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.create_connection(world, attrs) do
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
-       |> assign_world_connection_surface(world)
-       |> assign(:world_connection_create_open, false)
-       |> assign(
-         :world_connection_create_form,
-         ConnectionsSurface.create_form(socket.assigns.world_connection_types)
-       )}
+         {:ok, connection} <- persist_world_connection(world, attrs, params) do
+      case action do
+        :connect_gmail ->
+          {:noreply, redirect(socket, to: world_gmail_oauth_start_path(world, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_created"))
+           |> assign_world_connection_surface(world)
+           |> assign(:world_connection_create_open, false)
+           |> assign(
+             :world_connection_create_form,
+             ConnectionsSurface.create_form(socket.assigns.world_connection_types)
+           )}
+      end
     else
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply,
@@ -242,6 +256,7 @@ defmodule LemmingsOsWeb.WorldLive do
 
   def handle_event("save_world_connection_edit", %{"connection_edit" => params}, socket) do
     connection_id = Map.get(params, "connection_id", "")
+    action = ConnectionsSurface.connection_form_action(params)
 
     with {:ok, world} <- load_world_scope(socket),
          {:ok, row} <-
@@ -250,13 +265,19 @@ defmodule LemmingsOsWeb.WorldLive do
              connection_id
            ),
          {:ok, attrs} <- ConnectionsSurface.parse_connection_form_params(params),
-         {:ok, _connection} <- Connections.update_connection(world, row.connection, attrs) do
-      {:noreply,
-       socket
-       |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
-       |> assign_world_connection_surface(world)
-       |> assign(:world_connection_editing_id, nil)
-       |> assign(:world_connection_edit_form, nil)}
+         {:ok, connection} <- Connections.update_connection(world, row.connection, attrs) do
+      case action do
+        :connect_gmail ->
+          {:noreply, redirect(socket, to: world_gmail_oauth_start_path(world, connection, attrs))}
+
+        :save ->
+          {:noreply,
+           socket
+           |> put_flash(:info, dgettext("layout", ".connections_flash_updated"))
+           |> assign_world_connection_surface(world)
+           |> assign(:world_connection_editing_id, nil)
+           |> assign(:world_connection_edit_form, nil)}
+      end
     else
       {:error, :invalid_payload} ->
         {:noreply,
@@ -355,6 +376,8 @@ defmodule LemmingsOsWeb.WorldLive do
         |> assign(:world_connection_create_open, false)
         |> assign(:world_connection_editing_id, nil)
         |> assign(:world_connection_edit_form, nil)
+        |> assign(:world_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+        |> assign(:world_connection_scope_params, %{})
         |> assign(:world_artifact_rows, [])
     end
   end
@@ -467,6 +490,8 @@ defmodule LemmingsOsWeb.WorldLive do
       ConnectionsSurface.create_form(socket.assigns.world_connection_types)
     )
     |> assign(:world_connection_create_open, false)
+    |> assign(:world_gmail_oauth, ConnectionsSurface.gmail_oauth_state(world))
+    |> assign(:world_connection_scope_params, %{world_id: world.id})
   end
 
   defp assign_world_connection_surface(socket, nil) do
@@ -479,6 +504,8 @@ defmodule LemmingsOsWeb.WorldLive do
     |> assign(:world_connection_create_open, false)
     |> assign(:world_connection_editing_id, nil)
     |> assign(:world_connection_edit_form, nil)
+    |> assign(:world_gmail_oauth, ConnectionsSurface.gmail_oauth_state(nil))
+    |> assign(:world_connection_scope_params, %{})
   end
 
   defp assign_world_artifact_surface(socket, world_id) when is_binary(world_id) do
@@ -500,6 +527,19 @@ defmodule LemmingsOsWeb.WorldLive do
 
   defp assign_world_artifact_surface(socket, nil) do
     assign(socket, :world_artifact_rows, [])
+  end
+
+  defp persist_world_connection(world, %{type: "gmail"} = attrs, params) do
+    ConnectionsSurface.upsert_gmail_connection(world, attrs, Map.get(params, "connection_id"))
+  end
+
+  defp persist_world_connection(world, attrs, _params),
+    do: Connections.create_connection(world, attrs)
+
+  defp world_gmail_oauth_start_path(%World{} = world, connection, attrs) do
+    return_to = ~p"/world?#{%{tab: "connections"}}"
+
+    ~p"/connections/gmail/oauth/start?#{%{world_id: world.id, connection_id: connection.id, client_id: attrs.config["client_id"], client_secret: attrs.config["client_secret"], return_to: return_to}}"
   end
 
   defp blank_secret_form, do: to_form(%{"bank_key" => "", "value" => ""}, as: :secret)

--- a/lib/lemmings_os_web/live/world_live.html.heex
+++ b/lib/lemmings_os_web/live/world_live.html.heex
@@ -23,6 +23,8 @@
     connection_rows={@world_connection_rows}
     connection_editing_id={@world_connection_editing_id}
     connection_edit_form={@world_connection_edit_form}
+    connection_gmail_oauth={@world_gmail_oauth}
+    connection_scope_params={@world_connection_scope_params}
     artifact_rows={@world_artifact_rows}
   />
 </Layouts.app>

--- a/lib/lemmings_os_web/router.ex
+++ b/lib/lemmings_os_web/router.ex
@@ -47,6 +47,8 @@ defmodule LemmingsOsWeb.Router do
     live "/knowledge", KnowledgeLive, :index
     live "/logs", LogsLive, :index
     live "/settings", SettingsLive, :index
+    get "/connections/gmail/oauth/start", GmailOAuthController, :start
+    get "/connections/gmail/oauth/callback", GmailOAuthController, :callback
   end
 
   # Other scopes may use custom stacks.

--- a/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
+++ b/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
@@ -1,0 +1,92 @@
+# Task 01: Gmail Connection OAuth And Secret Storage
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`dev-backend-elixir-engineer` - Senior backend engineer for Elixir/Phoenix contexts, external integrations, secrets, observability, and tests.
+
+## Agent Invocation
+
+Act as `dev-backend-elixir-engineer`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/coding_styles/elixir.md`, `llms/coding_styles/elixir_tests.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, and this task. Implement only the Gmail Connection type, OAuth onboarding backend boundary, Secret Bank storage, safe events, and tests needed for connection setup.
+
+## Objective
+
+Add the safe connection foundation for Gmail:
+
+- register a `gmail` Connection type;
+- validate Gmail Connection config shape;
+- start Google OAuth with the Gmail compose scope only;
+- validate OAuth callback state/session;
+- exchange the authorization code through a testable HTTP boundary;
+- store the returned refresh token through Secret Bank;
+- create or update the effective scope-local `gmail` Connection with safe metadata.
+
+This task does not implement `email.create_draft` and does not add Gmail send, read, sync, or mailbox functionality.
+
+## Scope Notes
+
+- `connection_ref = "gmail"` maps to Connection `type = "gmail"` for this MVP.
+- The current app has local-admin control-plane behavior and no implemented authenticated user model. Bind OAuth state to the browser session and document this as the ADR-0010 sequencing limitation; do not introduce users/RBAC in this task.
+- OAuth state must bind the selected target scope (`world`, `city`, or `department`) to the browser session. The callback must not trust scope identifiers supplied only by callback params.
+- Use `Req` for Google token calls and any compose-scope-safe metadata calls. Do not add dependencies.
+- Prefer session-bound OAuth state with expiry. Do not add a migration unless implementation discovers a reviewed need.
+- Account email is optional. Do not request additional OAuth scopes only to populate `account_email`. If the compose-only scope does not provide safe account metadata, leave `account_email` blank or use a safe operator-provided label.
+
+## Expected Outputs
+
+- Gmail provider/caller module under the Connections boundary.
+- `gmail` entry in `LemmingsOs.Connections.TypeRegistry`.
+- Config validation that accepts only safe Gmail metadata and Secret Bank refs:
+  - `provider = "gmail"`
+  - compose-only `scopes`
+  - `client_id`, `client_secret`, and `refresh_token` as refs, not raw values
+  - optional safe `account_email`
+- OAuth start and callback backend routes/controllers or equivalent Phoenix boundary.
+- OAuth state generation, expiry, and callback validation.
+- Refresh token persistence through `LemmingsOs.SecretBank.upsert_secret/3`.
+- Connection create/update through `LemmingsOs.Connections` context APIs.
+- Safe `connection.gmail.oauth_started`, `connection.gmail.oauth_succeeded`, and `connection.gmail.oauth_failed` events, or similarly scoped names consistent with existing event vocabulary.
+- Documentation and doctests for any new public backend APIs, including parameters, return values, and examples.
+
+## Testing Requirements
+
+- Add doctests for the Gmail provider public functions and any new public OAuth helper module.
+- Extend Connection and TypeRegistry tests to prove `gmail` is registered, validated, and listed without regressing `mock`.
+- Test Gmail config validation accepts only Secret Bank refs and rejects raw access tokens, refresh tokens, client secrets, authorization headers, and passwords.
+- Test OAuth start generates state, stores only safe session data, and redirects with exactly the Gmail compose scope.
+- Test callback rejects missing, invalid, expired, and mismatched state/session.
+- Test callback rejects scope tampering, such as changing the target scope between OAuth start and callback.
+- Test callback exchanges an authorization code through a fake Google endpoint or injected fake client.
+- Test refresh token storage uses Secret Bank and Connection config stores only the generated ref.
+- Test create/update behavior when a local `gmail` Connection already exists at the selected scope.
+- Test failures return safe UI/backend errors and do not include token values or raw Google response bodies.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os/connections test/lemmings_os/secret_bank_test.exs
+mix test test/lemmings_os_web/controllers
+mix format
+```
+
+When the task is complete and ready for human approval, run `mix precommit` if the task changes are stable enough for a full gate.
+
+## Acceptance Criteria
+
+- `gmail` is a registered Connection type.
+- Normal onboarding creates or updates a scope-local Gmail Connection.
+- Refresh tokens are stored only in Secret Bank.
+- Connection config contains refs and safe metadata only.
+- OAuth state is session-bound, expires, and fails closed.
+- OAuth requests only the Gmail compose scope.
+- No token value appears in logs, events, Connection config, test failures, or rendered errors.
+- Existing `mock` Connection behavior still passes.
+- Human reviewer can approve Task 02 after reviewing test evidence and public API docs/doctests.
+
+## Human Approval Gate
+
+Human reviewer validates the connection/OAuth behavior, no-secret-leak tests, and API documentation before backend draft creation work begins.

--- a/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
+++ b/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
@@ -2,8 +2,45 @@
 
 ## Status
 
-- **Status**: NOT STARTED
+- **Status**: COMPLETED 
 - **Approved**: [ ] Human sign-off
+
+## Implementation Progress (2026-05-11)
+
+### Done
+
+- [x] Added Gmail provider/caller module under Connections:
+  `LemmingsOs.Connections.Providers.GmailCaller`.
+- [x] Registered `gmail` in `LemmingsOs.Connections.TypeRegistry`.
+- [x] Added Gmail config contract validation for:
+  - `provider = "gmail"`
+  - compose-only Gmail scope
+  - secret refs for `client_id`, `client_secret`, and `refresh_token`
+  - optional `account_email`
+- [x] Added OAuth backend boundary and HTTP client:
+  - `LemmingsOs.Connections.GmailOAuth`
+  - `LemmingsOs.Connections.GmailOAuth.Client` (Req-based token exchange)
+- [x] Added OAuth start + callback routes/controller:
+  `LemmingsOsWeb.GmailOAuthController` and router entries.
+- [x] Added session-bound OAuth state with expiry checks and callback validation path.
+- [x] Added Secret Bank + Connection upsert flow in the Gmail OAuth boundary.
+- [x] Wired safe OAuth lifecycle events:
+  `connection.gmail.oauth_started`, `connection.gmail.oauth_succeeded`,
+  `connection.gmail.oauth_failed`.
+- [x] Added initial doctests/tests coverage for:
+  - Gmail type registry presence
+  - Gmail config validation
+  - Connection changeset Gmail validation
+  - OAuth start redirect/scope + callback invalid-state rejection
+
+### Remaining Before Approval
+
+- [x] Add automated happy-path callback test proving:
+  code exchange, refresh token persistence in Secret Bank, and Connection create/update behavior.
+- [x] Add callback rejection matrix coverage for missing/expired/mismatched state-session and explicit scope-tampering cases.
+- [x] Expand validation tests for disallowed raw credential patterns (access token/authorization header/password-like values).
+- [x] Add no-secret-leak assertions for failure paths/events/provider error handling.
+- [x] Run full final gate (`mix precommit`) once the remaining behavior/tests are complete.
 
 ## Assigned Agent
 

--- a/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
+++ b/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- **Status**: COMPLETED 
+- **Status**: COMPLETED
 - **Approved**: [x] Human sign-off
 
 ## Implementation Progress (2026-05-11)

--- a/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
+++ b/llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md
@@ -3,7 +3,7 @@
 ## Status
 
 - **Status**: COMPLETED 
-- **Approved**: [ ] Human sign-off
+- **Approved**: [x] Human sign-off
 
 ## Implementation Progress (2026-05-11)
 

--- a/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
+++ b/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
@@ -1,0 +1,99 @@
+# Task 02: Email Create Draft Backend Tool
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`dev-backend-elixir-engineer` - Senior backend engineer for Elixir/Phoenix tool runtime, external HTTP integrations, artifacts, observability, and tests.
+
+## Agent Invocation
+
+Act as `dev-backend-elixir-engineer`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/coding_styles/elixir.md`, `llms/coding_styles/elixir_tests.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, Task 01, and this task. Implement only the `email.create_draft` backend tool, Gmail adapter/client boundary, attachment handling, observability, and tests.
+
+## Objective
+
+Add the first Gmail outbound runtime slice:
+
+```text
+prepared email content + artifact_ids + connection_ref
+  -> email.create_draft
+  -> Gmail draft descriptor
+```
+
+The tool creates a Gmail draft and never sends email.
+
+## Expected Outputs
+
+- `email.create_draft` entry in `LemmingsOs.Tools.Catalog` with category `email` and risk `medium`.
+- Runtime dispatch in `LemmingsOs.Tools.Runtime` that preserves the existing tool result envelope.
+- Gmail draft adapter/client modules using `Req`, with tests using Bypass or an injected fake client.
+- Input validation for:
+  - `connection_ref == "gmail"`
+  - non-empty `to`
+  - optional `cc` and `bcc`
+  - simple recipient validation
+  - non-empty `subject`
+  - string `body`
+  - `body_format` in `text/plain` or `text/html`
+  - optional `artifact_ids`
+- Scoped Connection resolution using the current LemmingInstance hierarchy and existing Connections runtime boundary.
+- Secret ref resolution only inside the adapter execution boundary.
+- Refresh-token to access-token exchange.
+- MIME payload construction for text/plain, text/html, and attachments.
+- Attachment loading only through `LemmingsOs.Artifacts` trusted APIs by Artifact ID.
+- Safe draft result containing only `status`, `provider`, `connection_ref`, `draft_id`, optional `message_id`, recipients, subject, and `artifact_ids`.
+- Best-effort safe events:
+  - `email.draft_requested`
+  - `email.draft_created`
+  - `email.draft_failed`
+- Public API docs, parameter descriptions, specs, and executable examples/doctests for non-trivial new public functions.
+
+## Backend Safety Rules
+
+- Do not return raw Gmail API responses.
+- Do not log or emit OAuth tokens, refresh tokens, access tokens, client secrets, authorization headers, Secret Bank resolved values, Artifact storage refs, or local paths.
+- Do not accept raw file paths in tool input.
+- Do not expose a send path, `email.send_approved`, mailbox read, sync, watch, or reply processing.
+- Provider errors must be normalized to the safe error taxonomy from `plan.md`.
+- Event persistence is best-effort and must not fail a successful draft creation.
+
+## Testing Requirements
+
+- Catalog test proves `email.create_draft` is listed and supported.
+- Runtime test proves success normalization preserves `tool_name`, `args`, `summary`, `preview`, and `result`.
+- Runtime and adapter tests cover missing/disabled/invalid/inaccessible Gmail Connections.
+- Validation tests cover missing required fields, invalid recipients, unsupported body format, unsupported `connection_ref`, malformed `artifact_ids`, and unsupported raw path fields.
+- Secret resolution tests prove refs resolve only inside adapter execution, not in catalog/runtime/Connection resolution.
+- Gmail HTTP tests cover refresh success/failure and draft creation success/failure with fake endpoints.
+- MIME tests cover no attachments, one attachment, multiple attachments, text/plain, and text/html.
+- Artifact tests cover missing, non-ready, cross-scope, inaccessible, and broken-storage attachments.
+- No-leak tests use sentinel tokens, secret refs, storage refs, local paths, and raw provider bodies and assert they are absent from tool results, events, logs, and persisted tool execution output.
+- Tests assert no send tool or send HTTP path is exposed.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os/tools test/lemmings_os/artifacts test/lemmings_os/connections
+mix test test/lemmings_os/lemming_instances
+mix format
+```
+
+When the task is complete and ready for human approval, run `mix precommit` if the task changes are stable enough for a full gate.
+
+## Acceptance Criteria
+
+- `email.create_draft` can create a Gmail draft through the runtime with the existing normalized envelope.
+- The adapter supports text/plain and text/html bodies.
+- Attachments are loaded by Artifact ID through scope-checked Artifact APIs.
+- All specified safe error codes are returned where applicable.
+- Successful and failed draft events are safe and best-effort.
+- No raw credential, provider response, storage ref, or local path leaks through any tested backend surface.
+- Public backend APIs added in this task include docs, specs, parameter descriptions, and examples/doctests.
+- Human reviewer can approve Task 03 after reviewing backend test evidence.
+
+## Human Approval Gate
+
+Human reviewer validates tool behavior, attachment safety, no-send boundary, no-leak evidence, and API documentation before UI work begins.

--- a/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
+++ b/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-- **Status**: COMPLETED 
+- **Status**: COMPLETED
 - **Approved**: [x] Human sign-off
 
 ## Assigned Agent

--- a/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
+++ b/llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: NOT STARTED
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED 
+- **Approved**: [x] Human sign-off
 
 ## Assigned Agent
 
@@ -50,6 +50,23 @@ The tool creates a Gmail draft and never sends email.
   - `email.draft_created`
   - `email.draft_failed`
 - Public API docs, parameter descriptions, specs, and executable examples/doctests for non-trivial new public functions.
+
+## Implementation Checklist
+
+- [x] `email.create_draft` added to `LemmingsOs.Tools.Catalog` (`category: email`, `risk: medium`).
+- [x] Runtime dispatch wired in `LemmingsOs.Tools.Runtime` with existing normalized envelope.
+- [x] Added `LemmingsOs.Tools.Adapters.Email` and `LemmingsOs.Tools.Adapters.Email.GmailClient` (Req boundary).
+- [x] Input validation for recipients, body format, connection ref, and artifact ID contract.
+- [x] Scoped Connection resolution via `LemmingsOs.Connections.Runtime`.
+- [x] Secret ref resolution kept inside adapter execution (`LemmingsOs.SecretBank.resolve_runtime_secret/3`).
+- [x] Refresh-token exchange and Gmail draft create HTTP flow implemented.
+- [x] MIME construction supports `text/plain`, `text/html`, and multipart attachments.
+- [x] Attachment loading uses `LemmingsOs.Artifacts` APIs by Artifact ID only.
+- [x] Safe draft result contract implemented (no raw provider responses).
+- [x] Best-effort safe events added: `email.draft_requested`, `email.draft_created`, `email.draft_failed`.
+- [x] Public docs/specs/examples added for new public APIs (adapter + Gmail client).
+- [x] Tests added/updated for catalog/runtime, adapter validation/errors, MIME/attachments, provider failures, and no-leak assertions.
+- [x] Validation run complete: targeted tests + `mix precommit` passing.
 
 ## Backend Safety Rules
 

--- a/llms/tasks/0016_gmail_draft_creation/03_gmail_connection_ui_and_documentation.md
+++ b/llms/tasks/0016_gmail_draft_creation/03_gmail_connection_ui_and_documentation.md
@@ -1,0 +1,76 @@
+# Task 03: Gmail Connection UI And Documentation
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`dev-frontend-ui-engineer` - Frontend engineer for Phoenix LiveView UI, forms, accessible states, and responsive operator workflows.
+
+## Agent Invocation
+
+Act as `dev-frontend-ui-engineer`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/coding_styles/elixir.md`, `llms/coding_styles/elixir_tests.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, Tasks 01-02, and this task. Implement only the user-facing Gmail connection onboarding controls, safe UI states, instance timeline adjustments if required, documentation updates, and tests.
+
+## Objective
+
+Expose the Gmail connection flow to operators and ensure draft creation results are reviewable without leaking credentials or storage internals.
+
+## Expected Outputs
+
+- Gmail connect control in the existing Connections surfaces for World, City, and Department scopes.
+- Stable DOM IDs for Gmail connect buttons, status messages, error states, and any callback result UI.
+- Safe success and failure flashes/states for OAuth start/callback outcomes.
+- Existing generic Connection create/edit/test/delete behavior remains intact.
+- Existing instance timeline/tool execution cards render `email.create_draft` summaries, previews, and safe results clearly. Add targeted UI handling only if current generic cards are insufficient.
+- Documentation updates:
+  - `docs/features/tools.md` for `email.create_draft`
+  - `docs/features/connections.md` for Gmail Connection config and onboarding
+  - `docs/features/secret_bank.md` only if needed for Gmail secret refs
+  - Google OAuth setup how-to covering Gmail API enablement, OAuth consent, OAuth Web Client, authorized redirect URI, required env vars, and the in-app `Connections -> Gmail -> Connect` flow
+- Clear documentation that sending, reading, sync, mailbox watch, and approval records are out of scope.
+
+## UI Safety Rules
+
+- Do not render refresh tokens, access tokens, client secrets, authorization headers, Secret Bank resolved values, Artifact storage refs, or local filesystem paths.
+- Do not show raw Google error bodies.
+- Do not add a send button or any UI that implies email can be sent from this PR.
+- Use existing LiveView navigation conventions and HEEx rules.
+- Use imported `<.icon>` where icons are needed.
+- Use stable selectors and accessible labels for tests.
+
+## Testing Requirements
+
+- LiveView tests cover Gmail connect controls on World, City, and Department Connections tabs.
+- Tests verify controls have stable IDs, accessible labels, and expected disabled/error state when OAuth config is unavailable.
+- ConnCase or controller tests cover success/failure callback UI behavior if not already covered in Task 01.
+- LiveView tests verify generic `mock` Connection create/edit/test/delete flows still work.
+- Instance timeline test verifies an `email.create_draft` tool execution renders safe subject, recipient summary, and Artifact IDs without token values, raw provider payloads, storage refs, or local paths.
+- Documentation review checks confirm required docs mention env vars, compose-only scope, manual send in Gmail, and explicit non-goals.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os_web/live/world_live_test.exs
+mix test test/lemmings_os_web/live/cities_live_test.exs
+mix test test/lemmings_os_web/live/departments_live_test.exs
+mix test test/lemmings_os_web/live/instance_live_test.exs
+mix format
+```
+
+When the task is complete and ready for human approval, run `mix precommit` if the task changes are stable enough for a full gate.
+
+## Acceptance Criteria
+
+- Operators can start Gmail connection onboarding from the Connections UI.
+- OAuth success/failure is represented safely and understandably.
+- The UI never exposes token values, raw provider payloads, storage refs, or local paths.
+- Draft creation tool results are reviewable in existing runtime UI.
+- No send action appears anywhere in the UI.
+- Documentation is aligned with the shipped behavior and non-goals.
+- Human reviewer can approve audit work after reviewing UI tests, screenshots or local verification notes, and docs.
+
+## Human Approval Gate
+
+Human reviewer validates the UI workflow, documentation, no-leak behavior, and no-send boundary before audit tasks begin.

--- a/llms/tasks/0016_gmail_draft_creation/03_gmail_connection_ui_and_documentation.md
+++ b/llms/tasks/0016_gmail_draft_creation/03_gmail_connection_ui_and_documentation.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-- **Status**: NOT STARTED
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
 
 ## Assigned Agent
 
@@ -28,7 +28,7 @@ Expose the Gmail connection flow to operators and ensure draft creation results 
   - `docs/features/tools.md` for `email.create_draft`
   - `docs/features/connections.md` for Gmail Connection config and onboarding
   - `docs/features/secret_bank.md` only if needed for Gmail secret refs
-  - Google OAuth setup how-to covering Gmail API enablement, OAuth consent, OAuth Web Client, authorized redirect URI, required env vars, and the in-app `Connections -> Gmail -> Connect` flow
+  - Google OAuth setup how-to covering Gmail API enablement, OAuth consent, OAuth Web Client, authorized redirect URI, required env vars, and the in-app `Connections -> + Create -> Gmail -> Connect Gmail` flow
 - Clear documentation that sending, reading, sync, mailbox watch, and approval records are out of scope.
 
 ## UI Safety Rules

--- a/llms/tasks/0016_gmail_draft_creation/04_gmail_security_observability_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/04_gmail_security_observability_audit.md
@@ -2,8 +2,85 @@
 
 ## Status
 
-- **Status**: NOT STARTED
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
+
+## Audit Result (2026-05-12)
+
+### Scope
+
+Reviewed Gmail OAuth onboarding, Gmail Connection config validation, Secret Bank
+token storage, `email.create_draft`, Gmail HTTP boundaries, Artifact attachment
+loading, timeline-facing result payloads, durable events, and related tests.
+
+Assumption: the current control plane is still local-admin mode with no
+implemented per-user auth/RBAC. OAuth state is therefore browser-session-bound,
+not user-id-bound.
+
+### Threat Model Snapshot
+
+- Actors: local operator/admin, same-browser attacker attempting OAuth CSRF or
+  callback replay, Lemming/tool runtime attempting unsafe draft or attachment
+  input, Google/Gmail provider failure surfaces.
+- Assets: OAuth refresh tokens, temporary access tokens, OAuth client secret,
+  Secret Bank refs, Gmail draft content, Artifact bytes, Artifact storage refs,
+  local filesystem paths, event/timeline payloads.
+- Entrypoints: `/connections/gmail/oauth/start`,
+  `/connections/gmail/oauth/callback`, `email.create_draft`, Artifact download
+  boundary, Gmail token/draft/profile HTTP calls.
+
+### Findings Table
+
+| ID | Severity | Category | Location | Risk | Evidence | Recommendation |
+|---|---|---|---|---|---|---|
+| GMAIL-AUD-001 | Medium | Session / CSRF | `LemmingsOs.Connections.GmailOAuth.complete/4` | Public OAuth completion boundary validated nonce/expiry but did not independently compare the passed scope to the session-bound scope. The controller derived scope from session, so browser flow was protected, but the backend boundary was weaker than the documented contract. | Fixed in this audit by adding `validate_session_scope/2` before code exchange or secret resolution. Added `test/lemmings_os/connections/gmail_oauth_test.exs` coverage proving mismatched scope fails before token exchange. | Fixed. Keep this direct boundary test. |
+| GMAIL-AUD-002 | Medium | Config / Browser Session | `LemmingsOsWeb.Endpoint` session config | Phoenix session cookie is signed but not encrypted, so OAuth session metadata such as selected scope and Secret Bank ref names is readable by the browser. No raw token/client secret values are stored there. | Endpoint comments explicitly state signed-only cookie storage. OAuth state contains refs and safe metadata only. | Accept for current local-admin MVP, or add `:encryption_salt` if ref names are considered sensitive in deployment threat model. |
+| GMAIL-AUD-003 | Medium | Auth / Access Control | Control-plane routes | There is no implemented per-user control-plane auth/RBAC, so any party with browser access to the local admin plane can start Gmail onboarding or create/update scope-local Gmail Connections. | Project plan explicitly documents local-admin mode and ADR-0010 sequencing gap. | Human reviewer must explicitly accept this residual risk before broader deployment. Re-audit when per-user auth lands. |
+| GMAIL-AUD-004 | Low | Logging / Observability | `email.create_draft` validation path | Draft requested/created/failed events are safe for parsed execution paths, but malformed argument validation failures return safe tool errors without an `email.draft_failed` event because no parsed args exist yet. | Event payloads include safe IDs/counts/status/error code; validation happens before event recording. | Accept for MVP or add a minimal invalid-args event using only instance scope, tool name, and error code. |
+| GMAIL-AUD-005 | Low | Supply Chain / Web Config | `mix sobelow` global findings | Sobelow reports global missing CSP and HTTPS/HSTS hardening, plus existing low-confidence file/path findings. These are app-wide findings, not introduced by this Gmail slice. | `mix sobelow` reported `Config.CSP` and `Config.HTTPS` high-confidence findings and low/medium-confidence path/XSS findings in existing storage/download code. Gmail attachment file read is behind `Artifacts.open_artifact_download/2` scope/status checks. | Track as platform hardening. Do not block this Gmail task unless the release target is non-local production. |
+
+### Observability Findings
+
+- OAuth events are present and safe:
+  `connection.gmail.oauth_started`, `connection.gmail.oauth_succeeded`,
+  `connection.gmail.oauth_failed`, plus profile lookup failure.
+- Draft events are present and safe:
+  `email.draft_requested`, `email.draft_created`, `email.draft_failed`.
+- Draft event payloads include hierarchy IDs, tool/provider identifiers,
+  connection ID where available, recipient/attachment counts, Artifact IDs,
+  status, draft ID on success, and safe error code on failure.
+- No reviewed event/result path includes raw refresh tokens, access tokens,
+  OAuth codes, authorization headers, raw Google response bodies, Artifact
+  storage refs, or local paths.
+
+### Remediation Completed
+
+- Added backend scope/session comparison in `GmailOAuth.complete/4`.
+- Added direct ExUnit coverage proving mismatched session scope rejects before
+  OAuth exchange.
+- Follow-up remediation added Phoenix session cookie encryption while preserving
+  signed session behavior.
+- Follow-up remediation added regression coverage that the app exposes Gmail
+  draft creation only, with no registered, routed, or callable Gmail
+  send/read/list/sync/delete tool paths.
+- Follow-up remediation emits a minimal safe `email.draft_failed` event for
+  invalid `email.create_draft` arguments without recording raw args.
+
+### Residual Risks
+
+- No per-user control-plane auth/RBAC is implemented yet; current safety depends
+  on local-admin deployment boundaries.
+- Gmail `gmail.compose` is the minimum Gmail compose scope, but Google grants
+  capabilities beyond this app's exposed draft-only path. Regression tests now
+  assert no send/read/list/sync/delete path is exposed by the catalog, runtime,
+  router, or Gmail client surface.
+- Global CSP/HTTPS hardening remains outside this Gmail task.
+
+### Recommendation
+
+Proceed to human review for Task 04 after accepting the documented local-admin
+and signed-session residual risks. Re-audit before production/non-local
+deployment or after control-plane authentication is implemented.
 
 ## Assigned Agent
 

--- a/llms/tasks/0016_gmail_draft_creation/04_gmail_security_observability_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/04_gmail_security_observability_audit.md
@@ -1,0 +1,59 @@
+# Task 04: Gmail Security And Observability Audit
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`audit-security` - Security reviewer for authentication, authorization, input validation, secrets management, OWASP risks, and PII safety.
+
+## Agent Invocation
+
+Act as `audit-security`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, Tasks 01-03, and the implementation diff. Perform a security and observability audit of the Gmail OAuth onboarding and `email.create_draft` implementation.
+
+## Objective
+
+Verify that the implementation is safe for credentials, OAuth state handling, attachment boundaries, provider errors, and operational visibility.
+
+## Audit Scope
+
+- OAuth state generation, expiry, session binding, and callback validation.
+- CSRF and browser-session assumptions under current local-admin control-plane mode.
+- Gmail compose-only scope and absence of read/send/sync functionality.
+- Secret Bank storage of refresh tokens and runtime-only resolution.
+- Connection config containing refs and safe metadata only.
+- Gmail adapter credential exchange and authorization header handling.
+- Artifact attachment access by ID through scope-checked APIs only.
+- Sanitized tool errors, provider failures, events, logs, raw context pages, and timeline payloads.
+- Best-effort event recording that cannot fail successful draft creation.
+- No token, credential, storage ref, local path, or raw provider body leakage.
+
+## Expected Outputs
+
+- Security findings ordered by severity.
+- Observability findings about event/log completeness and safety.
+- Targeted remediation requirements for confirmed defects.
+- Explicit residual risks, including the current absence of implemented per-user control-plane auth.
+- Recommendation to proceed, block, or re-audit.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os/connections test/lemmings_os/tools test/lemmings_os/artifacts
+mix sobelow # if already available in the project
+```
+
+## Acceptance Criteria
+
+- OAuth callback cannot be replayed or completed with missing, invalid, expired, or mismatched state.
+- No credential material is persisted outside Secret Bank or emitted to unsafe surfaces.
+- No Gmail read/send/sync capability is reachable.
+- Attachment scope enforcement is server-side and tested.
+- Events include useful safe metadata for success and failure without raw payload leakage.
+- Confirmed high and medium security findings are fixed or explicitly waived by the human reviewer.
+
+## Human Approval Gate
+
+Human reviewer validates security and observability findings before the accessibility audit begins.

--- a/llms/tasks/0016_gmail_draft_creation/05_gmail_accessibility_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/05_gmail_accessibility_audit.md
@@ -1,0 +1,57 @@
+# Task 05: Gmail Accessibility Audit
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`audit-accessibility` - Accessibility auditor for Phoenix LiveView apps, keyboard navigation, focus management, ARIA semantics, and WCAG compliance.
+
+## Agent Invocation
+
+Act as `audit-accessibility`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, Task 03, and the implementation diff. Audit the Gmail connection UI and any draft-result UI changes for accessibility.
+
+## Objective
+
+Verify that the Gmail onboarding controls and result states are usable with keyboard, screen readers, and responsive layouts.
+
+## Audit Scope
+
+- Gmail connect controls on World, City, and Department Connections tabs.
+- OAuth success, failure, unavailable-config, loading, and retry states.
+- Focus behavior after opening the connect flow, returning from callback, and displaying validation errors.
+- Accessible names for buttons and links.
+- Flash/error announcements and `aria-live` behavior where appropriate.
+- Color contrast and non-color-only status communication.
+- Existing generic Connection UI regressions.
+- Instance timeline display for `email.create_draft` results, if UI changes were made.
+
+## Expected Outputs
+
+- Accessibility findings ordered by severity.
+- Targeted remediation requirements for confirmed defects.
+- Notes on residual manual-testing gaps.
+- Recommendation to proceed, block, or re-audit.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os_web/live/world_live_test.exs
+mix test test/lemmings_os_web/live/cities_live_test.exs
+mix test test/lemmings_os_web/live/departments_live_test.exs
+mix test test/lemmings_os_web/live/instance_live_test.exs
+```
+
+## Acceptance Criteria
+
+- Gmail connect controls are reachable by keyboard and have clear accessible names.
+- OAuth status and error states are announced or discoverable without relying only on color.
+- Text fits in mobile and desktop layouts without overlap.
+- Existing Connection UI accessibility does not regress.
+- Confirmed high and medium accessibility findings are fixed or explicitly waived by the human reviewer.
+
+## Human Approval Gate
+
+Human reviewer validates accessibility findings before final PR audit begins.

--- a/llms/tasks/0016_gmail_draft_creation/05_gmail_accessibility_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/05_gmail_accessibility_audit.md
@@ -2,8 +2,55 @@
 
 ## Status
 
-- **Status**: NOT STARTED
-- **Approved**: [ ] Human sign-off
+- **Status**: COMPLETED
+- **Approved**: [X] Human sign-off
+
+## Audit Result (2026-05-12)
+
+### Summary
+
+- Audited Gmail connect/create/edit surfaces in World, City, and Department
+  Connections UI plus Gmail draft-result rendering in Instance timeline.
+- Verified keyboard reachability, accessible names, semantic controls, and
+  non-color status text for Gmail onboarding and draft-result states.
+- No BLOCKER or MAJOR accessibility defects were confirmed in the audited
+  Gmail scope.
+
+### Issues
+
+#### BLOCKER
+
+- None found.
+
+#### MAJOR
+
+- None found.
+
+#### MINOR
+
+- `lib/lemmings_os_web/components/connections_components.ex`:
+  Gmail helper panel text and controls are clear and keyboard reachable, but no
+  dedicated live-region exists inside the panel for asynchronous connection
+  feedback. Current UX relies on global flash announcements, which is
+  acceptable for this MVP but can be improved for local context.
+  Remediation requirement: optional follow-up to add a panel-local polite status
+  region for future richer async Gmail states (loading/retry progress).
+
+### Fixes Applied
+
+- No code changes required for this audit.
+
+### Residual Manual-Testing Gaps
+
+- Screen-reader spot checks (NVDA/VoiceOver) for full OAuth browser redirect
+  flow were not executed in this audit run.
+- Mobile viewport/manual keyboard traversal should be re-verified in-browser
+  during human sign-off.
+
+### Recommendation
+
+Proceed to final PR audit. Re-audit is not required unless Gmail connection UI
+states are expanded (e.g., in-panel async loading/retry messaging).
 
 ## Assigned Agent
 

--- a/llms/tasks/0016_gmail_draft_creation/06_gmail_final_pr_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/06_gmail_final_pr_audit.md
@@ -2,8 +2,136 @@
 
 ## Status
 
-- **Status**: NOT STARTED
+- **Status**: COMPLETED
 - **Approved**: [ ] Human sign-off
+
+## Final Audit Result (2026-05-12)
+
+### Summary
+
+- Reviewed the cumulative Gmail onboarding and `email.create_draft` branch diff
+  against `main`, including OAuth, Connection validation, Secret Bank handling,
+  Gmail HTTP boundaries, Artifact attachment loading, UI surfaces, docs, and
+  tests.
+- Confirmed Tasks 01-05 are marked complete and Tasks 01-05 human sign-off is
+  recorded where required.
+- Confirmed the app exposes Gmail draft creation only: no Gmail send, read,
+  sync, watch, delete, or mailbox ingestion path is registered in catalog,
+  runtime, router, or Gmail client code.
+- Applied final cleanup for committed credential placeholders, Gmail env
+  fallback policy, documentation alignment, and task-file whitespace.
+- Applied follow-up runtime hardening so `email.create_draft` accepts common LLM
+  recipient shapes and defaults `body_format` to `text/plain`.
+- No unresolved BLOCKER or MAJOR findings remain in the Gmail PR scope.
+
+### Risk Assessment
+
+**Medium**. The Gmail slice handles credentials through Secret Bank refs,
+session-bound OAuth state, safe result/event payloads, and server-side Artifact
+scope checks. Residual risk remains medium because the current control plane is
+still local-admin mode with no per-user RBAC, and because Google's
+`gmail.compose` scope has provider-side capabilities broader than the app's
+exposed draft-only path.
+
+### BLOCKER
+
+- None remaining.
+
+### MAJOR
+
+- None remaining.
+
+### MINOR
+
+- **Where**: `lib/lemmings_os_web/connections_surface.ex`, Gmail create/edit
+  form behavior.
+  **Why it matters**: Operators can use `Save config` before completing OAuth,
+  which intentionally persists client credential refs without a refresh-token
+  ref. Draft execution then fails safely with a connection authentication error
+  until `Connect Gmail` completes.
+  **Suggested fix**: Accept for this MVP because the UI documents the
+  pre-OAuth state and the runtime fails closed. If this becomes confusing in
+  operator testing, disable generic Save for new Gmail rows or persist pre-OAuth
+  rows as `invalid` until callback completion.
+
+### NITS
+
+- None remaining.
+
+### Resolved Findings
+
+- **Where**: `.envrc`.
+  **Why it mattered**: The branch included Gmail credential-looking placeholder
+  exports in a tracked file, violating public-repository credential hygiene.
+  **Fix applied**: Removed placeholder values and documented that optional
+  Gmail OAuth env vars belong in `.envrc.custom`.
+- **Where**: `config/config.exs`, `docs/features/connections.md`,
+  `docs/features/secret_bank.md`.
+  **Why it mattered**: The documentation described Secret Bank env fallback use
+  for Gmail OAuth refs, but the default Secret Bank allowlist did not include
+  Gmail OAuth env vars.
+  **Fix applied**: Added explicit Gmail OAuth env fallback allowlist entries and
+  aligned docs with the shipped `$GMAIL_*` defaults and accepted aliases.
+- **Where**:
+  `llms/tasks/0016_gmail_draft_creation/01_gmail_connection_oauth_and_secret_storage.md`,
+  `llms/tasks/0016_gmail_draft_creation/02_email_create_draft_backend_tool.md`.
+  **Why it mattered**: `git diff --check` found trailing whitespace in task
+  metadata.
+  **Fix applied**: Removed trailing whitespace.
+- **Where**: `LemmingsOs.ModelRuntime` and `LemmingsOs.Tools.Adapters.Email`.
+  **Why it mattered**: The model-facing tool contract did not describe
+  `email.create_draft` arguments, and the adapter rejected common model output
+  shapes such as `"to": "person@example.com"` or omitted `body_format`.
+  **Fix applied**: Added the email draft argument contract to the model runtime
+  prompt and normalized single/comma-separated recipient strings, blank
+  optional `cc`/`bcc`, blank attachment IDs, and default `body_format`.
+
+### Test Coverage Notes
+
+- Backend coverage includes Gmail provider config validation, OAuth state
+  rejection/success paths, Secret Bank refresh-token persistence, tool catalog
+  registration, runtime normalization, adapter validation, Gmail client fakes,
+  MIME/attachment handling, provider failure normalization, and no-send
+  regression assertions.
+- UI/controller coverage includes World, City, and Department Gmail connection
+  controls, OAuth redirect/callback behavior, generic Connection regression
+  coverage, and Instance timeline safe draft-result rendering.
+- Residual manual gaps: browser-based Google OAuth flow, screen-reader pass
+  through the external redirect, and production reverse-proxy callback URL
+  verification.
+
+### Observability Notes
+
+- OAuth events are safe and present:
+  `connection.gmail.oauth_started`, `connection.gmail.oauth_succeeded`,
+  `connection.gmail.oauth_failed`, and profile lookup failure.
+- Draft events are safe and present:
+  `email.draft_requested`, `email.draft_created`, `email.draft_failed`.
+- Reviewed event/result surfaces avoid raw OAuth codes, refresh tokens, access
+  tokens, authorization headers, raw provider bodies, Artifact storage refs, and
+  local filesystem paths.
+
+### Validation Evidence
+
+```bash
+mix test test/lemmings_os/connections test/lemmings_os/tools test/lemmings_os/artifacts test/lemmings_os/model_runtime_test.exs
+# 55 doctests, 220 tests, 0 failures
+
+mix test test/lemmings_os_web/live/world_live_test.exs test/lemmings_os_web/live/cities_live_test.exs test/lemmings_os_web/live/departments_live_test.exs test/lemmings_os_web/live/instance_live_test.exs test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
+# 102 tests, 0 failures
+
+mix format
+git diff main --check
+# no output
+
+mix precommit
+# passed successfully; Credo found no issues; Dialyzer total errors: 0
+```
+
+### Merge Recommendation
+
+**APPROVE after the human reviewer accepts the documented local-admin/RBAC
+residual risk.**
 
 ## Assigned Agent
 

--- a/llms/tasks/0016_gmail_draft_creation/06_gmail_final_pr_audit.md
+++ b/llms/tasks/0016_gmail_draft_creation/06_gmail_final_pr_audit.md
@@ -1,0 +1,62 @@
+# Task 06: Gmail Final PR Audit
+
+## Status
+
+- **Status**: NOT STARTED
+- **Approved**: [ ] Human sign-off
+
+## Assigned Agent
+
+`audit-pr-elixir` - Senior PR reviewer for Elixir/Phoenix correctness, design quality, security, performance, logging, and test coverage.
+
+## Agent Invocation
+
+Act as `audit-pr-elixir`. Read `llms/constitution.md`, `llms/project_context.md`, `llms/coding_styles/elixir.md`, `llms/coding_styles/elixir_tests.md`, `llms/tasks/0016_gmail_draft_creation/plan.md`, Tasks 01-05, and the implementation diff. Perform the final PR review and resolve confirmed high-priority findings.
+
+## Objective
+
+Verify merge readiness for Gmail connection onboarding and `email.create_draft` across correctness, security, observability, accessibility, documentation, Elixir style, test style, and operational readiness.
+
+## Review Scope
+
+- Task 01 connection/OAuth acceptance criteria are complete.
+- Task 02 backend tool acceptance criteria are complete.
+- Task 03 UI/docs acceptance criteria are complete.
+- Security and observability audit findings are fixed or explicitly documented.
+- Accessibility audit findings are fixed or explicitly documented.
+- Public API functions added or materially changed include `@doc`, parameter descriptions, `@spec`, and examples/doctests where non-trivial.
+- Tests are outcome-based and use factories, stable selectors, Bypass/fakes for HTTP, and no external network.
+- No source code hardcodes secrets or generated credential values.
+- No code uses `String.to_atom/1` on user input or map access syntax on structs.
+- No raw tokens, authorization headers, provider bodies, storage refs, or local paths leak in results, events, logs, raw context pages, timeline entries, docs, or tests.
+- No email send/read/sync path is present.
+
+## Expected Outputs
+
+- Final findings report ordered by severity.
+- Targeted corrections for confirmed defects, if any.
+- Explicit residual risks and testing gaps.
+- Final validation evidence.
+- Clear merge recommendation for the human reviewer.
+
+## Suggested Checks
+
+```bash
+mix test test/lemmings_os/connections test/lemmings_os/tools test/lemmings_os/artifacts
+mix test test/lemmings_os_web/live/world_live_test.exs
+mix test test/lemmings_os_web/live/cities_live_test.exs
+mix test test/lemmings_os_web/live/departments_live_test.exs
+mix test test/lemmings_os_web/live/instance_live_test.exs
+mix precommit
+```
+
+## Acceptance Criteria
+
+- All implementation tasks are complete and approved.
+- Security, observability, accessibility, Elixir style, and test style findings are closed or explicitly waived.
+- `mix precommit` passes.
+- Final PR review recommends merge or clearly lists blockers.
+
+## Human Approval Gate
+
+Human reviewer performs final PR sign-off. Implementation sequence is complete after this approval.

--- a/llms/tasks/0016_gmail_draft_creation/plan.md
+++ b/llms/tasks/0016_gmail_draft_creation/plan.md
@@ -1,0 +1,666 @@
+# Gmail Connection Onboarding And Draft Creation Tool - Implementation Plan
+
+## Goal
+
+Implement Gmail connection onboarding plus the first Gmail outbound slice for
+the demo workflow:
+
+```text
+Connections -> Gmail -> Connect
+  -> Google OAuth consent
+  -> OAuth callback
+  -> store refresh token through Secret Bank
+  -> create or update Gmail Connection
+
+prepared email content + artifact_ids + Gmail connection_ref
+  -> email.create_draft
+  -> reviewable Gmail draft with attachments
+```
+
+This PR lets an admin/operator connect a Gmail account, then lets a Lemming
+create a Gmail draft that a human reviews and sends manually in Gmail.
+
+This issue must not implement sending email, reading Gmail, or mailbox sync.
+
+## Current Architecture Alignment
+
+The app already has the foundations this slice should reuse:
+
+| Foundation | Existing pattern | Gmail draft alignment |
+|---|---|---|
+| Tool catalog | Fixed first-party catalog in `LemmingsOs.Tools.Catalog` | Add `email.create_draft` as a fixed tool |
+| Tool runtime | `LemmingsOs.Tools.Runtime` normalizes adapter output | Keep existing `summary`, `preview`, `result` envelope |
+| Connections | Hierarchical, nearest-wins resolution by `type` | Add Gmail onboarding that creates/updates a `gmail` Connection |
+| Secret Bank | Runtime-only secret resolution through `$KEY` refs | Store OAuth refresh token through Secret Bank and resolve refs only inside adapters |
+| Artifacts | Managed storage and scoped download boundary | Attach existing Artifacts by ID, not paths |
+| Timeline | Tool executions render summaries/results | Use safe summary/result data; no special timeline table |
+| Events | Generic durable `Events.record_event/4` | Attempt best-effort safe onboarding and draft events |
+
+The issue text recommends `type=email` and `provider=gmail`, but the current
+Connection model has only `type` and no `provider` column or slug/ref field.
+For this MVP, use:
+
+```text
+type: gmail
+provider: gmail
+```
+
+where `provider` is safe metadata inside the Connection config and tool result.
+The tool input `connection_ref` maps to the current Connection `type`, so the
+supported value for this slice is `"gmail"`.
+
+For this MVP, `connection_ref` maps to the current Connection type because the
+current Connection model has no separate slug/ref. This means the effective
+Gmail Connection is selected by hierarchical resolution for type `gmail`, and
+there is only one effective Gmail account per scope.
+
+This is an MVP compatibility choice with the current Connection schema. It does
+not introduce the final multi-provider email model. A future migration may add
+`type=email`, `provider=gmail`, or a dedicated connection slug/ref if multiple
+Gmail accounts per scope become necessary.
+
+## Gmail OAuth Onboarding
+
+This PR includes a basic control-plane flow for connecting a Gmail account.
+
+Admin/operator flow:
+
+```text
+Connections -> Gmail -> Connect
+  -> Google OAuth consent
+  -> OAuth callback
+  -> store refresh token through Secret Bank
+  -> create or update Gmail Connection
+```
+
+The connected Gmail account is then available to `email.create_draft` through
+`connection_ref`.
+
+This onboarding flow is intentionally narrow:
+
+- Gmail only.
+- Draft creation scope only.
+- No Gmail read scopes.
+- No mailbox sync.
+- No send flow.
+- No generic OAuth provider framework.
+- No multi-account management beyond what the existing Connection model can represent.
+
+OAuth client id and client secret may remain environment/admin configured.
+The OAuth callback stores the generated refresh token through Secret Bank and
+stores only the resulting Secret Bank ref in Connection config.
+
+## External Setup Dependency
+
+This issue requires a Google Cloud project configured with:
+
+- Gmail API enabled
+- OAuth consent screen
+- OAuth Web Client credentials
+- Authorized redirect URI pointing to the LemmingsOS OAuth callback
+
+Each deployment must provide application-level OAuth config:
+
+```text
+GOOGLE_OAUTH_CLIENT_ID
+GOOGLE_OAUTH_CLIENT_SECRET
+GOOGLE_OAUTH_REDIRECT_URI
+```
+
+This PR does not automate Google Cloud project setup. Each self-hosted
+deployment must provide a Google OAuth client configuration once. After that,
+LemmingsOS users/admins can connect Gmail accounts through the control-plane
+Connect Gmail flow.
+
+## OAuth Security Requirements
+
+The Gmail OAuth onboarding flow must:
+
+- generate and validate OAuth `state`
+- bind the OAuth flow to the authenticated control-plane user/session
+- prevent CSRF on the callback
+- reject callbacks with missing, invalid, expired, or mismatched state
+- request only the Gmail compose scope
+- store refresh tokens only through Secret Bank
+- never expose refresh tokens or access tokens after callback handling
+- store only safe metadata in Connection config
+- show a safe success/failure result in the UI
+
+## New Tool
+
+Add a first-party runtime tool:
+
+```text
+email.create_draft
+```
+
+Catalog metadata:
+
+| Field | Value |
+|---|---|
+| `id` | `email.create_draft` |
+| `name` | `Create Gmail Draft` |
+| `category` | `email` |
+| `risk` | `medium` |
+| `description` | Create a Gmail draft from prepared email content and optional Artifact attachments. |
+
+### Input
+
+```json
+{
+  "connection_ref": "gmail",
+  "to": ["customer@example.com"],
+  "cc": [],
+  "bcc": [],
+  "subject": "Quotation for requested service",
+  "body": "Prepared email body",
+  "body_format": "text/plain",
+  "artifact_ids": ["artifact-id-1"]
+}
+```
+
+| Field | Required? | Rules |
+|---|---:|---|
+| `connection_ref` | Yes | Must be `"gmail"` for this MVP |
+| `to` | Yes | Non-empty list of simple valid email recipients |
+| `cc` | No | List of simple valid email recipients; default `[]` |
+| `bcc` | No | List of simple valid email recipients; default `[]` |
+| `subject` | Yes | Non-empty string |
+| `body` | Yes | String email body prepared by the Lemming |
+| `body_format` | Yes | `text/plain` or `text/html` |
+| `artifact_ids` | No | List of Artifact IDs; default `[]` |
+
+Markdown-to-HTML conversion is out of scope. If a Lemming wants HTML email, it
+must provide HTML body content and `body_format: "text/html"`.
+
+### Success Result
+
+Adapter result before runtime normalization:
+
+```elixir
+{:ok,
+ %{
+   summary: "Created Gmail draft for customer@example.com with 1 attachment",
+   preview: "Subject: Quotation for requested service",
+   result: %{
+     "status" => "draft_created",
+     "provider" => "gmail",
+     "connection_ref" => "gmail",
+     "draft_id" => "gmail-draft-id",
+     "message_id" => "gmail-message-id-if-available",
+     "to" => ["customer@example.com"],
+     "cc" => [],
+     "bcc" => [],
+     "subject" => "Quotation for requested service",
+     "artifact_ids" => ["artifact-id-1"]
+   }
+ }}
+```
+
+Runtime result must preserve the existing runtime envelope:
+
+```elixir
+{:ok,
+ %{
+   tool_name: "email.create_draft",
+   args: args,
+   summary: "Created Gmail draft for customer@example.com with 1 attachment",
+   preview: "Subject: Quotation for requested service",
+   result: %{...}
+ }}
+```
+
+Do not return raw Gmail API responses.
+
+## Gmail Connection
+
+Add a registered Connection type:
+
+```text
+gmail
+```
+
+For this PR, the primary supported path is the control-plane Gmail OAuth
+onboarding flow:
+
+```text
+Connections -> Gmail -> Connect
+  -> Google OAuth consent
+  -> OAuth callback
+  -> Secret Bank refresh token storage
+  -> Gmail Connection created or updated
+```
+
+Manual/admin-created Gmail Connections may exist for tests or local
+development, but they are not the normal product flow. If manually configured,
+the config may contain secret refs like this:
+
+```json
+{
+  "provider": "gmail",
+  "account_email": "sales@example.com",
+  "scopes": ["https://www.googleapis.com/auth/gmail.compose"],
+  "client_id": "$GMAIL_CLIENT_ID",
+  "client_secret": "$GMAIL_CLIENT_SECRET",
+  "refresh_token": "$GMAIL_REFRESH_TOKEN"
+}
+```
+
+After onboarding, the preferred config shape is:
+
+```json
+{
+  "provider": "gmail",
+  "account_email": "sales@example.com",
+  "scopes": ["https://www.googleapis.com/auth/gmail.compose"],
+  "client_id": "$GMAIL_CLIENT_ID",
+  "client_secret": "$GMAIL_CLIENT_SECRET",
+  "refresh_token": "$GMAIL_REFRESH_TOKEN_GENERATED_FOR_THIS_CONNECTION"
+}
+```
+
+Meaning:
+
+- `client_id` and `client_secret` can remain environment/admin configured.
+- `refresh_token` is generated by the OAuth callback and stored as a Secret Bank entry.
+- Connection config stores the secret ref, not the token value.
+
+Rules:
+
+- `provider` must be `"gmail"`.
+- `account_email` is safe display metadata.
+- `scopes` must include only the minimum draft-composition scope for this issue.
+- Credential fields must be Secret Bank refs.
+- Raw OAuth tokens, refresh tokens, access tokens, client secrets, or passwords are invalid config.
+- Runtime Connection resolution returns a safe descriptor only.
+- Secret refs are resolved only by the Gmail adapter during tool execution.
+
+Minimum Gmail scope:
+
+```text
+https://www.googleapis.com/auth/gmail.compose
+```
+
+Do not request Gmail read scopes. Do not implement or expose a send path even if
+the scope technically permits later send operations.
+
+## Gmail Adapter
+
+Add a narrow Gmail adapter for `email.create_draft`.
+
+Responsibilities:
+
+- Validate tool input.
+- Resolve `connection_ref` through the existing Connection runtime boundary.
+- Resolve Secret Bank refs only inside the adapter execution boundary.
+- Exchange the configured refresh token for an access token.
+- Build a MIME email payload for `text/plain` or `text/html`.
+- Attach existing Artifacts loaded through the Artifact boundary.
+- Call Gmail draft creation.
+- Return only a safe draft descriptor.
+- Sanitize all provider and credential failures.
+
+Use existing `Req` for HTTP calls. Do not add a Google client dependency unless
+explicitly approved in a later implementation decision.
+
+Keep the adapter provider-specific. Do not introduce a generic email provider
+framework in this issue.
+
+## Artifact Attachments
+
+The tool accepts Artifact identifiers only:
+
+```json
+{"artifact_ids": ["artifact-id-1"]}
+```
+
+Rules:
+
+- Raw local file paths are never accepted.
+- Attachments are opened through `LemmingsOs.Artifacts` trusted APIs.
+- Each Artifact must exist, be ready, and be accessible from the invoking
+  `LemmingInstance` scope.
+- Attachment MIME parts use the Artifact filename and content type.
+- Filenames are sanitized before MIME use.
+- Artifact storage refs and local filesystem paths are never included in tool
+  inputs, results, logs, events, timeline entries, or raw context pages.
+- Attachment errors return safe categories such as `artifact_not_found`,
+  `artifact_not_allowed`, or `gmail_draft_create_failed`.
+
+The expected demo attachment is a generated quotation, contract, or report PDF,
+but the implementation should not be hardcoded to PDF if the Artifact metadata
+already has a safe content type.
+
+## Error Handling
+
+Use the existing tool error envelope:
+
+```elixir
+{:error, %{code: binary(), message: binary(), details: map()}}
+```
+
+Safe error categories:
+
+| Code | Meaning |
+|---|---|
+| `tool.email.connection_not_found` | No visible Gmail Connection |
+| `tool.email.connection_not_allowed` | Connection exists but is not usable in scope |
+| `tool.email.connection_auth_failed` | Secret resolution or OAuth refresh failed |
+| `tool.email.artifact_not_found` | Attachment Artifact is missing or not ready |
+| `tool.email.artifact_not_allowed` | Attachment is outside the invoking scope |
+| `tool.email.invalid_recipient` | Recipient validation failed |
+| `tool.email.invalid_body_format` | Unsupported `body_format` |
+| `tool.email.draft_create_failed` | Gmail draft creation failed safely |
+| `tool.validation.invalid_args` | Missing or malformed arguments |
+
+Provider errors must be sanitized before returning to the Lemming or showing in
+the UI. Never expose raw Google responses, authorization headers, tokens,
+credential refs resolved values, storage refs, or local paths.
+
+## Observability
+
+Draft creation should follow existing tool execution and event patterns.
+
+Attempt to record safe events through the existing `Events.record_event/4`
+pattern. Event recording is best-effort and must not fail Gmail draft creation
+if event persistence fails.
+
+```text
+email.draft_requested
+email.draft_created
+email.draft_failed
+```
+
+Safe metadata may include:
+
+- `world_id`
+- `city_id`
+- `department_id`
+- `lemming_id`
+- `lemming_instance_id`
+- `tool_name`
+- `provider`
+- `connection_ref`
+- `connection_id`
+- `recipient_count`
+- `attachment_count`
+- `artifact_ids`
+- `draft_id`
+- `status`
+
+Events must not include:
+
+- OAuth tokens
+- refresh tokens
+- access tokens
+- client secrets
+- authorization headers
+- raw Gmail API responses
+- local file paths
+- Artifact storage refs
+
+The existing instance timeline should show a readable tool result using the
+tool execution summary/preview/result. It should show subject, recipient
+summary, and Artifact IDs. It should not expose provider auth data or storage
+internals.
+
+## Non-goals
+
+Do not implement:
+
+- SMTP
+- email sending
+- `email.send_approved`
+- approval records or approval workflow
+- inbound Gmail reading
+- Gmail mailbox sync
+- Gmail watch/push notifications
+- Gmail thread ingestion
+- automatic reply processing
+- generic multi-provider email abstraction
+- email template management
+- Markdown-to-HTML email rendering
+- new outbound email domain model
+- persisted `outbound_email_drafts` table
+- billing-grade or compliance-grade audit storage
+
+## Acceptance Criteria
+
+### Gmail OAuth onboarding
+
+- A control-plane user can start Gmail connection from the Connections UI.
+- The app redirects to Google OAuth consent with the Gmail compose scope.
+- The OAuth callback validates state/session before continuing.
+- The callback exchanges the authorization code for tokens.
+- The refresh token is stored through Secret Bank / Secret Provider.
+- The Connection is created or updated with safe Gmail metadata.
+- The Connection stores only secret refs, never token values.
+- OAuth failures are shown as safe UI errors.
+- No token value appears in logs, events, tool results, raw context pages, or artifacts.
+
+### Connection and secrets
+
+- A Gmail account can be represented using the existing Connection model with
+  `type=gmail` and safe provider metadata.
+- Manual Secret Bank/Connection setup is not required for the normal product flow.
+- Gmail credentials are referenced through Secret Bank refs.
+- No raw Gmail credential material is accepted in Connection config or tool input.
+- No Gmail credential material appears in tool results, events, logs, raw
+  context pages, artifacts, ETS, DETS, or checkpoints.
+
+### Tool behavior
+
+- `email.create_draft` is available in the fixed runtime catalog.
+- The tool accepts `connection_ref`, recipients, subject, body, body format, and
+  optional `artifact_ids`.
+- The tool creates a Gmail draft and does not send email.
+- The implementation contains no exposed send path.
+- The tool supports `text/plain` and `text/html`.
+- The tool performs simple recipient validation.
+- The tool rejects unsupported body formats.
+- Runtime output uses the existing tool result envelope.
+
+### Attachments
+
+- The tool can attach one or more existing Artifacts.
+- The tool uses Artifact identifiers, not raw local paths.
+- The tool verifies Artifact existence and scope access.
+- The tool uses safe filenames and content types for MIME attachments.
+- Attachment failures return safe errors.
+
+### Gmail adapter
+
+- Gmail API calls are isolated behind a small adapter/wrapper.
+- The adapter resolves credentials only inside the execution boundary.
+- The adapter builds the MIME draft payload.
+- The adapter sanitizes Gmail/provider failures.
+- Tests can use a fake Gmail client without calling Gmail.
+
+### Observability
+
+- Draft creation emits best-effort safe events.
+- Successful draft creation is visible in the Lemming timeline.
+- Failure events are safe and actionable.
+- Events do not leak credentials, raw provider auth data, or local storage paths.
+
+### Demo readiness
+
+- A Lemming can create a Gmail draft with a prepared email body.
+- A Lemming can attach an existing quotation, contract, or report Artifact.
+- The user can review the created draft in Gmail.
+- No send action is available from this issue.
+
+## Test Plan
+
+Backend tests:
+
+- Catalog includes `email.create_draft`.
+- Runtime dispatch normalizes success and failure.
+- Gmail Connection type validates required safe config.
+- Gmail Connection type rejects raw credential values.
+- Missing, disabled, invalid, or inaccessible Gmail Connections fail safely.
+- Tool validation covers required fields, recipient validation, body format, and
+  invalid `artifact_ids`.
+- Secret refs resolve only inside adapter execution.
+- Fake Gmail client covers OAuth refresh success/failure.
+- Fake Gmail client covers draft creation success/failure.
+- MIME construction works with no attachments.
+- MIME construction works with one or more Artifact attachments.
+- Missing, non-ready, inaccessible, or broken Artifact attachments fail safely.
+- Provider errors are sanitized.
+- Tool result and events do not leak credentials, raw provider responses,
+  storage refs, or local paths.
+
+OAuth onboarding tests:
+
+- start connect flow generates OAuth state
+- callback rejects missing state
+- callback rejects invalid state
+- callback rejects expired state
+- callback rejects mismatched state/session
+- callback exchanges code through a fake Google OAuth client
+- callback stores refresh token through a fake Secret Provider or Secret Bank boundary
+- callback creates or updates Gmail Connection with safe metadata
+- callback does not expose tokens in UI, events, logs, or safe results
+- OAuth provider failure returns safe errors
+
+Documentation checks:
+
+- Update `docs/features/tools.md` for `email.create_draft`.
+- Update `docs/features/connections.md` for Gmail Connection config.
+- Update `docs/features/secret_bank.md` only as needed for Gmail secret refs.
+- Document Gmail OAuth onboarding, OAuth scope, and explicit no-send/no-read/non-sync boundaries.
+- Add a how-to for configuring and linking Google OAuth:
+  Google Cloud project setup, Gmail API enablement, OAuth consent screen,
+  OAuth Web Client creation, authorized redirect URI, deployment env vars
+  (`GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`,
+  `GOOGLE_OAUTH_REDIRECT_URI`), and the in-app `Connections -> Gmail -> Connect`
+  flow.
+
+Final validation:
+
+```bash
+mix test test/lemmings_os/connections test/lemmings_os/tools
+mix precommit
+```
+
+## Involved Roles
+
+Recommended implementation/review roles from `llms/agents/agent_catalog.md`:
+
+- `po-analyst` for specification validation.
+- `dev-backend-elixir-engineer` for tool, adapter, Connection, Secret Bank, and
+  Artifact integration.
+- `qa-test-scenarios` for acceptance and edge-case coverage.
+- `qa-elixir-test-author` for ExUnit coverage.
+- `docs-feature-documentation-author` for feature docs.
+- `audit-security` for credential, provider, and attachment safety review.
+- `audit-pr-elixir` for final Elixir/Phoenix code review.
+
+## Generated Implementation Task Plan
+
+### Metadata
+
+- **Source plan**: `llms/tasks/0016_gmail_draft_creation/plan.md`
+- **Generated**: 2026-05-09
+- **Status**: PLANNING
+- **Operating role**: `tl-architect`
+
+This generated sequence converts the Gmail connection onboarding and draft
+creation plan into grouped, sequential, human-approved implementation tasks.
+The source plan is ready for task decomposition because it defines current
+architecture alignment, OAuth security requirements, tool input/output
+contracts, error taxonomy, attachment rules, observability expectations,
+non-goals, acceptance criteria, and a test plan.
+
+### Codebase Findings
+
+- Connections already use `LemmingsOs.Connections`, `Connection`,
+  `TypeRegistry`, and `Connections.Runtime` with nearest-wins resolution by
+  `type`.
+- The only registered Connection type today is `mock`, implemented by
+  `LemmingsOs.Connections.Providers.MockCaller`.
+- Connection config can store Secret Bank refs, and provider callers resolve
+  refs just in time through `LemmingsOs.SecretBank`.
+- `LemmingsOs.Tools.Catalog` and `LemmingsOs.Tools.Runtime` are fixed
+  first-party boundaries. Runtime normalizes adapter outputs into the existing
+  `summary`, `preview`, and `result` envelope.
+- Artifact access already has trusted scoped APIs and safe public descriptors.
+  The Gmail adapter should open attachment bytes only through `LemmingsOs.Artifacts`.
+- The control plane currently runs in local-admin mode without implemented
+  per-user authentication. OAuth state must still be session-bound and CSRF
+  protected, and the sequencing gap must be documented.
+- Connections UI is shared through `LemmingsOsWeb.ConnectionsSurface` and is
+  embedded on World, City, and Department LiveViews.
+
+### Technical Summary
+
+- **New files anticipated**: Gmail connection provider, Gmail OAuth/controller
+  boundary, Gmail tool adapter/client helpers, tests, and documentation updates.
+- **Modified files anticipated**: Connection type registry, Connections context
+  or helper APIs as needed, Secret Bank env fallback config, Tool catalog/runtime,
+  router, Connections UI surfaces, instance timeline rendering only if existing
+  cards are insufficient, factories, and docs.
+- **Database migrations**: Not expected for the MVP. OAuth state should prefer
+  session-bound state unless implementation discovers a reviewed need for a
+  server-side state store.
+- **External dependencies**: None. Use existing `Req`; do not add a Google
+  client dependency.
+
+### Assumptions For Human Review
+
+- `connection_ref = "gmail"` maps to the current Connection `type = "gmail"`.
+- Only one effective Gmail account per scope is supported through existing
+  nearest-wins Connection resolution.
+- Authenticated-user binding in the plan maps to the current browser/session
+  boundary until ADR-0010 is implemented. This feature must not invent a full
+  user/RBAC subsystem.
+- Gmail OAuth requests only the compose scope. If implementation discovers that
+  displaying `account_email` requires an additional Google scope, it must stop
+  for human approval before broadening scopes.
+- OAuth client id and client secret are deployment configuration. Refresh
+  tokens generated by callback handling are stored through Secret Bank.
+- Public backend APIs introduced by these tasks must include `@doc`, clear
+  parameter descriptions, `@spec`, and executable examples/doctests where
+  behavior is non-trivial.
+
+### Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| OAuth state/session handling is implemented too loosely | Medium | High | Make OAuth state validation the first task and require callback rejection tests for missing, invalid, expired, and mismatched state. |
+| Credential material leaks into Connection config, logs, events, tool results, or UI | Medium | High | Secret refs only in config; raw token sentinel tests; dedicated security and final PR audits. |
+| Gmail adapter accidentally exposes send/read behavior | Low | High | Restrict catalog to `email.create_draft`; tests assert no send tool/path and compose-only scope. |
+| Attachment access bypasses Artifact scope checks | Medium | High | Adapter must use Artifact APIs by ID only; tests cover missing, non-ready, cross-scope, and broken storage cases. |
+| UI changes regress existing generic Connection forms | Medium | Medium | Keep shared `ConnectionsSurface` behavior intact and include LiveView tests for existing create/edit/test/delete flow plus Gmail connect controls. |
+
+### Roles
+
+#### Human Reviewer
+
+- Approves each task before the next begins.
+- Executes all git operations.
+- Can reject a task and request revisions before the sequence continues.
+- Performs final sign-off after security, observability, accessibility, coding
+  style, and PR-readiness audits.
+
+#### Executing Agents
+
+Each task names exactly one assigned agent from
+`llms/agents/agent_catalog.md`.
+
+### Task Sequence
+
+1. `01_gmail_connection_oauth_and_secret_storage.md` - `dev-backend-elixir-engineer`
+2. `02_email_create_draft_backend_tool.md` - `dev-backend-elixir-engineer`
+3. `03_gmail_connection_ui_and_documentation.md` - `dev-frontend-ui-engineer`
+4. `04_gmail_security_observability_audit.md` - `audit-security`
+5. `05_gmail_accessibility_audit.md` - `audit-accessibility`
+6. `06_gmail_final_pr_audit.md` - `audit-pr-elixir`
+
+### Human Approval Gates
+
+After each task, the human reviewer must validate the task file acceptance
+criteria and approve before the next task starts. Each implementation task must
+run the narrowest relevant checks first, then `mix precommit` when the task is
+complete and the branch is ready for the next approval gate.

--- a/priv/gettext/en/LC_MESSAGES/errors.po
+++ b/priv/gettext/en/LC_MESSAGES/errors.po
@@ -136,10 +136,10 @@ msgstr "Attempting to reconnect"
 msgid ".error_something_went_wrong"
 msgstr "Something went wrong!"
 
-#: lib/lemmings_os_web/live/cities_live.ex:179
-#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/departments_live.ex:163
 #: lib/lemmings_os_web/live/lemmings_live.ex:161
-#: lib/lemmings_os_web/live/world_live.ex:78
+#: lib/lemmings_os_web/live/world_live.ex:80
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr "Invalid secret key format. Use UPPERCASE letters, numbers, and _."
@@ -495,24 +495,24 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:172
-#: lib/lemmings_os_web/live/cities_live.ex:211
-#: lib/lemmings_os_web/live/cities_live.ex:276
-#: lib/lemmings_os_web/live/cities_live.ex:362
-#: lib/lemmings_os_web/live/cities_live.ex:389
-#: lib/lemmings_os_web/live/cities_live.ex:417
-#: lib/lemmings_os_web/live/cities_live.ex:435
+#: lib/lemmings_os_web/live/cities_live.ex:174
+#: lib/lemmings_os_web/live/cities_live.ex:213
+#: lib/lemmings_os_web/live/cities_live.ex:290
+#: lib/lemmings_os_web/live/cities_live.ex:387
+#: lib/lemmings_os_web/live/cities_live.ex:414
+#: lib/lemmings_os_web/live/cities_live.ex:442
+#: lib/lemmings_os_web/live/cities_live.ex:460
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr "City is unavailable"
 
-#: lib/lemmings_os_web/live/departments_live.ex:154
-#: lib/lemmings_os_web/live/departments_live.ex:196
-#: lib/lemmings_os_web/live/departments_live.ex:263
-#: lib/lemmings_os_web/live/departments_live.ex:357
-#: lib/lemmings_os_web/live/departments_live.ex:384
-#: lib/lemmings_os_web/live/departments_live.ex:412
-#: lib/lemmings_os_web/live/departments_live.ex:430
+#: lib/lemmings_os_web/live/departments_live.ex:156
+#: lib/lemmings_os_web/live/departments_live.ex:198
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:409
+#: lib/lemmings_os_web/live/departments_live.ex:437
+#: lib/lemmings_os_web/live/departments_live.ex:455
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr "Department is unavailable"
@@ -523,48 +523,48 @@ msgstr "Department is unavailable"
 msgid ".error_lemming_unavailable"
 msgstr "Lemming is unavailable"
 
-#: lib/lemmings_os_web/live/cities_live.ex:225
-#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/cities_live.ex:227
+#: lib/lemmings_os_web/live/departments_live.ex:212
 #: lib/lemmings_os_web/live/lemmings_live.ex:207
-#: lib/lemmings_os_web/live/world_live.ex:122
+#: lib/lemmings_os_web/live/world_live.ex:124
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr "Failed to delete secret"
 
-#: lib/lemmings_os_web/live/cities_live.ex:218
-#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/cities_live.ex:220
+#: lib/lemmings_os_web/live/departments_live.ex:205
 #: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:115
+#: lib/lemmings_os_web/live/world_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr "Only local values can be deleted at this scope"
 
-#: lib/lemmings_os_web/live/cities_live.ex:222
-#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/cities_live.ex:224
+#: lib/lemmings_os_web/live/departments_live.ex:209
 #: lib/lemmings_os_web/live/lemmings_live.ex:204
-#: lib/lemmings_os_web/live/world_live.ex:119
+#: lib/lemmings_os_web/live/world_live.ex:121
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr "Secret key not found"
 
-#: lib/lemmings_os_web/live/cities_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/cities_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:181
 #: lib/lemmings_os_web/live/lemmings_live.ex:176
-#: lib/lemmings_os_web/live/world_live.ex:93
+#: lib/lemmings_os_web/live/world_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr "Failed to save secret"
 
-#: lib/lemmings_os_web/live/cities_live.ex:187
-#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:189
+#: lib/lemmings_os_web/live/departments_live.ex:174
 #: lib/lemmings_os_web/live/lemmings_live.ex:169
-#: lib/lemmings_os_web/live/world_live.ex:86
+#: lib/lemmings_os_web/live/world_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr "Secret value is required"
 
-#: lib/lemmings_os_web/live/world_live.ex:71
-#: lib/lemmings_os_web/live/world_live.ex:108
+#: lib/lemmings_os_web/live/world_live.ex:73
+#: lib/lemmings_os_web/live/world_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr "World is unavailable"

--- a/priv/gettext/en/LC_MESSAGES/layout.po
+++ b/priv/gettext/en/LC_MESSAGES/layout.po
@@ -78,7 +78,7 @@ msgid ".nav_departments"
 msgstr "Departments"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -106,7 +106,7 @@ msgid ".nav_settings"
 msgstr "Settings"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:1036
+#: lib/lemmings_os_web/components/world_components.ex:1046
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "New Lemming"
@@ -850,231 +850,235 @@ msgstr "medium"
 msgid ".tools_risk_unknown"
 msgstr "unknown"
 
-#: lib/lemmings_os_web/components/connections_components.ex:116
-#: lib/lemmings_os_web/components/connections_components.ex:321
+#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:353
+#: lib/lemmings_os_web/components/connections_components.ex:470
 #, elixir-autogen, elixir-format
 msgid ".connections_action_cancel"
 msgstr "Cancel"
 
-#: lib/lemmings_os_web/components/connections_components.ex:66
+#: lib/lemmings_os_web/components/connections_components.ex:69
 #, elixir-autogen, elixir-format
 msgid ".connections_action_create"
 msgstr "Create"
 
-#: lib/lemmings_os_web/components/connections_components.ex:253
-#: lib/lemmings_os_web/components/connections_components.ex:254
+#: lib/lemmings_os_web/components/connections_components.ex:272
+#: lib/lemmings_os_web/components/connections_components.ex:273
 #, elixir-autogen, elixir-format
 msgid ".connections_action_delete"
 msgstr "Delete"
 
-#: lib/lemmings_os_web/components/connections_components.ex:229
-#: lib/lemmings_os_web/components/connections_components.ex:230
+#: lib/lemmings_os_web/components/connections_components.ex:248
+#: lib/lemmings_os_web/components/connections_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".connections_action_disable"
 msgstr "Disable"
 
-#: lib/lemmings_os_web/components/connections_components.ex:241
-#: lib/lemmings_os_web/components/connections_components.ex:242
+#: lib/lemmings_os_web/components/connections_components.ex:260
+#: lib/lemmings_os_web/components/connections_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".connections_action_edit"
 msgstr "Edit"
 
-#: lib/lemmings_os_web/components/connections_components.ex:216
-#: lib/lemmings_os_web/components/connections_components.ex:217
+#: lib/lemmings_os_web/components/connections_components.ex:235
+#: lib/lemmings_os_web/components/connections_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".connections_action_enable"
 msgstr "Enable"
 
-#: lib/lemmings_os_web/components/connections_components.ex:123
-#: lib/lemmings_os_web/components/connections_components.ex:313
+#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".connections_action_save"
 msgstr "Save"
 
-#: lib/lemmings_os_web/components/connections_components.ex:203
-#: lib/lemmings_os_web/components/connections_components.ex:204
+#: lib/lemmings_os_web/components/connections_components.ex:222
+#: lib/lemmings_os_web/components/connections_components.ex:223
 #, elixir-autogen, elixir-format
 msgid ".connections_action_test"
 msgstr "Test"
 
-#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:161
 #, elixir-autogen, elixir-format
 msgid ".connections_column_actions"
 msgstr "Actions"
 
-#: lib/lemmings_os_web/components/connections_components.ex:141
-#: lib/lemmings_os_web/components/connections_components.ex:190
+#: lib/lemmings_os_web/components/connections_components.ex:160
+#: lib/lemmings_os_web/components/connections_components.ex:209
 #, elixir-autogen, elixir-format
 msgid ".connections_column_last_test"
 msgstr "Last Test"
 
-#: lib/lemmings_os_web/components/connections_components.ex:139
+#: lib/lemmings_os_web/components/connections_components.ex:158
 #, elixir-autogen, elixir-format
 msgid ".connections_column_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/connections_components.ex:129
+#: lib/lemmings_os_web/components/connections_components.ex:148
 #, elixir-autogen, elixir-format
 msgid ".connections_empty"
 msgstr "No visible connections for this scope."
 
-#: lib/lemmings_os_web/live/cities_live.ex:271
-#: lib/lemmings_os_web/live/departments_live.ex:258
-#: lib/lemmings_os_web/live/world_live.ex:166
+#: lib/lemmings_os_web/live/cities_live.ex:284
+#: lib/lemmings_os_web/live/departments_live.ex:270
+#: lib/lemmings_os_web/live/world_live.ex:179
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr "Connection created."
 
-#: lib/lemmings_os_web/live/cities_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:380
-#: lib/lemmings_os_web/live/world_live.ex:280
+#: lib/lemmings_os_web/live/cities_live.ex:410
+#: lib/lemmings_os_web/live/departments_live.ex:405
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr "Connection deleted."
 
-#: lib/lemmings_os_web/live/cities_live.ex:286
-#: lib/lemmings_os_web/live/cities_live.ex:340
-#: lib/lemmings_os_web/live/cities_live.ex:366
-#: lib/lemmings_os_web/live/departments_live.ex:276
-#: lib/lemmings_os_web/live/departments_live.ex:335
-#: lib/lemmings_os_web/live/departments_live.ex:361
-#: lib/lemmings_os_web/live/world_live.ex:182
-#: lib/lemmings_os_web/live/world_live.ex:240
-#: lib/lemmings_os_web/live/world_live.ex:263
+#: lib/lemmings_os_web/live/cities_live.ex:300
+#: lib/lemmings_os_web/live/cities_live.ex:304
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/cities_live.ex:391
+#: lib/lemmings_os_web/live/departments_live.ex:289
+#: lib/lemmings_os_web/live/departments_live.ex:293
+#: lib/lemmings_os_web/live/departments_live.ex:352
+#: lib/lemmings_os_web/live/departments_live.ex:386
+#: lib/lemmings_os_web/live/world_live.ex:196
+#: lib/lemmings_os_web/live/world_live.ex:200
+#: lib/lemmings_os_web/live/world_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:288
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr "Invalid connection payload. Provide valid YAML or JSON."
 
-#: lib/lemmings_os_web/live/cities_live.ex:302
-#: lib/lemmings_os_web/live/cities_live.ex:334
-#: lib/lemmings_os_web/live/cities_live.ex:369
-#: lib/lemmings_os_web/live/cities_live.ex:392
-#: lib/lemmings_os_web/live/cities_live.ex:420
-#: lib/lemmings_os_web/live/departments_live.ex:296
-#: lib/lemmings_os_web/live/departments_live.ex:329
-#: lib/lemmings_os_web/live/departments_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:387
-#: lib/lemmings_os_web/live/departments_live.ex:415
-#: lib/lemmings_os_web/live/world_live.ex:202
-#: lib/lemmings_os_web/live/world_live.ex:234
-#: lib/lemmings_os_web/live/world_live.ex:266
-#: lib/lemmings_os_web/live/world_live.ex:286
-#: lib/lemmings_os_web/live/world_live.ex:309
+#: lib/lemmings_os_web/live/cities_live.ex:320
+#: lib/lemmings_os_web/live/cities_live.ex:352
+#: lib/lemmings_os_web/live/cities_live.ex:394
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:445
+#: lib/lemmings_os_web/live/departments_live.ex:313
+#: lib/lemmings_os_web/live/departments_live.ex:346
+#: lib/lemmings_os_web/live/departments_live.ex:389
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:440
+#: lib/lemmings_os_web/live/world_live.ex:220
+#: lib/lemmings_os_web/live/world_live.ex:252
+#: lib/lemmings_os_web/live/world_live.ex:291
+#: lib/lemmings_os_web/live/world_live.ex:311
+#: lib/lemmings_os_web/live/world_live.ex:334
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr "Only local connections can be changed here."
 
-#: lib/lemmings_os_web/live/world_live.ex:186
+#: lib/lemmings_os_web/live/world_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr "Scope is unavailable."
 
-#: lib/lemmings_os_web/live/cities_live.ex:413
-#: lib/lemmings_os_web/live/departments_live.ex:408
-#: lib/lemmings_os_web/live/world_live.ex:305
+#: lib/lemmings_os_web/live/cities_live.ex:438
+#: lib/lemmings_os_web/live/departments_live.ex:433
+#: lib/lemmings_os_web/live/world_live.ex:330
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr "Connection status updated."
 
-#: lib/lemmings_os_web/connections_surface.ex:108
+#: lib/lemmings_os_web/connections_surface.ex:218
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_test_failed"
 msgstr "Connection test failed."
 
-#: lib/lemmings_os_web/live/cities_live.ex:431
-#: lib/lemmings_os_web/live/departments_live.ex:426
-#: lib/lemmings_os_web/live/world_live.ex:318
+#: lib/lemmings_os_web/live/cities_live.ex:456
+#: lib/lemmings_os_web/live/departments_live.ex:451
+#: lib/lemmings_os_web/live/world_live.ex:343
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr "Connection tested."
 
-#: lib/lemmings_os_web/live/cities_live.ex:358
-#: lib/lemmings_os_web/live/departments_live.ex:353
-#: lib/lemmings_os_web/live/world_live.ex:256
+#: lib/lemmings_os_web/live/cities_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:377
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr "Connection updated."
 
-#: lib/lemmings_os_web/components/connections_components.ex:106
-#: lib/lemmings_os_web/components/connections_components.ex:304
+#: lib/lemmings_os_web/components/connections_components.ex:122
+#: lib/lemmings_os_web/components/connections_components.ex:336
 #, elixir-autogen, elixir-format
 msgid ".connections_label_config_json"
 msgstr "Config JSON"
 
-#: lib/lemmings_os_web/components/connections_components.ex:82
-#: lib/lemmings_os_web/components/connections_components.ex:140
-#: lib/lemmings_os_web/components/connections_components.ex:284
+#: lib/lemmings_os_web/components/connections_components.ex:85
+#: lib/lemmings_os_web/components/connections_components.ex:159
+#: lib/lemmings_os_web/components/connections_components.ex:302
 #, elixir-autogen, elixir-format
 msgid ".connections_label_type"
 msgstr "Type"
 
-#: lib/lemmings_os_web/components/connections_components.ex:333
+#: lib/lemmings_os_web/components/connections_components.ex:490
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_city"
 msgstr "City Scope"
 
-#: lib/lemmings_os_web/components/connections_components.ex:334
+#: lib/lemmings_os_web/components/connections_components.ex:491
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_department"
 msgstr "Department Scope"
 
-#: lib/lemmings_os_web/components/connections_components.ex:50
-#: lib/lemmings_os_web/components/connections_components.ex:335
+#: lib/lemmings_os_web/components/connections_components.ex:53
+#: lib/lemmings_os_web/components/connections_components.ex:492
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_unavailable"
 msgstr "No scope record available."
 
-#: lib/lemmings_os_web/components/connections_components.ex:332
+#: lib/lemmings_os_web/components/connections_components.ex:489
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_world"
 msgstr "World Scope"
 
-#: lib/lemmings_os_web/connections_surface.ex:88
+#: lib/lemmings_os_web/connections_surface.ex:191
 #, elixir-autogen, elixir-format
 msgid ".connections_source_city"
 msgstr "City"
 
-#: lib/lemmings_os_web/connections_surface.ex:89
+#: lib/lemmings_os_web/connections_surface.ex:192
 #, elixir-autogen, elixir-format
 msgid ".connections_source_department"
 msgstr "Department"
 
-#: lib/lemmings_os_web/connections_surface.ex:83
+#: lib/lemmings_os_web/connections_surface.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_source_inherited"
 msgstr "Inherited"
 
-#: lib/lemmings_os_web/connections_surface.ex:80
+#: lib/lemmings_os_web/connections_surface.ex:183
 #, elixir-autogen, elixir-format
 msgid ".connections_source_local"
 msgstr "Local"
 
-#: lib/lemmings_os_web/connections_surface.ex:85
-#: lib/lemmings_os_web/connections_surface.ex:90
+#: lib/lemmings_os_web/connections_surface.ex:188
+#: lib/lemmings_os_web/connections_surface.ex:193
 #, elixir-autogen, elixir-format
 msgid ".connections_source_unknown"
 msgstr "Unknown"
 
-#: lib/lemmings_os_web/connections_surface.ex:87
+#: lib/lemmings_os_web/connections_surface.ex:190
 #, elixir-autogen, elixir-format
 msgid ".connections_source_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/world_components.ex:237
-#: lib/lemmings_os_web/components/world_components.ex:842
+#: lib/lemmings_os_web/components/world_components.ex:243
+#: lib/lemmings_os_web/components/world_components.ex:852
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
 msgstr "Connections"
 
-#: lib/lemmings_os_web/components/connections_components.ex:38
+#: lib/lemmings_os_web/components/connections_components.ex:40
 #, elixir-autogen, elixir-format
 msgid ".subtitle_connections"
 msgstr "Read-only scope visibility and inheritance."
 
-#: lib/lemmings_os_web/components/connections_components.ex:37
-#: lib/lemmings_os_web/components/connections_components.ex:55
-#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:39
+#: lib/lemmings_os_web/components/connections_components.ex:58
+#: lib/lemmings_os_web/components/connections_components.ex:154
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
 msgstr "Connections"
@@ -1088,8 +1092,8 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:35
 #: lib/lemmings_os_web/components/lemming_components.ex:399
 #: lib/lemmings_os_web/components/lemming_components.ex:1100
-#: lib/lemmings_os_web/components/world_components.ex:246
-#: lib/lemmings_os_web/components/world_components.ex:852
+#: lib/lemmings_os_web/components/world_components.ex:252
+#: lib/lemmings_os_web/components/world_components.ex:862
 #: lib/lemmings_os_web/live/cities_live.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
@@ -1163,4 +1167,29 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "world"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:172
+#, elixir-autogen, elixir-format
+msgid "Connect Gmail"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:162
+#, elixir-autogen, elixir-format
+msgid "Connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:149
+#, elixir-autogen, elixir-format
+msgid "Not available"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:164
+#, elixir-autogen, elixir-format
+msgid "Not connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:170
+#, elixir-autogen, elixir-format
+msgid "Reconnect Gmail"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/en/LC_MESSAGES/lemmings.po
@@ -630,19 +630,19 @@ msgstr "Stable identifier used in URLs and topology records. It is auto-generate
 msgid ".tooltip_create_status"
 msgstr "Initial lifecycle state for the new lemming type."
 
-#: lib/lemmings_os_web/components/instance_components.ex:915
+#: lib/lemmings_os_web/components/instance_components.ex:916
 #: lib/lemmings_os_web/live/instance_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:908
 #: lib/lemmings_os_web/live/instance_live.ex:703
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:901
+#: lib/lemmings_os_web/components/instance_components.ex:902
 #: lib/lemmings_os_web/live/instance_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
@@ -653,7 +653,7 @@ msgstr ""
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:968
+#: lib/lemmings_os_web/components/instance_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -673,7 +673,7 @@ msgstr ""
 msgid "Conversation Transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:66
+#: lib/lemmings_os_web/components/instance_components.ex:67
 #: lib/lemmings_os_web/live/instance_live.html.heex:186
 #: lib/lemmings_os_web/live/instance_raw_live.html.heex:260
 #, elixir-autogen, elixir-format
@@ -690,7 +690,7 @@ msgstr ""
 msgid "Current status: %{status}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:102
+#: lib/lemmings_os_web/components/instance_components.ex:103
 #, elixir-autogen, elixir-format
 msgid "Elapsed"
 msgstr ""
@@ -700,13 +700,13 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1018
+#: lib/lemmings_os_web/components/instance_components.ex:1019
 #: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:54
+#: lib/lemmings_os_web/components/instance_components.ex:55
 #, elixir-autogen, elixir-format
 msgid "Failure detail"
 msgstr ""
@@ -722,13 +722,13 @@ msgstr ""
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:858
+#: lib/lemmings_os_web/components/instance_components.ex:859
 #: lib/lemmings_os_web/live/instance_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:192
+#: lib/lemmings_os_web/components/instance_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Input %{count} tokens"
 msgstr ""
@@ -787,7 +787,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:195
+#: lib/lemmings_os_web/components/instance_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Output %{count} tokens"
 msgstr ""
@@ -797,7 +797,7 @@ msgstr ""
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:845
+#: lib/lemmings_os_web/components/instance_components.ex:846
 #: lib/lemmings_os_web/live/instance_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:78
+#: lib/lemmings_os_web/components/instance_components.ex:79
 #: lib/lemmings_os_web/live/instance_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
@@ -819,15 +819,15 @@ msgstr ""
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:828
-#: lib/lemmings_os_web/components/instance_components.ex:851
+#: lib/lemmings_os_web/components/instance_components.ex:829
+#: lib/lemmings_os_web/components/instance_components.ex:852
 #: lib/lemmings_os_web/live/instance_live.ex:628
 #: lib/lemmings_os_web/live/instance_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:90
+#: lib/lemmings_os_web/components/instance_components.ex:91
 #: lib/lemmings_os_web/live/instance_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Retry state"
@@ -849,13 +849,13 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:864
+#: lib/lemmings_os_web/components/instance_components.ex:865
 #: lib/lemmings_os_web/live/instance_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:863
+#: lib/lemmings_os_web/components/instance_components.ex:864
 #: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
@@ -882,8 +882,8 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:839
-#: lib/lemmings_os_web/components/instance_components.ex:865
+#: lib/lemmings_os_web/components/instance_components.ex:840
+#: lib/lemmings_os_web/components/instance_components.ex:866
 #: lib/lemmings_os_web/live/instance_live.ex:636
 #: lib/lemmings_os_web/live/instance_live.ex:650
 #: lib/lemmings_os_web/live/instance_live.ex:652
@@ -905,7 +905,7 @@ msgstr ""
 msgid "This request will reuse the current transcript context."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:198
+#: lib/lemmings_os_web/components/instance_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Total %{count} tokens"
 msgstr ""
@@ -921,8 +921,8 @@ msgstr ""
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1129
-#: lib/lemmings_os_web/components/instance_components.ex:1251
+#: lib/lemmings_os_web/components/instance_components.ex:1141
+#: lib/lemmings_os_web/components/instance_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
@@ -932,12 +932,12 @@ msgstr ""
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:970
+#: lib/lemmings_os_web/components/instance_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:842
+#: lib/lemmings_os_web/components/instance_components.ex:843
 #: lib/lemmings_os_web/live/instance_live.ex:637
 #: lib/lemmings_os_web/live/instance_live.ex:655
 #: lib/lemmings_os_web/live/instance_live.ex:781
@@ -955,7 +955,7 @@ msgstr ""
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:896
+#: lib/lemmings_os_web/components/instance_components.ex:897
 #: lib/lemmings_os_web/live/instance_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -971,7 +971,7 @@ msgstr ""
 msgid "Only failed instances can be retried."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:116
+#: lib/lemmings_os_web/components/instance_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Operator action"
 msgstr ""
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Retry requested for this instance."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:119
+#: lib/lemmings_os_web/components/instance_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Retry the latest failed request."
 msgstr ""
@@ -1002,7 +1002,7 @@ msgstr ""
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1257
+#: lib/lemmings_os_web/components/instance_components.ex:1344
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1479,22 +1479,22 @@ msgstr "Runtime Dashboard"
 msgid ".title_spawn_instance"
 msgstr "Spawn instance"
 
-#: lib/lemmings_os_web/components/instance_components.ex:1151
+#: lib/lemmings_os_web/components/instance_components.ex:1163
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1145
+#: lib/lemmings_os_web/components/instance_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1154
+#: lib/lemmings_os_web/components/instance_components.ex:1166
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:526
+#: lib/lemmings_os_web/components/instance_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1509,8 +1509,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:711
-#: lib/lemmings_os_web/components/instance_components.ex:1017
+#: lib/lemmings_os_web/components/instance_components.ex:712
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1525,12 +1525,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:546
+#: lib/lemmings_os_web/components/instance_components.ex:547
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:520
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1576,12 +1576,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:536
+#: lib/lemmings_os_web/components/instance_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1016
+#: lib/lemmings_os_web/components/instance_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1601,37 +1601,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:273
+#: lib/lemmings_os_web/components/instance_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1027
+#: lib/lemmings_os_web/components/instance_components.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1033
+#: lib/lemmings_os_web/components/instance_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1035
+#: lib/lemmings_os_web/components/instance_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1024
+#: lib/lemmings_os_web/components/instance_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1039
+#: lib/lemmings_os_web/components/instance_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:275
+#: lib/lemmings_os_web/components/instance_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1646,22 +1646,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:753
+#: lib/lemmings_os_web/components/instance_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:929
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:778
+#: lib/lemmings_os_web/components/instance_components.ex:779
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:663
+#: lib/lemmings_os_web/components/instance_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1203
+#: lib/lemmings_os_web/components/instance_components.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1686,20 +1686,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:721
+#: lib/lemmings_os_web/components/instance_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:585
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/instance_components.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:624
+#: lib/lemmings_os_web/components/instance_components.ex:669
+#: lib/lemmings_os_web/components/world_components.ex:924
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1709,18 +1709,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:899
+#: lib/lemmings_os_web/components/world_components.ex:909
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:693
+#: lib/lemmings_os_web/components/instance_components.ex:694
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:769
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:770
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1730,18 +1730,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:897
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:708
+#: lib/lemmings_os_web/components/instance_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:731
+#: lib/lemmings_os_web/components/instance_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1756,17 +1756,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1214
+#: lib/lemmings_os_web/components/instance_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1209
+#: lib/lemmings_os_web/components/instance_components.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:671
+#: lib/lemmings_os_web/components/instance_components.ex:672
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1796,12 +1796,12 @@ msgstr ""
 msgid "Workspace path copied."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1122
+#: lib/lemmings_os_web/components/instance_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid "%{count} bytes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:359
+#: lib/lemmings_os_web/components/instance_components.ex:360
 #, elixir-autogen, elixir-format
 msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
 msgstr ""
@@ -1826,7 +1826,7 @@ msgstr ""
 msgid "Artifact promoted: %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:342
+#: lib/lemmings_os_web/components/instance_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Artifact promotion"
 msgstr ""
@@ -1871,22 +1871,22 @@ msgstr ""
 msgid "Choose a valid promotion action for this Artifact."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:492
+#: lib/lemmings_os_web/components/instance_components.ex:493
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:486
+#: lib/lemmings_os_web/components/instance_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Download Artifact %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:506
+#: lib/lemmings_os_web/components/instance_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -1901,33 +1901,33 @@ msgstr ""
 msgid "Only regular files can be promoted as Artifacts."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:438
+#: lib/lemmings_os_web/components/instance_components.ex:439
 #, elixir-autogen, elixir-format
 msgid "Promote as New Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:433
+#: lib/lemmings_os_web/components/instance_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "Promote as new Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:408
+#: lib/lemmings_os_web/components/instance_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "Promote to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Promote workspace file to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:374
+#: lib/lemmings_os_web/components/instance_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Promoted"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:402
-#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Promoting..."
 msgstr ""
@@ -1937,7 +1937,7 @@ msgstr ""
 msgid "Runtime instance not found for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:352
+#: lib/lemmings_os_web/components/instance_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Show Artifact help"
 msgstr ""
@@ -1952,22 +1952,22 @@ msgstr ""
 msgid "Unable to promote this file right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1124
+#: lib/lemmings_os_web/components/instance_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Unknown size"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:423
+#: lib/lemmings_os_web/components/instance_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "Update Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:418
+#: lib/lemmings_os_web/components/instance_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "Update existing Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:417
+#: lib/lemmings_os_web/components/instance_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "Updating..."
 msgstr ""
@@ -1983,7 +1983,22 @@ msgstr ""
 msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:182
+#: lib/lemmings_os_web/components/instance_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "View/Edit memory"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1200
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1197
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1203
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation recorded."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/world.po
+++ b/priv/gettext/en/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Unknown"
 
 #: lib/lemmings_os/helpers.ex:130
 #: lib/lemmings_os/helpers.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:1346
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/components/world_components.ex:1393
-#: lib/lemmings_os_web/components/world_components.ex:1410
-#: lib/lemmings_os_web/components/world_components.ex:1414
-#: lib/lemmings_os_web/components/world_components.ex:1435
+#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1422
+#: lib/lemmings_os_web/components/world_components.ex:1426
+#: lib/lemmings_os_web/components/world_components.ex:1447
 #: lib/lemmings_os_web/live/instance_live.ex:470
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
@@ -75,40 +75,40 @@ msgstr "Department node"
 msgid ".aria_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:789
+#: lib/lemmings_os_web/components/world_components.ex:799
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "All Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:266
-#: lib/lemmings_os_web/components/world_components.ex:557
+#: lib/lemmings_os_web/components/world_components.ex:272
+#: lib/lemmings_os_web/components/world_components.ex:565
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr "Import bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:736
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Open department"
 
-#: lib/lemmings_os_web/components/world_components.ex:105
-#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:111
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr "Refresh world"
 
-#: lib/lemmings_os_web/components/world_components.ex:448
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr "The city summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/components/world_components.ex:461
+#: lib/lemmings_os_web/components/world_components.ex:467
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr "The tools summary will appear here once a real source exists."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:128
+#: lib/lemmings_os_web/live/departments_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departments"
@@ -118,178 +118,178 @@ msgstr "%{count} departments"
 msgid ".count_running_of_total"
 msgstr "%{running} of %{total} running"
 
-#: lib/lemmings_os_web/components/world_components.ex:677
-#: lib/lemmings_os_web/live/departments_live.html.heex:56
-#: lib/lemmings_os_web/live/departments_live.html.heex:135
+#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/live/departments_live.html.heex:58
+#: lib/lemmings_os_web/live/departments_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "No departments yet"
 
-#: lib/lemmings_os_web/components/world_components.ex:678
-#: lib/lemmings_os_web/live/departments_live.html.heex:57
-#: lib/lemmings_os_web/live/departments_live.html.heex:136
+#: lib/lemmings_os_web/components/world_components.ex:686
+#: lib/lemmings_os_web/live/departments_live.html.heex:59
+#: lib/lemmings_os_web/live/departments_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Create or import a department to see it here."
 
-#: lib/lemmings_os_web/components/world_components.ex:562
+#: lib/lemmings_os_web/components/world_components.ex:570
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr "No world snapshot"
 
-#: lib/lemmings_os_web/components/world_components.ex:563
+#: lib/lemmings_os_web/components/world_components.ex:571
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr "Import bootstrap or refresh state to see the current snapshot."
 
-#: lib/lemmings_os_web/components/world_components.ex:350
+#: lib/lemmings_os_web/components/world_components.ex:356
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr "Bootstrap path"
 
-#: lib/lemmings_os_web/components/world_components.ex:345
+#: lib/lemmings_os_web/components/world_components.ex:351
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr "Bootstrap source"
 
-#: lib/lemmings_os_web/components/world_components.ex:422
-#: lib/lemmings_os_web/components/world_components.ex:651
+#: lib/lemmings_os_web/components/world_components.ex:428
+#: lib/lemmings_os_web/components/world_components.ex:659
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr "Budgets"
 
-#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1365
+#: lib/lemmings_os_web/components/world_components.ex:1377
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1374
+#: lib/lemmings_os_web/components/world_components.ex:1386
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declared"
 
-#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Depts."
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:759
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Empty"
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:132
+#: lib/lemmings_os_web/components/world_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr "Immediate import"
 
-#: lib/lemmings_os_web/components/world_components.ex:300
+#: lib/lemmings_os_web/components/world_components.ex:306
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr "Last bootstrap hash"
 
-#: lib/lemmings_os_web/components/world_components.ex:296
+#: lib/lemmings_os_web/components/world_components.ex:302
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr "Last imported at"
 
-#: lib/lemmings_os_web/components/world_components.ex:144
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:150
+#: lib/lemmings_os_web/components/world_components.ex:294
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr "Last sync"
 
-#: lib/lemmings_os_web/components/world_components.ex:1359
+#: lib/lemmings_os_web/components/world_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
 
-#: lib/lemmings_os_web/components/world_components.ex:417
-#: lib/lemmings_os_web/components/world_components.ex:635
+#: lib/lemmings_os_web/components/world_components.ex:423
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr "Limits"
 
-#: lib/lemmings_os_web/components/world_components.ex:1348
+#: lib/lemmings_os_web/components/world_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "No fallbacks"
 
-#: lib/lemmings_os_web/components/world_components.ex:314
+#: lib/lemmings_os_web/components/world_components.ex:320
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr "No world issues"
 
-#: lib/lemmings_os_web/components/world_components.ex:445
-#: lib/lemmings_os_web/components/world_components.ex:458
+#: lib/lemmings_os_web/components/world_components.ex:451
+#: lib/lemmings_os_web/components/world_components.ex:464
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr "Placeholder only"
 
-#: lib/lemmings_os_web/components/world_components.ex:432
+#: lib/lemmings_os_web/components/world_components.ex:438
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr "Placeholder sections"
 
-#: lib/lemmings_os_web/components/world_components.ex:394
-#: lib/lemmings_os_web/components/world_components.ex:657
+#: lib/lemmings_os_web/components/world_components.ex:400
+#: lib/lemmings_os_web/components/world_components.ex:665
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr "Profiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1421
+#: lib/lemmings_os_web/components/world_components.ex:1433
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credentials ready"
 
-#: lib/lemmings_os_web/components/world_components.ex:1345
+#: lib/lemmings_os_web/components/world_components.ex:1357
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Provider disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1344
+#: lib/lemmings_os_web/components/world_components.ex:1356
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Provider enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:369
+#: lib/lemmings_os_web/components/world_components.ex:375
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr "Providers"
 
-#: lib/lemmings_os_web/components/world_components.ex:750
+#: lib/lemmings_os_web/components/world_components.ex:758
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Queue"
 
-#: lib/lemmings_os_web/components/world_components.ex:427
-#: lib/lemmings_os_web/components/world_components.ex:643
+#: lib/lemmings_os_web/components/world_components.ex:433
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr "Runtime defaults"
 
-#: lib/lemmings_os_web/components/world_components.ex:1430
-#: lib/lemmings_os_web/components/world_components.ex:1431
+#: lib/lemmings_os_web/components/world_components.ex:1442
+#: lib/lemmings_os_web/components/world_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Runtime deferred"
 
-#: lib/lemmings_os_web/components/world_components.ex:1387
+#: lib/lemmings_os_web/components/world_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "World ID"
 
-#: lib/lemmings_os_web/components/world_components.ex:885
-#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:895
+#: lib/lemmings_os_web/components/world_components.ex:1400
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -329,22 +329,22 @@ msgstr "Online"
 msgid ".metric_status"
 msgstr "Status"
 
-#: lib/lemmings_os_web/components/world_components.ex:1396
+#: lib/lemmings_os_web/components/world_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Bootstrap file"
 
-#: lib/lemmings_os_web/components/world_components.ex:1399
+#: lib/lemmings_os_web/components/world_components.ex:1411
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Postgres connection"
 
-#: lib/lemmings_os_web/components/world_components.ex:1402
+#: lib/lemmings_os_web/components/world_components.ex:1414
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Provider credentials"
 
-#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Provider reachability"
@@ -375,23 +375,23 @@ msgstr "Online"
 msgid ".subtitle_all_cities"
 msgstr "Cities registered in this world"
 
-#: lib/lemmings_os_web/components/world_components.ex:210
+#: lib/lemmings_os_web/components/world_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:201
+#: lib/lemmings_os_web/components/world_components.ex:207
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr "Import"
 
-#: lib/lemmings_os_web/components/world_components.ex:192
+#: lib/lemmings_os_web/components/world_components.ex:198
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:219
+#: lib/lemmings_os_web/components/world_components.ex:225
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr "Runtime"
@@ -401,45 +401,45 @@ msgstr "Runtime"
 msgid ".title_all_cities"
 msgstr "All Cities"
 
-#: lib/lemmings_os_web/components/world_components.ex:158
-#: lib/lemmings_os_web/components/world_components.ex:339
+#: lib/lemmings_os_web/components/world_components.ex:164
+#: lib/lemmings_os_web/components/world_components.ex:345
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr "Bootstrap config"
 
-#: lib/lemmings_os_web/components/world_components.ex:671
-#: lib/lemmings_os_web/live/departments_live.html.heex:124
+#: lib/lemmings_os_web/components/world_components.ex:679
+#: lib/lemmings_os_web/live/departments_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:129
-#: lib/lemmings_os_web/components/world_components.ex:258
+#: lib/lemmings_os_web/components/world_components.ex:135
+#: lib/lemmings_os_web/components/world_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr "Import state"
 
-#: lib/lemmings_os_web/components/world_components.ex:172
-#: lib/lemmings_os_web/components/world_components.ex:469
+#: lib/lemmings_os_web/components/world_components.ex:178
+#: lib/lemmings_os_web/components/world_components.ex:475
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr "Runtime checks"
 
-#: lib/lemmings_os_web/components/world_components.ex:441
+#: lib/lemmings_os_web/components/world_components.ex:447
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr "World cities"
 
-#: lib/lemmings_os_web/components/world_components.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:361
-#: lib/lemmings_os_web/components/world_components.ex:546
-#: lib/lemmings_os_web/components/world_components.ex:880
+#: lib/lemmings_os_web/components/world_components.ex:120
+#: lib/lemmings_os_web/components/world_components.ex:367
+#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:890
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "World identity"
 
-#: lib/lemmings_os_web/components/world_components.ex:309
+#: lib/lemmings_os_web/components/world_components.ex:315
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr "World issues"
@@ -449,12 +449,12 @@ msgstr "World issues"
 msgid ".title_world_map"
 msgstr "World map"
 
-#: lib/lemmings_os_web/components/world_components.ex:97
+#: lib/lemmings_os_web/components/world_components.ex:103
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr "World status"
 
-#: lib/lemmings_os_web/components/world_components.ex:454
+#: lib/lemmings_os_web/components/world_components.ex:460
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr "World tools"
@@ -469,13 +469,13 @@ msgstr "Department"
 msgid ".tooltip_running"
 msgstr "Running"
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr "Resolved from the persisted World and City layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:875
-#: lib/lemmings_os_web/live/departments_live.html.heex:51
+#: lib/lemmings_os_web/components/world_components.ex:885
+#: lib/lemmings_os_web/live/departments_live.html.heex:53
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr "Cities"
@@ -534,7 +534,7 @@ msgstr "BEAM node"
 msgid ".label_city_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/world_components.ex:629
+#: lib/lemmings_os_web/components/world_components.ex:637
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr "Effective city config"
@@ -604,7 +604,7 @@ msgstr "BEAM node name"
 msgid ".city_form_node_name_placeholder"
 msgstr "e.g. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:870
+#: lib/lemmings_os_web/components/world_components.ex:880
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -645,268 +645,268 @@ msgstr "Create city"
 msgid ".city_form_submit_update"
 msgstr "Save changes"
 
-#: lib/lemmings_os_web/live/cities_live.ex:508
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "City created."
 
-#: lib/lemmings_os_web/live/cities_live.ex:533
+#: lib/lemmings_os_web/live/cities_live.ex:558
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "City updated."
 
-#: lib/lemmings_os_web/live/cities_live.ex:146
+#: lib/lemmings_os_web/live/cities_live.ex:148
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr "City deleted."
 
-#: lib/lemmings_os_web/live/cities_live.ex:102
-#: lib/lemmings_os_web/live/cities_live.ex:155
+#: lib/lemmings_os_web/live/cities_live.ex:104
+#: lib/lemmings_os_web/live/cities_live.ex:157
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr "City not found."
 
-#: lib/lemmings_os_web/live/cities_live.ex:518
 #: lib/lemmings_os_web/live/cities_live.ex:543
+#: lib/lemmings_os_web/live/cities_live.ex:568
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "Could not save city. Check the form for errors."
 
-#: lib/lemmings_os_web/live/cities_live.ex:152
+#: lib/lemmings_os_web/live/cities_live.ex:154
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr "Could not delete city."
 
-#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Open Departments"
 
-#: lib/lemmings_os_web/components/world_components.ex:684
+#: lib/lemmings_os_web/components/world_components.ex:692
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr "%{city} has %{count} departments."
 
-#: lib/lemmings_os_web/components/world_components.ex:672
+#: lib/lemmings_os_web/components/world_components.ex:680
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr "Compact summary of persisted departments for this city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:99
+#: lib/lemmings_os_web/live/departments_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Change the city scope for the map and department list."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:98
-#: lib/lemmings_os_web/live/departments_live.html.heex:117
+#: lib/lemmings_os_web/live/departments_live.html.heex:100
+#: lib/lemmings_os_web/live/departments_live.html.heex:119
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "Selected City"
 
-#: lib/lemmings_os_web/components/world_components.ex:965
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activate"
 
-#: lib/lemmings_os_web/components/world_components.ex:993
+#: lib/lemmings_os_web/components/world_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Delete"
 
-#: lib/lemmings_os_web/components/world_components.ex:983
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Disable"
 
-#: lib/lemmings_os_web/components/world_components.ex:974
+#: lib/lemmings_os_web/components/world_components.ex:984
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drain"
 
-#: lib/lemmings_os_web/components/world_components.ex:1217
+#: lib/lemmings_os_web/components/world_components.ex:1227
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Save settings"
 
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:1000
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "Are you sure you want to delete this department?"
 
-#: lib/lemmings_os_web/components/world_components.ex:937
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Name"
 
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:957
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notes"
 
-#: lib/lemmings_os_web/components/world_components.ex:942
+#: lib/lemmings_os_web/components/world_components.ex:952
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No lemmings available"
 
-#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1038
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "No runtime-backed or mock preview lemmings are available for this department yet."
 
-#: lib/lemmings_os_web/components/world_components.ex:1003
+#: lib/lemmings_os_web/components/world_components.ex:1013
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:954
+#: lib/lemmings_os_web/components/world_components.ex:964
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Lifecycle actions"
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:965
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Use the persisted department lifecycle controls. Delete remains guarded by safety checks."
 
-#: lib/lemmings_os_web/components/world_components.ex:933
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadata"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1145
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1122
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1204
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Cross-city communication"
 
-#: lib/lemmings_os_web/components/world_components.ex:1117
-#: lib/lemmings_os_web/components/world_components.ex:1154
-#: lib/lemmings_os_web/components/world_components.ex:1209
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Daily tokens"
 
-#: lib/lemmings_os_web/components/world_components.ex:1198
+#: lib/lemmings_os_web/components/world_components.ex:1208
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Disabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1197
+#: lib/lemmings_os_web/components/world_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Enabled"
 
-#: lib/lemmings_os_web/components/world_components.ex:1107
-#: lib/lemmings_os_web/components/world_components.ex:1138
-#: lib/lemmings_os_web/components/world_components.ex:1188
+#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Idle TTL seconds"
 
-#: lib/lemmings_os_web/components/world_components.ex:1196
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Inherit"
 
-#: lib/lemmings_os_web/components/world_components.ex:1102
-#: lib/lemmings_os_web/components/world_components.ex:1129
-#: lib/lemmings_os_web/components/world_components.ex:1179
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Max lemmings per department"
 
-#: lib/lemmings_os_web/components/world_components.ex:1098
+#: lib/lemmings_os_web/components/world_components.ex:1108
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Effective values after resolving World, City, and Department layers."
 
-#: lib/lemmings_os_web/components/world_components.ex:1097
+#: lib/lemmings_os_web/components/world_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Effective config"
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Only Department-local overrides persisted on this row. Empty values inherit from City or World."
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Local overrides"
 
-#: lib/lemmings_os_web/components/world_components.ex:1165
+#: lib/lemmings_os_web/components/world_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "V1 editor. This safely updates a narrow subset of Department-local overrides."
 
-#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1174
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Settings editor"
 
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:822
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:812
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Overview"
 
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:832
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Settings"
 
-#: lib/lemmings_os_web/live/departments_live.ex:670
+#: lib/lemmings_os_web/live/departments_live.ex:703
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Department activated."
 
-#: lib/lemmings_os_web/live/departments_live.ex:118
+#: lib/lemmings_os_web/live/departments_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Department deleted."
 
-#: lib/lemmings_os_web/live/departments_live.ex:672
+#: lib/lemmings_os_web/live/departments_live.ex:705
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Department disabled."
 
-#: lib/lemmings_os_web/live/departments_live.ex:671
+#: lib/lemmings_os_web/live/departments_live.ex:704
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Department set to draining."
 
-#: lib/lemmings_os_web/live/departments_live.ex:132
+#: lib/lemmings_os_web/live/departments_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "Could not update the department lifecycle."
 
-#: lib/lemmings_os_web/live/departments_live.ex:102
+#: lib/lemmings_os_web/live/departments_live.ex:104
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Department settings saved."
 
-#: lib/lemmings_os_web/live/departments_live.ex:673
+#: lib/lemmings_os_web/live/departments_live.ex:706
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Department updated."
 
-#: lib/lemmings_os_web/components/world_components.ex:1012
+#: lib/lemmings_os_web/components/world_components.ex:1022
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1004
+#: lib/lemmings_os_web/components/world_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -992,15 +992,15 @@ msgstr "Delete this local secret value?"
 msgid ".secret_delete_label"
 msgstr "Delete local secret %{key}"
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
-#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/cities_live.ex:208
+#: lib/lemmings_os_web/live/departments_live.ex:193
 #: lib/lemmings_os_web/live/lemmings_live.ex:188
-#: lib/lemmings_os_web/live/world_live.ex:103
+#: lib/lemmings_os_web/live/world_live.ex:105
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr "Local secret deleted"
 
-#: lib/lemmings_os_web/components/world_components.ex:1234
+#: lib/lemmings_os_web/components/world_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr "Write-only Secret Bank values scoped to this department."
@@ -1110,10 +1110,10 @@ msgstr "Save secret"
 msgid ".secret_save_pending"
 msgstr "Saving secret..."
 
-#: lib/lemmings_os_web/live/cities_live.ex:166
-#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/cities_live.ex:168
+#: lib/lemmings_os_web/live/departments_live.ex:150
 #: lib/lemmings_os_web/live/lemmings_live.ex:148
-#: lib/lemmings_os_web/live/world_live.ex:65
+#: lib/lemmings_os_web/live/world_live.ex:67
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr "Secret saved"
@@ -1131,8 +1131,8 @@ msgstr "Secret value"
 #: lib/lemmings_os_web/components/lemming_components.ex:383
 #: lib/lemmings_os_web/components/lemming_components.ex:1098
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:228
-#: lib/lemmings_os_web/components/world_components.ex:832
+#: lib/lemmings_os_web/components/world_components.ex:234
+#: lib/lemmings_os_web/components/world_components.ex:842
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -133,10 +133,10 @@ msgstr ""
 msgid ".error_something_went_wrong"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:179
-#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/departments_live.ex:163
 #: lib/lemmings_os_web/live/lemmings_live.ex:161
-#: lib/lemmings_os_web/live/world_live.ex:78
+#: lib/lemmings_os_web/live/world_live.ex:80
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr ""
@@ -492,24 +492,24 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:172
-#: lib/lemmings_os_web/live/cities_live.ex:211
-#: lib/lemmings_os_web/live/cities_live.ex:276
-#: lib/lemmings_os_web/live/cities_live.ex:362
-#: lib/lemmings_os_web/live/cities_live.ex:389
-#: lib/lemmings_os_web/live/cities_live.ex:417
-#: lib/lemmings_os_web/live/cities_live.ex:435
+#: lib/lemmings_os_web/live/cities_live.ex:174
+#: lib/lemmings_os_web/live/cities_live.ex:213
+#: lib/lemmings_os_web/live/cities_live.ex:290
+#: lib/lemmings_os_web/live/cities_live.ex:387
+#: lib/lemmings_os_web/live/cities_live.ex:414
+#: lib/lemmings_os_web/live/cities_live.ex:442
+#: lib/lemmings_os_web/live/cities_live.ex:460
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:154
-#: lib/lemmings_os_web/live/departments_live.ex:196
-#: lib/lemmings_os_web/live/departments_live.ex:263
-#: lib/lemmings_os_web/live/departments_live.ex:357
-#: lib/lemmings_os_web/live/departments_live.ex:384
-#: lib/lemmings_os_web/live/departments_live.ex:412
-#: lib/lemmings_os_web/live/departments_live.ex:430
+#: lib/lemmings_os_web/live/departments_live.ex:156
+#: lib/lemmings_os_web/live/departments_live.ex:198
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:409
+#: lib/lemmings_os_web/live/departments_live.ex:437
+#: lib/lemmings_os_web/live/departments_live.ex:455
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr ""
@@ -520,48 +520,48 @@ msgstr ""
 msgid ".error_lemming_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:225
-#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/cities_live.ex:227
+#: lib/lemmings_os_web/live/departments_live.ex:212
 #: lib/lemmings_os_web/live/lemmings_live.ex:207
-#: lib/lemmings_os_web/live/world_live.ex:122
+#: lib/lemmings_os_web/live/world_live.ex:124
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:218
-#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/cities_live.ex:220
+#: lib/lemmings_os_web/live/departments_live.ex:205
 #: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:115
+#: lib/lemmings_os_web/live/world_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:222
-#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/cities_live.ex:224
+#: lib/lemmings_os_web/live/departments_live.ex:209
 #: lib/lemmings_os_web/live/lemmings_live.ex:204
-#: lib/lemmings_os_web/live/world_live.ex:119
+#: lib/lemmings_os_web/live/world_live.ex:121
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/cities_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:181
 #: lib/lemmings_os_web/live/lemmings_live.ex:176
-#: lib/lemmings_os_web/live/world_live.ex:93
+#: lib/lemmings_os_web/live/world_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:187
-#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:189
+#: lib/lemmings_os_web/live/departments_live.ex:174
 #: lib/lemmings_os_web/live/lemmings_live.ex:169
-#: lib/lemmings_os_web/live/world_live.ex:86
+#: lib/lemmings_os_web/live/world_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:71
-#: lib/lemmings_os_web/live/world_live.ex:108
+#: lib/lemmings_os_web/live/world_live.ex:73
+#: lib/lemmings_os_web/live/world_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/errors.po
+++ b/priv/gettext/es/LC_MESSAGES/errors.po
@@ -136,10 +136,10 @@ msgstr "Intentando reconectar"
 msgid ".error_something_went_wrong"
 msgstr "Algo salio mal!"
 
-#: lib/lemmings_os_web/live/cities_live.ex:179
-#: lib/lemmings_os_web/live/departments_live.ex:161
+#: lib/lemmings_os_web/live/cities_live.ex:181
+#: lib/lemmings_os_web/live/departments_live.ex:163
 #: lib/lemmings_os_web/live/lemmings_live.ex:161
-#: lib/lemmings_os_web/live/world_live.ex:78
+#: lib/lemmings_os_web/live/world_live.ex:80
 #, elixir-autogen
 msgid ".error_invalid_key"
 msgstr "Formato de clave secreta invalido. Usa letras MAYUSCULAS, numeros y _."
@@ -495,24 +495,24 @@ msgstr ""
 msgid "Tool iteration limit reached before final reply."
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:172
-#: lib/lemmings_os_web/live/cities_live.ex:211
-#: lib/lemmings_os_web/live/cities_live.ex:276
-#: lib/lemmings_os_web/live/cities_live.ex:362
-#: lib/lemmings_os_web/live/cities_live.ex:389
-#: lib/lemmings_os_web/live/cities_live.ex:417
-#: lib/lemmings_os_web/live/cities_live.ex:435
+#: lib/lemmings_os_web/live/cities_live.ex:174
+#: lib/lemmings_os_web/live/cities_live.ex:213
+#: lib/lemmings_os_web/live/cities_live.ex:290
+#: lib/lemmings_os_web/live/cities_live.ex:387
+#: lib/lemmings_os_web/live/cities_live.ex:414
+#: lib/lemmings_os_web/live/cities_live.ex:442
+#: lib/lemmings_os_web/live/cities_live.ex:460
 #, elixir-autogen, elixir-format
 msgid ".error_city_unavailable"
 msgstr "La ciudad no está disponible"
 
-#: lib/lemmings_os_web/live/departments_live.ex:154
-#: lib/lemmings_os_web/live/departments_live.ex:196
-#: lib/lemmings_os_web/live/departments_live.ex:263
-#: lib/lemmings_os_web/live/departments_live.ex:357
-#: lib/lemmings_os_web/live/departments_live.ex:384
-#: lib/lemmings_os_web/live/departments_live.ex:412
-#: lib/lemmings_os_web/live/departments_live.ex:430
+#: lib/lemmings_os_web/live/departments_live.ex:156
+#: lib/lemmings_os_web/live/departments_live.ex:198
+#: lib/lemmings_os_web/live/departments_live.ex:276
+#: lib/lemmings_os_web/live/departments_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:409
+#: lib/lemmings_os_web/live/departments_live.ex:437
+#: lib/lemmings_os_web/live/departments_live.ex:455
 #, elixir-autogen, elixir-format
 msgid ".error_department_unavailable"
 msgstr "El departamento no está disponible"
@@ -523,48 +523,48 @@ msgstr "El departamento no está disponible"
 msgid ".error_lemming_unavailable"
 msgstr "El lemming no está disponible"
 
-#: lib/lemmings_os_web/live/cities_live.ex:225
-#: lib/lemmings_os_web/live/departments_live.ex:210
+#: lib/lemmings_os_web/live/cities_live.ex:227
+#: lib/lemmings_os_web/live/departments_live.ex:212
 #: lib/lemmings_os_web/live/lemmings_live.ex:207
-#: lib/lemmings_os_web/live/world_live.ex:122
+#: lib/lemmings_os_web/live/world_live.ex:124
 #, elixir-autogen, elixir-format
 msgid ".error_secret_delete_failed"
 msgstr "No se pudo eliminar el secreto"
 
-#: lib/lemmings_os_web/live/cities_live.ex:218
-#: lib/lemmings_os_web/live/departments_live.ex:203
+#: lib/lemmings_os_web/live/cities_live.ex:220
+#: lib/lemmings_os_web/live/departments_live.ex:205
 #: lib/lemmings_os_web/live/lemmings_live.ex:200
-#: lib/lemmings_os_web/live/world_live.ex:115
+#: lib/lemmings_os_web/live/world_live.ex:117
 #, elixir-autogen, elixir-format
 msgid ".error_secret_inherited_not_deletable"
 msgstr "Solo los valores locales pueden eliminarse en este alcance"
 
-#: lib/lemmings_os_web/live/cities_live.ex:222
-#: lib/lemmings_os_web/live/departments_live.ex:207
+#: lib/lemmings_os_web/live/cities_live.ex:224
+#: lib/lemmings_os_web/live/departments_live.ex:209
 #: lib/lemmings_os_web/live/lemmings_live.ex:204
-#: lib/lemmings_os_web/live/world_live.ex:119
+#: lib/lemmings_os_web/live/world_live.ex:121
 #, elixir-autogen, elixir-format
 msgid ".error_secret_key_not_found"
 msgstr "Clave secreta no encontrada"
 
-#: lib/lemmings_os_web/live/cities_live.ex:194
-#: lib/lemmings_os_web/live/departments_live.ex:179
+#: lib/lemmings_os_web/live/cities_live.ex:196
+#: lib/lemmings_os_web/live/departments_live.ex:181
 #: lib/lemmings_os_web/live/lemmings_live.ex:176
-#: lib/lemmings_os_web/live/world_live.ex:93
+#: lib/lemmings_os_web/live/world_live.ex:95
 #, elixir-autogen, elixir-format
 msgid ".error_secret_save_failed"
 msgstr "No se pudo guardar el secreto"
 
-#: lib/lemmings_os_web/live/cities_live.ex:187
-#: lib/lemmings_os_web/live/departments_live.ex:172
+#: lib/lemmings_os_web/live/cities_live.ex:189
+#: lib/lemmings_os_web/live/departments_live.ex:174
 #: lib/lemmings_os_web/live/lemmings_live.ex:169
-#: lib/lemmings_os_web/live/world_live.ex:86
+#: lib/lemmings_os_web/live/world_live.ex:88
 #, elixir-autogen, elixir-format
 msgid ".error_secret_value_required"
 msgstr "El valor secreto es obligatorio"
 
-#: lib/lemmings_os_web/live/world_live.ex:71
-#: lib/lemmings_os_web/live/world_live.ex:108
+#: lib/lemmings_os_web/live/world_live.ex:73
+#: lib/lemmings_os_web/live/world_live.ex:110
 #, elixir-autogen, elixir-format
 msgid ".error_world_unavailable"
 msgstr "El mundo no está disponible"

--- a/priv/gettext/es/LC_MESSAGES/layout.po
+++ b/priv/gettext/es/LC_MESSAGES/layout.po
@@ -79,7 +79,7 @@ msgid ".nav_departments"
 msgstr "Departamentos"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -107,7 +107,7 @@ msgid ".nav_settings"
 msgstr "Ajustes"
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:1036
+#: lib/lemmings_os_web/components/world_components.ex:1046
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr "Nuevo lemming"
@@ -851,231 +851,235 @@ msgstr "medio"
 msgid ".tools_risk_unknown"
 msgstr "desconocido"
 
-#: lib/lemmings_os_web/components/connections_components.ex:116
-#: lib/lemmings_os_web/components/connections_components.ex:321
+#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:353
+#: lib/lemmings_os_web/components/connections_components.ex:470
 #, elixir-autogen, elixir-format
 msgid ".connections_action_cancel"
 msgstr "Cancelar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:66
+#: lib/lemmings_os_web/components/connections_components.ex:69
 #, elixir-autogen, elixir-format
 msgid ".connections_action_create"
 msgstr "Crear"
 
-#: lib/lemmings_os_web/components/connections_components.ex:253
-#: lib/lemmings_os_web/components/connections_components.ex:254
+#: lib/lemmings_os_web/components/connections_components.ex:272
+#: lib/lemmings_os_web/components/connections_components.ex:273
 #, elixir-autogen, elixir-format
 msgid ".connections_action_delete"
 msgstr "Eliminar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:229
-#: lib/lemmings_os_web/components/connections_components.ex:230
+#: lib/lemmings_os_web/components/connections_components.ex:248
+#: lib/lemmings_os_web/components/connections_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".connections_action_disable"
 msgstr "Deshabilitar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:241
-#: lib/lemmings_os_web/components/connections_components.ex:242
+#: lib/lemmings_os_web/components/connections_components.ex:260
+#: lib/lemmings_os_web/components/connections_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".connections_action_edit"
 msgstr "Editar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:216
-#: lib/lemmings_os_web/components/connections_components.ex:217
+#: lib/lemmings_os_web/components/connections_components.ex:235
+#: lib/lemmings_os_web/components/connections_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".connections_action_enable"
 msgstr "Habilitar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:123
-#: lib/lemmings_os_web/components/connections_components.ex:313
+#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".connections_action_save"
 msgstr "Guardar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:203
-#: lib/lemmings_os_web/components/connections_components.ex:204
+#: lib/lemmings_os_web/components/connections_components.ex:222
+#: lib/lemmings_os_web/components/connections_components.ex:223
 #, elixir-autogen, elixir-format
 msgid ".connections_action_test"
 msgstr "Probar"
 
-#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:161
 #, elixir-autogen, elixir-format
 msgid ".connections_column_actions"
 msgstr "Acciones"
 
-#: lib/lemmings_os_web/components/connections_components.ex:141
-#: lib/lemmings_os_web/components/connections_components.ex:190
+#: lib/lemmings_os_web/components/connections_components.ex:160
+#: lib/lemmings_os_web/components/connections_components.ex:209
 #, elixir-autogen, elixir-format
 msgid ".connections_column_last_test"
 msgstr "Ultima prueba"
 
-#: lib/lemmings_os_web/components/connections_components.ex:139
+#: lib/lemmings_os_web/components/connections_components.ex:158
 #, elixir-autogen, elixir-format
 msgid ".connections_column_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/connections_components.ex:129
+#: lib/lemmings_os_web/components/connections_components.ex:148
 #, elixir-autogen, elixir-format
 msgid ".connections_empty"
 msgstr "No hay conexiones visibles para este alcance."
 
-#: lib/lemmings_os_web/live/cities_live.ex:271
-#: lib/lemmings_os_web/live/departments_live.ex:258
-#: lib/lemmings_os_web/live/world_live.ex:166
+#: lib/lemmings_os_web/live/cities_live.ex:284
+#: lib/lemmings_os_web/live/departments_live.ex:270
+#: lib/lemmings_os_web/live/world_live.ex:179
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr "Conexion creada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:380
-#: lib/lemmings_os_web/live/world_live.ex:280
+#: lib/lemmings_os_web/live/cities_live.ex:410
+#: lib/lemmings_os_web/live/departments_live.ex:405
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr "Conexion eliminada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:286
-#: lib/lemmings_os_web/live/cities_live.ex:340
-#: lib/lemmings_os_web/live/cities_live.ex:366
-#: lib/lemmings_os_web/live/departments_live.ex:276
-#: lib/lemmings_os_web/live/departments_live.ex:335
-#: lib/lemmings_os_web/live/departments_live.ex:361
-#: lib/lemmings_os_web/live/world_live.ex:182
-#: lib/lemmings_os_web/live/world_live.ex:240
-#: lib/lemmings_os_web/live/world_live.ex:263
+#: lib/lemmings_os_web/live/cities_live.ex:300
+#: lib/lemmings_os_web/live/cities_live.ex:304
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/cities_live.ex:391
+#: lib/lemmings_os_web/live/departments_live.ex:289
+#: lib/lemmings_os_web/live/departments_live.ex:293
+#: lib/lemmings_os_web/live/departments_live.ex:352
+#: lib/lemmings_os_web/live/departments_live.ex:386
+#: lib/lemmings_os_web/live/world_live.ex:196
+#: lib/lemmings_os_web/live/world_live.ex:200
+#: lib/lemmings_os_web/live/world_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:288
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr "Payload de conexion invalido. Usa YAML o JSON valido."
 
-#: lib/lemmings_os_web/live/cities_live.ex:302
-#: lib/lemmings_os_web/live/cities_live.ex:334
-#: lib/lemmings_os_web/live/cities_live.ex:369
-#: lib/lemmings_os_web/live/cities_live.ex:392
-#: lib/lemmings_os_web/live/cities_live.ex:420
-#: lib/lemmings_os_web/live/departments_live.ex:296
-#: lib/lemmings_os_web/live/departments_live.ex:329
-#: lib/lemmings_os_web/live/departments_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:387
-#: lib/lemmings_os_web/live/departments_live.ex:415
-#: lib/lemmings_os_web/live/world_live.ex:202
-#: lib/lemmings_os_web/live/world_live.ex:234
-#: lib/lemmings_os_web/live/world_live.ex:266
-#: lib/lemmings_os_web/live/world_live.ex:286
-#: lib/lemmings_os_web/live/world_live.ex:309
+#: lib/lemmings_os_web/live/cities_live.ex:320
+#: lib/lemmings_os_web/live/cities_live.ex:352
+#: lib/lemmings_os_web/live/cities_live.ex:394
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:445
+#: lib/lemmings_os_web/live/departments_live.ex:313
+#: lib/lemmings_os_web/live/departments_live.ex:346
+#: lib/lemmings_os_web/live/departments_live.ex:389
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:440
+#: lib/lemmings_os_web/live/world_live.ex:220
+#: lib/lemmings_os_web/live/world_live.ex:252
+#: lib/lemmings_os_web/live/world_live.ex:291
+#: lib/lemmings_os_web/live/world_live.ex:311
+#: lib/lemmings_os_web/live/world_live.ex:334
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr "Solo se pueden cambiar conexiones locales aqui."
 
-#: lib/lemmings_os_web/live/world_live.ex:186
+#: lib/lemmings_os_web/live/world_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr "El alcance no esta disponible."
 
-#: lib/lemmings_os_web/live/cities_live.ex:413
-#: lib/lemmings_os_web/live/departments_live.ex:408
-#: lib/lemmings_os_web/live/world_live.ex:305
+#: lib/lemmings_os_web/live/cities_live.ex:438
+#: lib/lemmings_os_web/live/departments_live.ex:433
+#: lib/lemmings_os_web/live/world_live.ex:330
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr "Estado de conexion actualizado."
 
-#: lib/lemmings_os_web/connections_surface.ex:108
+#: lib/lemmings_os_web/connections_surface.ex:218
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_test_failed"
 msgstr "Fallo la prueba de conexion."
 
-#: lib/lemmings_os_web/live/cities_live.ex:431
-#: lib/lemmings_os_web/live/departments_live.ex:426
-#: lib/lemmings_os_web/live/world_live.ex:318
+#: lib/lemmings_os_web/live/cities_live.ex:456
+#: lib/lemmings_os_web/live/departments_live.ex:451
+#: lib/lemmings_os_web/live/world_live.ex:343
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr "Conexion probada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:358
-#: lib/lemmings_os_web/live/departments_live.ex:353
-#: lib/lemmings_os_web/live/world_live.ex:256
+#: lib/lemmings_os_web/live/cities_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:377
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr "Conexion actualizada."
 
-#: lib/lemmings_os_web/components/connections_components.ex:106
-#: lib/lemmings_os_web/components/connections_components.ex:304
+#: lib/lemmings_os_web/components/connections_components.ex:122
+#: lib/lemmings_os_web/components/connections_components.ex:336
 #, elixir-autogen, elixir-format
 msgid ".connections_label_config_json"
 msgstr "Config JSON"
 
-#: lib/lemmings_os_web/components/connections_components.ex:82
-#: lib/lemmings_os_web/components/connections_components.ex:140
-#: lib/lemmings_os_web/components/connections_components.ex:284
+#: lib/lemmings_os_web/components/connections_components.ex:85
+#: lib/lemmings_os_web/components/connections_components.ex:159
+#: lib/lemmings_os_web/components/connections_components.ex:302
 #, elixir-autogen, elixir-format
 msgid ".connections_label_type"
 msgstr "Tipo"
 
-#: lib/lemmings_os_web/components/connections_components.ex:333
+#: lib/lemmings_os_web/components/connections_components.ex:490
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_city"
 msgstr "Alcance City"
 
-#: lib/lemmings_os_web/components/connections_components.ex:334
+#: lib/lemmings_os_web/components/connections_components.ex:491
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_department"
 msgstr "Alcance Department"
 
-#: lib/lemmings_os_web/components/connections_components.ex:50
-#: lib/lemmings_os_web/components/connections_components.ex:335
+#: lib/lemmings_os_web/components/connections_components.ex:53
+#: lib/lemmings_os_web/components/connections_components.ex:492
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_unavailable"
 msgstr "No hay registro de alcance disponible."
 
-#: lib/lemmings_os_web/components/connections_components.ex:332
+#: lib/lemmings_os_web/components/connections_components.ex:489
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_world"
 msgstr "Alcance World"
 
-#: lib/lemmings_os_web/connections_surface.ex:88
+#: lib/lemmings_os_web/connections_surface.ex:191
 #, elixir-autogen, elixir-format
 msgid ".connections_source_city"
 msgstr "City"
 
-#: lib/lemmings_os_web/connections_surface.ex:89
+#: lib/lemmings_os_web/connections_surface.ex:192
 #, elixir-autogen, elixir-format
 msgid ".connections_source_department"
 msgstr "Department"
 
-#: lib/lemmings_os_web/connections_surface.ex:83
+#: lib/lemmings_os_web/connections_surface.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_source_inherited"
 msgstr "Heredada"
 
-#: lib/lemmings_os_web/connections_surface.ex:80
+#: lib/lemmings_os_web/connections_surface.ex:183
 #, elixir-autogen, elixir-format
 msgid ".connections_source_local"
 msgstr "Local"
 
-#: lib/lemmings_os_web/connections_surface.ex:85
-#: lib/lemmings_os_web/connections_surface.ex:90
+#: lib/lemmings_os_web/connections_surface.ex:188
+#: lib/lemmings_os_web/connections_surface.ex:193
 #, elixir-autogen, elixir-format
 msgid ".connections_source_unknown"
 msgstr "Desconocido"
 
-#: lib/lemmings_os_web/connections_surface.ex:87
+#: lib/lemmings_os_web/connections_surface.ex:190
 #, elixir-autogen, elixir-format
 msgid ".connections_source_world"
 msgstr "World"
 
-#: lib/lemmings_os_web/components/world_components.ex:237
-#: lib/lemmings_os_web/components/world_components.ex:842
+#: lib/lemmings_os_web/components/world_components.ex:243
+#: lib/lemmings_os_web/components/world_components.ex:852
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
 msgstr "Conexiones"
 
-#: lib/lemmings_os_web/components/connections_components.ex:38
+#: lib/lemmings_os_web/components/connections_components.ex:40
 #, elixir-autogen, elixir-format
 msgid ".subtitle_connections"
 msgstr "Visibilidad de alcance y herencia en modo solo lectura."
 
-#: lib/lemmings_os_web/components/connections_components.ex:37
-#: lib/lemmings_os_web/components/connections_components.ex:55
-#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:39
+#: lib/lemmings_os_web/components/connections_components.ex:58
+#: lib/lemmings_os_web/components/connections_components.ex:154
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
 msgstr "Conexiones"
@@ -1089,8 +1093,8 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:35
 #: lib/lemmings_os_web/components/lemming_components.ex:399
 #: lib/lemmings_os_web/components/lemming_components.ex:1100
-#: lib/lemmings_os_web/components/world_components.ex:246
-#: lib/lemmings_os_web/components/world_components.ex:852
+#: lib/lemmings_os_web/components/world_components.ex:252
+#: lib/lemmings_os_web/components/world_components.ex:862
 #: lib/lemmings_os_web/live/cities_live.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
@@ -1164,4 +1168,29 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "world"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:172
+#, elixir-autogen, elixir-format
+msgid "Connect Gmail"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:162
+#, elixir-autogen, elixir-format
+msgid "Connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:149
+#, elixir-autogen, elixir-format
+msgid "Not available"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:164
+#, elixir-autogen, elixir-format
+msgid "Not connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:170
+#, elixir-autogen, elixir-format
+msgid "Reconnect Gmail"
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/lemmings.po
+++ b/priv/gettext/es/LC_MESSAGES/lemmings.po
@@ -631,19 +631,19 @@ msgstr "Identificador estable usado en URLs y registros de topología. Se genera
 msgid ".tooltip_create_status"
 msgstr "Estado inicial del ciclo de vida para el nuevo tipo de lemming."
 
-#: lib/lemmings_os_web/components/instance_components.ex:915
+#: lib/lemmings_os_web/components/instance_components.ex:916
 #: lib/lemmings_os_web/live/instance_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:908
 #: lib/lemmings_os_web/live/instance_live.ex:703
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:901
+#: lib/lemmings_os_web/components/instance_components.ex:902
 #: lib/lemmings_os_web/live/instance_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
@@ -654,7 +654,7 @@ msgstr ""
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:968
+#: lib/lemmings_os_web/components/instance_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -674,7 +674,7 @@ msgstr ""
 msgid "Conversation Transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:66
+#: lib/lemmings_os_web/components/instance_components.ex:67
 #: lib/lemmings_os_web/live/instance_live.html.heex:186
 #: lib/lemmings_os_web/live/instance_raw_live.html.heex:260
 #, elixir-autogen, elixir-format
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Current status: %{status}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:102
+#: lib/lemmings_os_web/components/instance_components.ex:103
 #, elixir-autogen, elixir-format
 msgid "Elapsed"
 msgstr ""
@@ -701,13 +701,13 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1018
+#: lib/lemmings_os_web/components/instance_components.ex:1019
 #: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:54
+#: lib/lemmings_os_web/components/instance_components.ex:55
 #, elixir-autogen, elixir-format
 msgid "Failure detail"
 msgstr ""
@@ -723,13 +723,13 @@ msgstr ""
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:858
+#: lib/lemmings_os_web/components/instance_components.ex:859
 #: lib/lemmings_os_web/live/instance_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:192
+#: lib/lemmings_os_web/components/instance_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Input %{count} tokens"
 msgstr ""
@@ -788,7 +788,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:195
+#: lib/lemmings_os_web/components/instance_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Output %{count} tokens"
 msgstr ""
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:845
+#: lib/lemmings_os_web/components/instance_components.ex:846
 #: lib/lemmings_os_web/live/instance_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:78
+#: lib/lemmings_os_web/components/instance_components.ex:79
 #: lib/lemmings_os_web/live/instance_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
@@ -820,15 +820,15 @@ msgstr ""
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:828
-#: lib/lemmings_os_web/components/instance_components.ex:851
+#: lib/lemmings_os_web/components/instance_components.ex:829
+#: lib/lemmings_os_web/components/instance_components.ex:852
 #: lib/lemmings_os_web/live/instance_live.ex:628
 #: lib/lemmings_os_web/live/instance_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:90
+#: lib/lemmings_os_web/components/instance_components.ex:91
 #: lib/lemmings_os_web/live/instance_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Retry state"
@@ -850,13 +850,13 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:864
+#: lib/lemmings_os_web/components/instance_components.ex:865
 #: lib/lemmings_os_web/live/instance_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:863
+#: lib/lemmings_os_web/components/instance_components.ex:864
 #: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
@@ -883,8 +883,8 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:839
-#: lib/lemmings_os_web/components/instance_components.ex:865
+#: lib/lemmings_os_web/components/instance_components.ex:840
+#: lib/lemmings_os_web/components/instance_components.ex:866
 #: lib/lemmings_os_web/live/instance_live.ex:636
 #: lib/lemmings_os_web/live/instance_live.ex:650
 #: lib/lemmings_os_web/live/instance_live.ex:652
@@ -906,7 +906,7 @@ msgstr ""
 msgid "This request will reuse the current transcript context."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:198
+#: lib/lemmings_os_web/components/instance_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Total %{count} tokens"
 msgstr ""
@@ -922,8 +922,8 @@ msgstr ""
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1129
-#: lib/lemmings_os_web/components/instance_components.ex:1251
+#: lib/lemmings_os_web/components/instance_components.ex:1141
+#: lib/lemmings_os_web/components/instance_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
@@ -933,12 +933,12 @@ msgstr ""
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:970
+#: lib/lemmings_os_web/components/instance_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:842
+#: lib/lemmings_os_web/components/instance_components.ex:843
 #: lib/lemmings_os_web/live/instance_live.ex:637
 #: lib/lemmings_os_web/live/instance_live.ex:655
 #: lib/lemmings_os_web/live/instance_live.ex:781
@@ -956,7 +956,7 @@ msgstr ""
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:896
+#: lib/lemmings_os_web/components/instance_components.ex:897
 #: lib/lemmings_os_web/live/instance_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Only failed instances can be retried."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:116
+#: lib/lemmings_os_web/components/instance_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Operator action"
 msgstr ""
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Retry requested for this instance."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:119
+#: lib/lemmings_os_web/components/instance_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Retry the latest failed request."
 msgstr ""
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1257
+#: lib/lemmings_os_web/components/instance_components.ex:1344
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1480,22 +1480,22 @@ msgstr "Dashboard runtime"
 msgid ".title_spawn_instance"
 msgstr "Lanzar instancia"
 
-#: lib/lemmings_os_web/components/instance_components.ex:1151
+#: lib/lemmings_os_web/components/instance_components.ex:1163
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1145
+#: lib/lemmings_os_web/components/instance_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1154
+#: lib/lemmings_os_web/components/instance_components.ex:1166
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:526
+#: lib/lemmings_os_web/components/instance_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1510,8 +1510,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:711
-#: lib/lemmings_os_web/components/instance_components.ex:1017
+#: lib/lemmings_os_web/components/instance_components.ex:712
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1526,12 +1526,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:546
+#: lib/lemmings_os_web/components/instance_components.ex:547
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:520
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1577,12 +1577,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:536
+#: lib/lemmings_os_web/components/instance_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1016
+#: lib/lemmings_os_web/components/instance_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1602,37 +1602,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:273
+#: lib/lemmings_os_web/components/instance_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1027
+#: lib/lemmings_os_web/components/instance_components.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1033
+#: lib/lemmings_os_web/components/instance_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1035
+#: lib/lemmings_os_web/components/instance_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1024
+#: lib/lemmings_os_web/components/instance_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1039
+#: lib/lemmings_os_web/components/instance_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:275
+#: lib/lemmings_os_web/components/instance_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1647,22 +1647,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:753
+#: lib/lemmings_os_web/components/instance_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:929
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:778
+#: lib/lemmings_os_web/components/instance_components.ex:779
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:663
+#: lib/lemmings_os_web/components/instance_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1677,7 +1677,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1203
+#: lib/lemmings_os_web/components/instance_components.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1687,20 +1687,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:721
+#: lib/lemmings_os_web/components/instance_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:585
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/instance_components.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:624
+#: lib/lemmings_os_web/components/instance_components.ex:669
+#: lib/lemmings_os_web/components/world_components.ex:924
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1710,18 +1710,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:899
+#: lib/lemmings_os_web/components/world_components.ex:909
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:693
+#: lib/lemmings_os_web/components/instance_components.ex:694
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:769
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:770
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1731,18 +1731,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:897
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:708
+#: lib/lemmings_os_web/components/instance_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:731
+#: lib/lemmings_os_web/components/instance_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1757,17 +1757,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1214
+#: lib/lemmings_os_web/components/instance_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1209
+#: lib/lemmings_os_web/components/instance_components.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:671
+#: lib/lemmings_os_web/components/instance_components.ex:672
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1797,12 +1797,12 @@ msgstr ""
 msgid "Workspace path copied."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1122
+#: lib/lemmings_os_web/components/instance_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid "%{count} bytes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:359
+#: lib/lemmings_os_web/components/instance_components.ex:360
 #, elixir-autogen, elixir-format
 msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
 msgstr ""
@@ -1827,7 +1827,7 @@ msgstr ""
 msgid "Artifact promoted: %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:342
+#: lib/lemmings_os_web/components/instance_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Artifact promotion"
 msgstr ""
@@ -1872,22 +1872,22 @@ msgstr ""
 msgid "Choose a valid promotion action for this Artifact."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:492
+#: lib/lemmings_os_web/components/instance_components.ex:493
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:486
+#: lib/lemmings_os_web/components/instance_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Download Artifact %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:506
+#: lib/lemmings_os_web/components/instance_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -1902,33 +1902,33 @@ msgstr ""
 msgid "Only regular files can be promoted as Artifacts."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:438
+#: lib/lemmings_os_web/components/instance_components.ex:439
 #, elixir-autogen, elixir-format
 msgid "Promote as New Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:433
+#: lib/lemmings_os_web/components/instance_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "Promote as new Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:408
+#: lib/lemmings_os_web/components/instance_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "Promote to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Promote workspace file to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:374
+#: lib/lemmings_os_web/components/instance_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Promoted"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:402
-#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Promoting..."
 msgstr ""
@@ -1938,7 +1938,7 @@ msgstr ""
 msgid "Runtime instance not found for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:352
+#: lib/lemmings_os_web/components/instance_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Show Artifact help"
 msgstr ""
@@ -1953,22 +1953,22 @@ msgstr ""
 msgid "Unable to promote this file right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1124
+#: lib/lemmings_os_web/components/instance_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Unknown size"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:423
+#: lib/lemmings_os_web/components/instance_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "Update Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:418
+#: lib/lemmings_os_web/components/instance_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "Update existing Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:417
+#: lib/lemmings_os_web/components/instance_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "Updating..."
 msgstr ""
@@ -1984,7 +1984,22 @@ msgstr ""
 msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:182
+#: lib/lemmings_os_web/components/instance_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "View/Edit memory"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1200
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1197
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1203
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation recorded."
 msgstr ""

--- a/priv/gettext/es/LC_MESSAGES/world.po
+++ b/priv/gettext/es/LC_MESSAGES/world.po
@@ -38,12 +38,12 @@ msgstr "Desconocido"
 
 #: lib/lemmings_os/helpers.ex:130
 #: lib/lemmings_os/helpers.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:1346
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/components/world_components.ex:1393
-#: lib/lemmings_os_web/components/world_components.ex:1410
-#: lib/lemmings_os_web/components/world_components.ex:1414
-#: lib/lemmings_os_web/components/world_components.ex:1435
+#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1422
+#: lib/lemmings_os_web/components/world_components.ex:1426
+#: lib/lemmings_os_web/components/world_components.ex:1447
 #: lib/lemmings_os_web/live/instance_live.ex:470
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
@@ -75,40 +75,40 @@ msgstr "Nodo de departamento"
 msgid ".aria_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:789
+#: lib/lemmings_os_web/components/world_components.ex:799
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr "Todos los departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:266
-#: lib/lemmings_os_web/components/world_components.ex:557
+#: lib/lemmings_os_web/components/world_components.ex:272
+#: lib/lemmings_os_web/components/world_components.ex:565
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr "Importar bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:736
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr "Abrir departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:105
-#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:111
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr "Actualizar mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:448
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr "Aquí aparecerá el resumen de ciudades cuando exista una fuente real."
 
-#: lib/lemmings_os_web/components/world_components.ex:461
+#: lib/lemmings_os_web/components/world_components.ex:467
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr "Aquí aparecerá el resumen de herramientas cuando exista una fuente real."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:128
+#: lib/lemmings_os_web/live/departments_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr "%{count} departamentos"
@@ -118,178 +118,178 @@ msgstr "%{count} departamentos"
 msgid ".count_running_of_total"
 msgstr "%{running} de %{total} en ejecución"
 
-#: lib/lemmings_os_web/components/world_components.ex:677
-#: lib/lemmings_os_web/live/departments_live.html.heex:56
-#: lib/lemmings_os_web/live/departments_live.html.heex:135
+#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/live/departments_live.html.heex:58
+#: lib/lemmings_os_web/live/departments_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr "Aún no hay departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:678
-#: lib/lemmings_os_web/live/departments_live.html.heex:57
-#: lib/lemmings_os_web/live/departments_live.html.heex:136
+#: lib/lemmings_os_web/components/world_components.ex:686
+#: lib/lemmings_os_web/live/departments_live.html.heex:59
+#: lib/lemmings_os_web/live/departments_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr "Crea o importa un departamento para verlo aquí."
 
-#: lib/lemmings_os_web/components/world_components.ex:562
+#: lib/lemmings_os_web/components/world_components.ex:570
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr "No hay snapshot del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:563
+#: lib/lemmings_os_web/components/world_components.ex:571
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr "Importa el bootstrap o actualiza el estado para ver el snapshot actual."
 
-#: lib/lemmings_os_web/components/world_components.ex:350
+#: lib/lemmings_os_web/components/world_components.ex:356
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr "Ruta del bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:345
+#: lib/lemmings_os_web/components/world_components.ex:351
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr "Fuente del bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:422
-#: lib/lemmings_os_web/components/world_components.ex:651
+#: lib/lemmings_os_web/components/world_components.ex:428
+#: lib/lemmings_os_web/components/world_components.ex:659
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr "Presupuestos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1365
+#: lib/lemmings_os_web/components/world_components.ex:1377
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1374
+#: lib/lemmings_os_web/components/world_components.ex:1386
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr "Declarado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr "Deps."
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:759
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr "Vacío"
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:132
+#: lib/lemmings_os_web/components/world_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr "Importación inmediata"
 
-#: lib/lemmings_os_web/components/world_components.ex:300
+#: lib/lemmings_os_web/components/world_components.ex:306
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr "Hash del último bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:296
+#: lib/lemmings_os_web/components/world_components.ex:302
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr "Última importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:144
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:150
+#: lib/lemmings_os_web/components/world_components.ex:294
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr "Última sincronización"
 
-#: lib/lemmings_os_web/components/world_components.ex:1359
+#: lib/lemmings_os_web/components/world_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr "Lemms."
 
-#: lib/lemmings_os_web/components/world_components.ex:417
-#: lib/lemmings_os_web/components/world_components.ex:635
+#: lib/lemmings_os_web/components/world_components.ex:423
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr "Límites"
 
-#: lib/lemmings_os_web/components/world_components.ex:1348
+#: lib/lemmings_os_web/components/world_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr "Sin fallback"
 
-#: lib/lemmings_os_web/components/world_components.ex:314
+#: lib/lemmings_os_web/components/world_components.ex:320
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr "No hay incidencias del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:445
-#: lib/lemmings_os_web/components/world_components.ex:458
+#: lib/lemmings_os_web/components/world_components.ex:451
+#: lib/lemmings_os_web/components/world_components.ex:464
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr "Solo marcador"
 
-#: lib/lemmings_os_web/components/world_components.ex:432
+#: lib/lemmings_os_web/components/world_components.ex:438
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr "Secciones de marcador"
 
-#: lib/lemmings_os_web/components/world_components.ex:394
-#: lib/lemmings_os_web/components/world_components.ex:657
+#: lib/lemmings_os_web/components/world_components.ex:400
+#: lib/lemmings_os_web/components/world_components.ex:665
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr "Perfiles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1421
+#: lib/lemmings_os_web/components/world_components.ex:1433
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr "Credenciales listas"
 
-#: lib/lemmings_os_web/components/world_components.ex:1345
+#: lib/lemmings_os_web/components/world_components.ex:1357
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr "Proveedor deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1344
+#: lib/lemmings_os_web/components/world_components.ex:1356
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr "Proveedor habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:369
+#: lib/lemmings_os_web/components/world_components.ex:375
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr "Proveedores"
 
-#: lib/lemmings_os_web/components/world_components.ex:750
+#: lib/lemmings_os_web/components/world_components.ex:758
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr "Cola"
 
-#: lib/lemmings_os_web/components/world_components.ex:427
-#: lib/lemmings_os_web/components/world_components.ex:643
+#: lib/lemmings_os_web/components/world_components.ex:433
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr "Valores por defecto del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1430
-#: lib/lemmings_os_web/components/world_components.ex:1431
+#: lib/lemmings_os_web/components/world_components.ex:1442
+#: lib/lemmings_os_web/components/world_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr "Diferido por el entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:1387
+#: lib/lemmings_os_web/components/world_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr "ID del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:885
-#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:895
+#: lib/lemmings_os_web/components/world_components.ex:1400
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -329,22 +329,22 @@ msgstr "En línea"
 msgid ".metric_status"
 msgstr "Estado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1396
+#: lib/lemmings_os_web/components/world_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr "Archivo bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:1399
+#: lib/lemmings_os_web/components/world_components.ex:1411
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr "Conexión a Postgres"
 
-#: lib/lemmings_os_web/components/world_components.ex:1402
+#: lib/lemmings_os_web/components/world_components.ex:1414
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr "Credenciales del proveedor"
 
-#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr "Alcance del proveedor"
@@ -375,23 +375,23 @@ msgstr "En línea"
 msgid ".subtitle_all_cities"
 msgstr "Ciudades registradas en este mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:210
+#: lib/lemmings_os_web/components/world_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr "Bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:201
+#: lib/lemmings_os_web/components/world_components.ex:207
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr "Importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:192
+#: lib/lemmings_os_web/components/world_components.ex:198
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:219
+#: lib/lemmings_os_web/components/world_components.ex:225
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr "Entorno"
@@ -401,45 +401,45 @@ msgstr "Entorno"
 msgid ".title_all_cities"
 msgstr "Todas las ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:158
-#: lib/lemmings_os_web/components/world_components.ex:339
+#: lib/lemmings_os_web/components/world_components.ex:164
+#: lib/lemmings_os_web/components/world_components.ex:345
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr "Configuración bootstrap"
 
-#: lib/lemmings_os_web/components/world_components.ex:671
-#: lib/lemmings_os_web/live/departments_live.html.heex:124
+#: lib/lemmings_os_web/components/world_components.ex:679
+#: lib/lemmings_os_web/live/departments_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr "Departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:129
-#: lib/lemmings_os_web/components/world_components.ex:258
+#: lib/lemmings_os_web/components/world_components.ex:135
+#: lib/lemmings_os_web/components/world_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr "Estado de importación"
 
-#: lib/lemmings_os_web/components/world_components.ex:172
-#: lib/lemmings_os_web/components/world_components.ex:469
+#: lib/lemmings_os_web/components/world_components.ex:178
+#: lib/lemmings_os_web/components/world_components.ex:475
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr "Verificaciones del entorno"
 
-#: lib/lemmings_os_web/components/world_components.ex:441
+#: lib/lemmings_os_web/components/world_components.ex:447
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr "Ciudades del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:361
-#: lib/lemmings_os_web/components/world_components.ex:546
-#: lib/lemmings_os_web/components/world_components.ex:880
+#: lib/lemmings_os_web/components/world_components.ex:120
+#: lib/lemmings_os_web/components/world_components.ex:367
+#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:890
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr "Identidad del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:309
+#: lib/lemmings_os_web/components/world_components.ex:315
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr "Incidencias del mundo"
@@ -449,12 +449,12 @@ msgstr "Incidencias del mundo"
 msgid ".title_world_map"
 msgstr "Mapa del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:97
+#: lib/lemmings_os_web/components/world_components.ex:103
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr "Estado del mundo"
 
-#: lib/lemmings_os_web/components/world_components.ex:454
+#: lib/lemmings_os_web/components/world_components.ex:460
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr "Herramientas del mundo"
@@ -469,13 +469,13 @@ msgstr "Departamento"
 msgid ".tooltip_running"
 msgstr "En ejecución"
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr "Se resuelve a partir de las capas persistidas World y City."
 
-#: lib/lemmings_os_web/components/world_components.ex:875
-#: lib/lemmings_os_web/live/departments_live.html.heex:51
+#: lib/lemmings_os_web/components/world_components.ex:885
+#: lib/lemmings_os_web/live/departments_live.html.heex:53
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr "Ciudades"
@@ -534,7 +534,7 @@ msgstr "Nodo BEAM"
 msgid ".label_city_slug"
 msgstr "Slug"
 
-#: lib/lemmings_os_web/components/world_components.ex:629
+#: lib/lemmings_os_web/components/world_components.ex:637
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr "Configuración efectiva de la ciudad"
@@ -604,7 +604,7 @@ msgstr "Nombre del nodo BEAM"
 msgid ".city_form_node_name_placeholder"
 msgstr "ej. app@hostname"
 
-#: lib/lemmings_os_web/components/world_components.ex:870
+#: lib/lemmings_os_web/components/world_components.ex:880
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -645,268 +645,268 @@ msgstr "Crear ciudad"
 msgid ".city_form_submit_update"
 msgstr "Guardar cambios"
 
-#: lib/lemmings_os_web/live/cities_live.ex:508
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr "Ciudad creada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:533
+#: lib/lemmings_os_web/live/cities_live.ex:558
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr "Ciudad actualizada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:146
+#: lib/lemmings_os_web/live/cities_live.ex:148
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr "Ciudad eliminada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:102
-#: lib/lemmings_os_web/live/cities_live.ex:155
+#: lib/lemmings_os_web/live/cities_live.ex:104
+#: lib/lemmings_os_web/live/cities_live.ex:157
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr "Ciudad no encontrada."
 
-#: lib/lemmings_os_web/live/cities_live.ex:518
 #: lib/lemmings_os_web/live/cities_live.ex:543
+#: lib/lemmings_os_web/live/cities_live.ex:568
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr "No se pudo guardar la ciudad. Revisá el formulario."
 
-#: lib/lemmings_os_web/live/cities_live.ex:152
+#: lib/lemmings_os_web/live/cities_live.ex:154
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr "No se pudo eliminar la ciudad."
 
-#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr "Abrir departamentos"
 
-#: lib/lemmings_os_web/components/world_components.ex:684
+#: lib/lemmings_os_web/components/world_components.ex:692
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr "%{city} tiene %{count} departamentos."
 
-#: lib/lemmings_os_web/components/world_components.ex:672
+#: lib/lemmings_os_web/components/world_components.ex:680
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr "Resumen compacto de los departamentos persistidos para esta city."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:99
+#: lib/lemmings_os_web/live/departments_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr "Cambiá la city activa para el mapa y la lista de departamentos."
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:98
-#: lib/lemmings_os_web/live/departments_live.html.heex:117
+#: lib/lemmings_os_web/live/departments_live.html.heex:100
+#: lib/lemmings_os_web/live/departments_live.html.heex:119
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr "City seleccionada"
 
-#: lib/lemmings_os_web/components/world_components.ex:965
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr "Activar"
 
-#: lib/lemmings_os_web/components/world_components.ex:993
+#: lib/lemmings_os_web/components/world_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr "Borrar"
 
-#: lib/lemmings_os_web/components/world_components.ex:983
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr "Deshabilitar"
 
-#: lib/lemmings_os_web/components/world_components.ex:974
+#: lib/lemmings_os_web/components/world_components.ex:984
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr "Drenar"
 
-#: lib/lemmings_os_web/components/world_components.ex:1217
+#: lib/lemmings_os_web/components/world_components.ex:1227
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr "Guardar ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:1000
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr "¿Seguro que quieres borrar este departamento?"
 
-#: lib/lemmings_os_web/components/world_components.ex:937
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr "Nombre"
 
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:957
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr "Notas"
 
-#: lib/lemmings_os_web/components/world_components.ex:942
+#: lib/lemmings_os_web/components/world_components.ex:952
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr "Tags"
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr "No hay lemmings disponibles"
 
-#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1038
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr "Todavía no hay lemmings con respaldo de runtime ni vista mock para este departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:1003
+#: lib/lemmings_os_web/components/world_components.ex:1013
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:954
+#: lib/lemmings_os_web/components/world_components.ex:964
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr "Acciones de ciclo de vida"
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:965
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr "Usa los controles persistidos del ciclo de vida del departamento. El borrado sigue protegido por checks de seguridad."
 
-#: lib/lemmings_os_web/components/world_components.ex:933
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr "Metadatos"
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1145
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1122
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1204
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr "Comunicación entre ciudades"
 
-#: lib/lemmings_os_web/components/world_components.ex:1117
-#: lib/lemmings_os_web/components/world_components.ex:1154
-#: lib/lemmings_os_web/components/world_components.ex:1209
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr "Tokens diarios"
 
-#: lib/lemmings_os_web/components/world_components.ex:1198
+#: lib/lemmings_os_web/components/world_components.ex:1208
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr "Deshabilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1197
+#: lib/lemmings_os_web/components/world_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr "Habilitado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1107
-#: lib/lemmings_os_web/components/world_components.ex:1138
-#: lib/lemmings_os_web/components/world_components.ex:1188
+#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr "Segundos TTL inactivo"
 
-#: lib/lemmings_os_web/components/world_components.ex:1196
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr "Heredar"
 
-#: lib/lemmings_os_web/components/world_components.ex:1102
-#: lib/lemmings_os_web/components/world_components.ex:1129
-#: lib/lemmings_os_web/components/world_components.ex:1179
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr "Máximo de lemmings por departamento"
 
-#: lib/lemmings_os_web/components/world_components.ex:1098
+#: lib/lemmings_os_web/components/world_components.ex:1108
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr "Valores efectivos después de resolver las capas de Mundo, Ciudad y Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:1097
+#: lib/lemmings_os_web/components/world_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr "Configuración efectiva"
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr "Solo los overrides locales del Departamento persistidos en esta fila. Los valores vacíos heredan desde Ciudad o Mundo."
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr "Overrides locales"
 
-#: lib/lemmings_os_web/components/world_components.ex:1165
+#: lib/lemmings_os_web/components/world_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr "Editor V1. Actualiza de forma segura un subconjunto pequeño de overrides locales del Departamento."
 
-#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1174
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr "Editor de ajustes"
 
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:822
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr "Lemmings"
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:812
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr "Resumen"
 
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:832
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr "Ajustes"
 
-#: lib/lemmings_os_web/live/departments_live.ex:670
+#: lib/lemmings_os_web/live/departments_live.ex:703
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr "Departamento activado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:118
+#: lib/lemmings_os_web/live/departments_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr "Departamento borrado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:672
+#: lib/lemmings_os_web/live/departments_live.ex:705
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr "Departamento deshabilitado."
 
-#: lib/lemmings_os_web/live/departments_live.ex:671
+#: lib/lemmings_os_web/live/departments_live.ex:704
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr "Departamento puesto en drenaje."
 
-#: lib/lemmings_os_web/live/departments_live.ex:132
+#: lib/lemmings_os_web/live/departments_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr "No se pudo actualizar el ciclo de vida del departamento."
 
-#: lib/lemmings_os_web/live/departments_live.ex:102
+#: lib/lemmings_os_web/live/departments_live.ex:104
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr "Ajustes del departamento guardados."
 
-#: lib/lemmings_os_web/live/departments_live.ex:673
+#: lib/lemmings_os_web/live/departments_live.ex:706
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr "Departamento actualizado."
 
-#: lib/lemmings_os_web/components/world_components.ex:1012
+#: lib/lemmings_os_web/components/world_components.ex:1022
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1004
+#: lib/lemmings_os_web/components/world_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -992,15 +992,15 @@ msgstr "¿Eliminar este valor secreto local?"
 msgid ".secret_delete_label"
 msgstr "Eliminar secreto local %{key}"
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
-#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/cities_live.ex:208
+#: lib/lemmings_os_web/live/departments_live.ex:193
 #: lib/lemmings_os_web/live/lemmings_live.ex:188
-#: lib/lemmings_os_web/live/world_live.ex:103
+#: lib/lemmings_os_web/live/world_live.ex:105
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr "Secreto local eliminado"
 
-#: lib/lemmings_os_web/components/world_components.ex:1234
+#: lib/lemmings_os_web/components/world_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr "Valores write-only del Secret Bank con alcance a este departamento."
@@ -1110,10 +1110,10 @@ msgstr "Guardar secreto"
 msgid ".secret_save_pending"
 msgstr "Guardando secreto..."
 
-#: lib/lemmings_os_web/live/cities_live.ex:166
-#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/cities_live.ex:168
+#: lib/lemmings_os_web/live/departments_live.ex:150
 #: lib/lemmings_os_web/live/lemmings_live.ex:148
-#: lib/lemmings_os_web/live/world_live.ex:65
+#: lib/lemmings_os_web/live/world_live.ex:67
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr "Secreto guardado"
@@ -1131,8 +1131,8 @@ msgstr "Valor secreto"
 #: lib/lemmings_os_web/components/lemming_components.ex:383
 #: lib/lemmings_os_web/components/lemming_components.ex:1098
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:228
-#: lib/lemmings_os_web/components/world_components.ex:832
+#: lib/lemmings_os_web/components/world_components.ex:234
+#: lib/lemmings_os_web/components/world_components.ex:842
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/priv/gettext/layout.pot
+++ b/priv/gettext/layout.pot
@@ -74,7 +74,7 @@ msgid ".nav_departments"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:170
-#: lib/lemmings_os_web/components/world_components.ex:699
+#: lib/lemmings_os_web/components/world_components.ex:707
 #: lib/lemmings_os_web/live/mock_shell.ex:49
 #, elixir-autogen
 msgid ".nav_lemmings"
@@ -102,7 +102,7 @@ msgid ".nav_settings"
 msgstr ""
 
 #: lib/lemmings_os_web/components/sidebar_components.ex:71
-#: lib/lemmings_os_web/components/world_components.ex:1036
+#: lib/lemmings_os_web/components/world_components.ex:1046
 #, elixir-autogen
 msgid ".button_new_lemming"
 msgstr ""
@@ -846,231 +846,235 @@ msgstr ""
 msgid ".tools_risk_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:116
-#: lib/lemmings_os_web/components/connections_components.ex:321
+#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:353
+#: lib/lemmings_os_web/components/connections_components.ex:470
 #, elixir-autogen, elixir-format
 msgid ".connections_action_cancel"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:66
+#: lib/lemmings_os_web/components/connections_components.ex:69
 #, elixir-autogen, elixir-format
 msgid ".connections_action_create"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:253
-#: lib/lemmings_os_web/components/connections_components.ex:254
+#: lib/lemmings_os_web/components/connections_components.ex:272
+#: lib/lemmings_os_web/components/connections_components.ex:273
 #, elixir-autogen, elixir-format
 msgid ".connections_action_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:229
-#: lib/lemmings_os_web/components/connections_components.ex:230
+#: lib/lemmings_os_web/components/connections_components.ex:248
+#: lib/lemmings_os_web/components/connections_components.ex:249
 #, elixir-autogen, elixir-format
 msgid ".connections_action_disable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:241
-#: lib/lemmings_os_web/components/connections_components.ex:242
+#: lib/lemmings_os_web/components/connections_components.ex:260
+#: lib/lemmings_os_web/components/connections_components.ex:261
 #, elixir-autogen, elixir-format
 msgid ".connections_action_edit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:216
-#: lib/lemmings_os_web/components/connections_components.ex:217
+#: lib/lemmings_os_web/components/connections_components.ex:235
+#: lib/lemmings_os_web/components/connections_components.ex:236
 #, elixir-autogen, elixir-format
 msgid ".connections_action_enable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:123
-#: lib/lemmings_os_web/components/connections_components.ex:313
+#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:345
 #, elixir-autogen, elixir-format
 msgid ".connections_action_save"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:203
-#: lib/lemmings_os_web/components/connections_components.ex:204
+#: lib/lemmings_os_web/components/connections_components.ex:222
+#: lib/lemmings_os_web/components/connections_components.ex:223
 #, elixir-autogen, elixir-format
 msgid ".connections_action_test"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:142
+#: lib/lemmings_os_web/components/connections_components.ex:161
 #, elixir-autogen, elixir-format
 msgid ".connections_column_actions"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:141
-#: lib/lemmings_os_web/components/connections_components.ex:190
+#: lib/lemmings_os_web/components/connections_components.ex:160
+#: lib/lemmings_os_web/components/connections_components.ex:209
 #, elixir-autogen, elixir-format
 msgid ".connections_column_last_test"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:139
+#: lib/lemmings_os_web/components/connections_components.ex:158
 #, elixir-autogen, elixir-format
 msgid ".connections_column_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:129
+#: lib/lemmings_os_web/components/connections_components.ex:148
 #, elixir-autogen, elixir-format
 msgid ".connections_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:271
-#: lib/lemmings_os_web/live/departments_live.ex:258
-#: lib/lemmings_os_web/live/world_live.ex:166
+#: lib/lemmings_os_web/live/cities_live.ex:284
+#: lib/lemmings_os_web/live/departments_live.ex:270
+#: lib/lemmings_os_web/live/world_live.ex:179
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_created"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:385
-#: lib/lemmings_os_web/live/departments_live.ex:380
-#: lib/lemmings_os_web/live/world_live.ex:280
+#: lib/lemmings_os_web/live/cities_live.ex:410
+#: lib/lemmings_os_web/live/departments_live.ex:405
+#: lib/lemmings_os_web/live/world_live.ex:305
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:286
-#: lib/lemmings_os_web/live/cities_live.ex:340
-#: lib/lemmings_os_web/live/cities_live.ex:366
-#: lib/lemmings_os_web/live/departments_live.ex:276
-#: lib/lemmings_os_web/live/departments_live.ex:335
-#: lib/lemmings_os_web/live/departments_live.ex:361
-#: lib/lemmings_os_web/live/world_live.ex:182
-#: lib/lemmings_os_web/live/world_live.ex:240
-#: lib/lemmings_os_web/live/world_live.ex:263
+#: lib/lemmings_os_web/live/cities_live.ex:300
+#: lib/lemmings_os_web/live/cities_live.ex:304
+#: lib/lemmings_os_web/live/cities_live.ex:358
+#: lib/lemmings_os_web/live/cities_live.ex:391
+#: lib/lemmings_os_web/live/departments_live.ex:289
+#: lib/lemmings_os_web/live/departments_live.ex:293
+#: lib/lemmings_os_web/live/departments_live.ex:352
+#: lib/lemmings_os_web/live/departments_live.ex:386
+#: lib/lemmings_os_web/live/world_live.ex:196
+#: lib/lemmings_os_web/live/world_live.ex:200
+#: lib/lemmings_os_web/live/world_live.ex:258
+#: lib/lemmings_os_web/live/world_live.ex:288
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_invalid_payload"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:302
-#: lib/lemmings_os_web/live/cities_live.ex:334
-#: lib/lemmings_os_web/live/cities_live.ex:369
-#: lib/lemmings_os_web/live/cities_live.ex:392
-#: lib/lemmings_os_web/live/cities_live.ex:420
-#: lib/lemmings_os_web/live/departments_live.ex:296
-#: lib/lemmings_os_web/live/departments_live.ex:329
-#: lib/lemmings_os_web/live/departments_live.ex:364
-#: lib/lemmings_os_web/live/departments_live.ex:387
-#: lib/lemmings_os_web/live/departments_live.ex:415
-#: lib/lemmings_os_web/live/world_live.ex:202
-#: lib/lemmings_os_web/live/world_live.ex:234
-#: lib/lemmings_os_web/live/world_live.ex:266
-#: lib/lemmings_os_web/live/world_live.ex:286
-#: lib/lemmings_os_web/live/world_live.ex:309
+#: lib/lemmings_os_web/live/cities_live.ex:320
+#: lib/lemmings_os_web/live/cities_live.ex:352
+#: lib/lemmings_os_web/live/cities_live.ex:394
+#: lib/lemmings_os_web/live/cities_live.ex:417
+#: lib/lemmings_os_web/live/cities_live.ex:445
+#: lib/lemmings_os_web/live/departments_live.ex:313
+#: lib/lemmings_os_web/live/departments_live.ex:346
+#: lib/lemmings_os_web/live/departments_live.ex:389
+#: lib/lemmings_os_web/live/departments_live.ex:412
+#: lib/lemmings_os_web/live/departments_live.ex:440
+#: lib/lemmings_os_web/live/world_live.ex:220
+#: lib/lemmings_os_web/live/world_live.ex:252
+#: lib/lemmings_os_web/live/world_live.ex:291
+#: lib/lemmings_os_web/live/world_live.ex:311
+#: lib/lemmings_os_web/live/world_live.ex:334
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_local_only"
 msgstr ""
 
-#: lib/lemmings_os_web/live/world_live.ex:186
+#: lib/lemmings_os_web/live/world_live.ex:204
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_scope_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:413
-#: lib/lemmings_os_web/live/departments_live.ex:408
-#: lib/lemmings_os_web/live/world_live.ex:305
+#: lib/lemmings_os_web/live/cities_live.ex:438
+#: lib/lemmings_os_web/live/departments_live.ex:433
+#: lib/lemmings_os_web/live/world_live.ex:330
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_status_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:108
+#: lib/lemmings_os_web/connections_surface.ex:218
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_test_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:431
-#: lib/lemmings_os_web/live/departments_live.ex:426
-#: lib/lemmings_os_web/live/world_live.ex:318
+#: lib/lemmings_os_web/live/cities_live.ex:456
+#: lib/lemmings_os_web/live/departments_live.ex:451
+#: lib/lemmings_os_web/live/world_live.ex:343
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_tested"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:358
-#: lib/lemmings_os_web/live/departments_live.ex:353
-#: lib/lemmings_os_web/live/world_live.ex:256
+#: lib/lemmings_os_web/live/cities_live.ex:382
+#: lib/lemmings_os_web/live/departments_live.ex:377
+#: lib/lemmings_os_web/live/world_live.ex:280
 #, elixir-autogen, elixir-format
 msgid ".connections_flash_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:106
-#: lib/lemmings_os_web/components/connections_components.ex:304
+#: lib/lemmings_os_web/components/connections_components.ex:122
+#: lib/lemmings_os_web/components/connections_components.ex:336
 #, elixir-autogen, elixir-format
 msgid ".connections_label_config_json"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:82
-#: lib/lemmings_os_web/components/connections_components.ex:140
-#: lib/lemmings_os_web/components/connections_components.ex:284
+#: lib/lemmings_os_web/components/connections_components.ex:85
+#: lib/lemmings_os_web/components/connections_components.ex:159
+#: lib/lemmings_os_web/components/connections_components.ex:302
 #, elixir-autogen, elixir-format
 msgid ".connections_label_type"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:333
+#: lib/lemmings_os_web/components/connections_components.ex:490
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:334
+#: lib/lemmings_os_web/components/connections_components.ex:491
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:50
-#: lib/lemmings_os_web/components/connections_components.ex:335
+#: lib/lemmings_os_web/components/connections_components.ex:53
+#: lib/lemmings_os_web/components/connections_components.ex:492
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_unavailable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:332
+#: lib/lemmings_os_web/components/connections_components.ex:489
 #, elixir-autogen, elixir-format
 msgid ".connections_scope_world"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:88
+#: lib/lemmings_os_web/connections_surface.ex:191
 #, elixir-autogen, elixir-format
 msgid ".connections_source_city"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:89
+#: lib/lemmings_os_web/connections_surface.ex:192
 #, elixir-autogen, elixir-format
 msgid ".connections_source_department"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:83
+#: lib/lemmings_os_web/connections_surface.ex:186
 #, elixir-autogen, elixir-format
 msgid ".connections_source_inherited"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:80
+#: lib/lemmings_os_web/connections_surface.ex:183
 #, elixir-autogen, elixir-format
 msgid ".connections_source_local"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:85
-#: lib/lemmings_os_web/connections_surface.ex:90
+#: lib/lemmings_os_web/connections_surface.ex:188
+#: lib/lemmings_os_web/connections_surface.ex:193
 #, elixir-autogen, elixir-format
 msgid ".connections_source_unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/connections_surface.ex:87
+#: lib/lemmings_os_web/connections_surface.ex:190
 #, elixir-autogen, elixir-format
 msgid ".connections_source_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:237
-#: lib/lemmings_os_web/components/world_components.ex:842
+#: lib/lemmings_os_web/components/world_components.ex:243
+#: lib/lemmings_os_web/components/world_components.ex:852
 #: lib/lemmings_os_web/live/cities_live.html.heex:247
 #, elixir-autogen, elixir-format
 msgid ".nav_connections"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:38
+#: lib/lemmings_os_web/components/connections_components.ex:40
 #, elixir-autogen, elixir-format
 msgid ".subtitle_connections"
 msgstr ""
 
-#: lib/lemmings_os_web/components/connections_components.ex:37
-#: lib/lemmings_os_web/components/connections_components.ex:55
-#: lib/lemmings_os_web/components/connections_components.ex:135
+#: lib/lemmings_os_web/components/connections_components.ex:39
+#: lib/lemmings_os_web/components/connections_components.ex:58
+#: lib/lemmings_os_web/components/connections_components.ex:154
 #, elixir-autogen, elixir-format
 msgid ".title_connections"
 msgstr ""
@@ -1084,8 +1088,8 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:35
 #: lib/lemmings_os_web/components/lemming_components.ex:399
 #: lib/lemmings_os_web/components/lemming_components.ex:1100
-#: lib/lemmings_os_web/components/world_components.ex:246
-#: lib/lemmings_os_web/components/world_components.ex:852
+#: lib/lemmings_os_web/components/world_components.ex:252
+#: lib/lemmings_os_web/components/world_components.ex:862
 #: lib/lemmings_os_web/live/cities_live.html.heex:256
 #, elixir-autogen, elixir-format
 msgid "Artifacts"
@@ -1159,4 +1163,29 @@ msgstr ""
 #: lib/lemmings_os_web/components/artifacts_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "world"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:172
+#, elixir-autogen, elixir-format
+msgid "Connect Gmail"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:162
+#, elixir-autogen, elixir-format
+msgid "Connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:149
+#, elixir-autogen, elixir-format
+msgid "Not available"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:164
+#, elixir-autogen, elixir-format
+msgid "Not connected"
+msgstr ""
+
+#: lib/lemmings_os_web/connections_surface.ex:170
+#, elixir-autogen, elixir-format
+msgid "Reconnect Gmail"
 msgstr ""

--- a/priv/gettext/lemmings.pot
+++ b/priv/gettext/lemmings.pot
@@ -618,19 +618,19 @@ msgstr ""
 msgid ".tooltip_create_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:915
+#: lib/lemmings_os_web/components/instance_components.ex:916
 #: lib/lemmings_os_web/live/instance_live.ex:711
 #, elixir-autogen, elixir-format
 msgid "%{hours}h %{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:908
 #: lib/lemmings_os_web/live/instance_live.ex:703
 #, elixir-autogen, elixir-format
 msgid "%{minutes}m %{seconds}s"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:901
+#: lib/lemmings_os_web/components/instance_components.ex:902
 #: lib/lemmings_os_web/live/instance_live.ex:697
 #, elixir-autogen, elixir-format
 msgid "%{seconds}s"
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Ask the instance to continue..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:968
+#: lib/lemmings_os_web/components/instance_components.ex:969
 #, elixir-autogen, elixir-format
 msgid "Assistant"
 msgstr ""
@@ -661,7 +661,7 @@ msgstr ""
 msgid "Conversation Transcript"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:66
+#: lib/lemmings_os_web/components/instance_components.ex:67
 #: lib/lemmings_os_web/live/instance_live.html.heex:186
 #: lib/lemmings_os_web/live/instance_raw_live.html.heex:260
 #, elixir-autogen, elixir-format
@@ -678,7 +678,7 @@ msgstr ""
 msgid "Current status: %{status}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:102
+#: lib/lemmings_os_web/components/instance_components.ex:103
 #, elixir-autogen, elixir-format
 msgid "Elapsed"
 msgstr ""
@@ -688,13 +688,13 @@ msgstr ""
 msgid "Expired"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1018
+#: lib/lemmings_os_web/components/instance_components.ex:1019
 #: lib/lemmings_os_web/live/instance_live.ex:648
 #, elixir-autogen, elixir-format
 msgid "Failed"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:54
+#: lib/lemmings_os_web/components/instance_components.ex:55
 #, elixir-autogen, elixir-format
 msgid "Failure detail"
 msgstr ""
@@ -710,13 +710,13 @@ msgstr ""
 msgid "Idle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:858
+#: lib/lemmings_os_web/components/instance_components.ex:859
 #: lib/lemmings_os_web/live/instance_live.ex:671
 #, elixir-autogen, elixir-format
 msgid "Idle for %{elapsed}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:192
+#: lib/lemmings_os_web/components/instance_components.ex:193
 #, elixir-autogen, elixir-format
 msgid "Input %{count} tokens"
 msgstr ""
@@ -775,7 +775,7 @@ msgstr ""
 msgid "Live"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:195
+#: lib/lemmings_os_web/components/instance_components.ex:196
 #, elixir-autogen, elixir-format
 msgid "Output %{count} tokens"
 msgstr ""
@@ -785,7 +785,7 @@ msgstr ""
 msgid "Processing"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:845
+#: lib/lemmings_os_web/components/instance_components.ex:846
 #: lib/lemmings_os_web/live/instance_live.ex:658
 #, elixir-autogen, elixir-format
 msgid "Processing for %{elapsed}"
@@ -796,7 +796,7 @@ msgstr ""
 msgid "Processing..."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:78
+#: lib/lemmings_os_web/components/instance_components.ex:79
 #: lib/lemmings_os_web/live/instance_live.html.heex:214
 #, elixir-autogen, elixir-format
 msgid "Queue depth"
@@ -807,15 +807,15 @@ msgstr ""
 msgid "Ready for another request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:828
-#: lib/lemmings_os_web/components/instance_components.ex:851
+#: lib/lemmings_os_web/components/instance_components.ex:829
+#: lib/lemmings_os_web/components/instance_components.ex:852
 #: lib/lemmings_os_web/live/instance_live.ex:628
 #: lib/lemmings_os_web/live/instance_live.ex:664
 #, elixir-autogen, elixir-format
 msgid "Retry attempt %{count} of %{max}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:90
+#: lib/lemmings_os_web/components/instance_components.ex:91
 #: lib/lemmings_os_web/live/instance_live.html.heex:202
 #, elixir-autogen, elixir-format
 msgid "Retry state"
@@ -837,13 +837,13 @@ msgstr ""
 msgid "Return to parent lemming"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:864
+#: lib/lemmings_os_web/components/instance_components.ex:865
 #: lib/lemmings_os_web/live/instance_live.ex:677
 #, elixir-autogen, elixir-format
 msgid "Runtime expired."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:863
+#: lib/lemmings_os_web/components/instance_components.ex:864
 #: lib/lemmings_os_web/live/instance_live.ex:676
 #, elixir-autogen, elixir-format
 msgid "Runtime failed."
@@ -870,8 +870,8 @@ msgstr ""
 msgid "Started at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:839
-#: lib/lemmings_os_web/components/instance_components.ex:865
+#: lib/lemmings_os_web/components/instance_components.ex:840
+#: lib/lemmings_os_web/components/instance_components.ex:866
 #: lib/lemmings_os_web/live/instance_live.ex:636
 #: lib/lemmings_os_web/live/instance_live.ex:650
 #: lib/lemmings_os_web/live/instance_live.ex:652
@@ -893,7 +893,7 @@ msgstr ""
 msgid "This request will reuse the current transcript context."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:198
+#: lib/lemmings_os_web/components/instance_components.ex:199
 #, elixir-autogen, elixir-format
 msgid "Total %{count} tokens"
 msgstr ""
@@ -909,8 +909,8 @@ msgstr ""
 msgid "Unable to save the follow-up request."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1129
-#: lib/lemmings_os_web/components/instance_components.ex:1251
+#: lib/lemmings_os_web/components/instance_components.ex:1141
+#: lib/lemmings_os_web/components/instance_components.ex:1338
 #, elixir-autogen, elixir-format
 msgid "Unknown time"
 msgstr ""
@@ -920,12 +920,12 @@ msgstr ""
 msgid "Use the transcript to review the latest runtime activity."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:970
+#: lib/lemmings_os_web/components/instance_components.ex:971
 #, elixir-autogen, elixir-format
 msgid "User"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:842
+#: lib/lemmings_os_web/components/instance_components.ex:843
 #: lib/lemmings_os_web/live/instance_live.ex:637
 #: lib/lemmings_os_web/live/instance_live.ex:655
 #: lib/lemmings_os_web/live/instance_live.ex:781
@@ -943,7 +943,7 @@ msgstr ""
 msgid "World"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:896
+#: lib/lemmings_os_web/components/instance_components.ex:897
 #: lib/lemmings_os_web/live/instance_live.ex:694
 #, elixir-autogen, elixir-format
 msgid "unknown"
@@ -959,7 +959,7 @@ msgstr ""
 msgid "Only failed instances can be retried."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:116
+#: lib/lemmings_os_web/components/instance_components.ex:117
 #, elixir-autogen, elixir-format
 msgid "Operator action"
 msgstr ""
@@ -974,7 +974,7 @@ msgstr ""
 msgid "Retry requested for this instance."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:119
+#: lib/lemmings_os_web/components/instance_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Retry the latest failed request."
 msgstr ""
@@ -990,7 +990,7 @@ msgstr ""
 msgid "Unable to retry this instance right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1257
+#: lib/lemmings_os_web/components/instance_components.ex:1344
 #, elixir-autogen, elixir-format
 msgid "now"
 msgstr ""
@@ -1467,22 +1467,22 @@ msgstr ""
 msgid ".title_spawn_instance"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1151
+#: lib/lemmings_os_web/components/instance_components.ex:1163
 #, elixir-autogen, elixir-format
 msgid "%{count} args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1145
+#: lib/lemmings_os_web/components/instance_components.ex:1157
 #, elixir-autogen, elixir-format
 msgid "%{count} ms"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1154
+#: lib/lemmings_os_web/components/instance_components.ex:1166
 #, elixir-autogen, elixir-format
 msgid "0 args"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:526
+#: lib/lemmings_os_web/components/instance_components.ex:527
 #, elixir-autogen, elixir-format
 msgid "Arguments"
 msgstr ""
@@ -1497,8 +1497,8 @@ msgstr ""
 msgid "Chronological session activity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:711
-#: lib/lemmings_os_web/components/instance_components.ex:1017
+#: lib/lemmings_os_web/components/instance_components.ex:712
+#: lib/lemmings_os_web/components/instance_components.ex:1018
 #, elixir-autogen, elixir-format
 msgid "Completed"
 msgstr ""
@@ -1513,12 +1513,12 @@ msgstr ""
 msgid "Context messages"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:546
+#: lib/lemmings_os_web/components/instance_components.ex:547
 #, elixir-autogen, elixir-format
 msgid "Error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:520
+#: lib/lemmings_os_web/components/instance_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Inspect persisted details"
 msgstr ""
@@ -1564,12 +1564,12 @@ msgstr ""
 msgid "Raw context"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:536
+#: lib/lemmings_os_web/components/instance_components.ex:537
 #, elixir-autogen, elixir-format
 msgid "Result"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1016
+#: lib/lemmings_os_web/components/instance_components.ex:1017
 #, elixir-autogen, elixir-format
 msgid "Running"
 msgstr ""
@@ -1589,37 +1589,37 @@ msgstr ""
 msgid "Shows the live LLM and tool loop as a readable timeline. Raw payloads stay collapsed under each step."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:273
+#: lib/lemmings_os_web/components/instance_components.ex:274
 #, elixir-autogen, elixir-format
 msgid "Tool"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1027
+#: lib/lemmings_os_web/components/instance_components.ex:1035
 #, elixir-autogen, elixir-format
 msgid "Tool execution completed successfully."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1033
+#: lib/lemmings_os_web/components/instance_components.ex:1041
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed with code %{code}."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1035
+#: lib/lemmings_os_web/components/instance_components.ex:1043
 #, elixir-autogen, elixir-format
 msgid "Tool execution failed."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1024
+#: lib/lemmings_os_web/components/instance_components.ex:1032
 #, elixir-autogen, elixir-format
 msgid "Tool execution is still running."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1039
+#: lib/lemmings_os_web/components/instance_components.ex:1047
 #, elixir-autogen, elixir-format
 msgid "Tool execution recorded."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:275
+#: lib/lemmings_os_web/components/instance_components.ex:276
 #, elixir-autogen, elixir-format
 msgid "Tool run"
 msgstr ""
@@ -1634,22 +1634,22 @@ msgstr ""
 msgid "%{count} historical"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:753
+#: lib/lemmings_os_web/components/instance_components.ex:754
 #, elixir-autogen, elixir-format
 msgid "Caller"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:919
+#: lib/lemmings_os_web/components/world_components.ex:929
 #, elixir-autogen, elixir-format
 msgid "Capability"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:778
+#: lib/lemmings_os_web/components/instance_components.ex:779
 #, elixir-autogen, elixir-format
 msgid "Child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:663
+#: lib/lemmings_os_web/components/instance_components.ex:664
 #, elixir-autogen, elixir-format
 msgid "Delegated"
 msgstr ""
@@ -1664,7 +1664,7 @@ msgstr ""
 msgid "Delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1203
+#: lib/lemmings_os_web/components/instance_components.ex:1290
 #, elixir-autogen, elixir-format
 msgid "Delegating work to a child lemming."
 msgstr ""
@@ -1674,20 +1674,20 @@ msgstr ""
 msgid "Delegation state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:742
+#: lib/lemmings_os_web/components/instance_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "Error summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:721
+#: lib/lemmings_os_web/components/instance_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Inspect delegated work"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:585
-#: lib/lemmings_os_web/components/instance_components.ex:623
-#: lib/lemmings_os_web/components/instance_components.ex:668
-#: lib/lemmings_os_web/components/world_components.ex:914
+#: lib/lemmings_os_web/components/instance_components.ex:586
+#: lib/lemmings_os_web/components/instance_components.ex:624
+#: lib/lemmings_os_web/components/instance_components.ex:669
+#: lib/lemmings_os_web/components/world_components.ex:924
 #, elixir-autogen, elixir-format
 msgid "Manager"
 msgstr ""
@@ -1697,18 +1697,18 @@ msgstr ""
 msgid "Manager relationship"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:899
+#: lib/lemmings_os_web/components/world_components.ex:909
 #, elixir-autogen, elixir-format
 msgid "Manager-centered entry for this department"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:693
+#: lib/lemmings_os_web/components/instance_components.ex:694
 #, elixir-autogen, elixir-format
 msgid "Open child"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:769
-#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/instance_components.ex:770
+#: lib/lemmings_os_web/components/world_components.ex:917
 #, elixir-autogen, elixir-format
 msgid "Open manager"
 msgstr ""
@@ -1718,18 +1718,18 @@ msgstr ""
 msgid "Open parent"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:897
-#: lib/lemmings_os_web/components/world_components.ex:1073
+#: lib/lemmings_os_web/components/world_components.ex:907
+#: lib/lemmings_os_web/components/world_components.ex:1083
 #, elixir-autogen, elixir-format
 msgid "Primary manager"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:708
+#: lib/lemmings_os_web/components/instance_components.ex:709
 #, elixir-autogen, elixir-format
 msgid "Requested"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:731
+#: lib/lemmings_os_web/components/instance_components.ex:732
 #, elixir-autogen, elixir-format
 msgid "Result summary"
 msgstr ""
@@ -1744,17 +1744,17 @@ msgstr ""
 msgid "This session was opened through a manager delegation flow"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1214
+#: lib/lemmings_os_web/components/instance_components.ex:1301
 #, elixir-autogen, elixir-format
 msgid "UNKNOWN"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1209
+#: lib/lemmings_os_web/components/instance_components.ex:1296
 #, elixir-autogen, elixir-format
 msgid "Unknown"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:671
+#: lib/lemmings_os_web/components/instance_components.ex:672
 #, elixir-autogen, elixir-format
 msgid "Worker"
 msgstr ""
@@ -1784,12 +1784,12 @@ msgstr ""
 msgid "Workspace path copied."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1122
+#: lib/lemmings_os_web/components/instance_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid "%{count} bytes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:359
+#: lib/lemmings_os_web/components/instance_components.ex:360
 #, elixir-autogen, elixir-format
 msgid "An Artifact is a promoted, durable file reference with tracked metadata and lifecycle state."
 msgstr ""
@@ -1814,7 +1814,7 @@ msgstr ""
 msgid "Artifact promoted: %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:342
+#: lib/lemmings_os_web/components/instance_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Artifact promotion"
 msgstr ""
@@ -1859,22 +1859,22 @@ msgstr ""
 msgid "Choose a valid promotion action for this Artifact."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:476
+#: lib/lemmings_os_web/components/instance_components.ex:477
 #, elixir-autogen, elixir-format
 msgid "Created"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:492
+#: lib/lemmings_os_web/components/instance_components.ex:493
 #, elixir-autogen, elixir-format
 msgid "Download"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:486
+#: lib/lemmings_os_web/components/instance_components.ex:487
 #, elixir-autogen, elixir-format
 msgid "Download Artifact %{filename}"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:506
+#: lib/lemmings_os_web/components/instance_components.ex:507
 #, elixir-autogen, elixir-format
 msgid "Notes"
 msgstr ""
@@ -1889,33 +1889,33 @@ msgstr ""
 msgid "Only regular files can be promoted as Artifacts."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:438
+#: lib/lemmings_os_web/components/instance_components.ex:439
 #, elixir-autogen, elixir-format
 msgid "Promote as New Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:433
+#: lib/lemmings_os_web/components/instance_components.ex:434
 #, elixir-autogen, elixir-format
 msgid "Promote as new Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:408
+#: lib/lemmings_os_web/components/instance_components.ex:409
 #, elixir-autogen, elixir-format
 msgid "Promote to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:404
 #, elixir-autogen, elixir-format
 msgid "Promote workspace file to Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:374
+#: lib/lemmings_os_web/components/instance_components.ex:375
 #, elixir-autogen, elixir-format
 msgid "Promoted"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:402
-#: lib/lemmings_os_web/components/instance_components.ex:432
+#: lib/lemmings_os_web/components/instance_components.ex:403
+#: lib/lemmings_os_web/components/instance_components.ex:433
 #, elixir-autogen, elixir-format
 msgid "Promoting..."
 msgstr ""
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Runtime instance not found for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:352
+#: lib/lemmings_os_web/components/instance_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Show Artifact help"
 msgstr ""
@@ -1940,22 +1940,22 @@ msgstr ""
 msgid "Unable to promote this file right now."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:1124
+#: lib/lemmings_os_web/components/instance_components.ex:1136
 #, elixir-autogen, elixir-format
 msgid "Unknown size"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:423
+#: lib/lemmings_os_web/components/instance_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "Update Artifact"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:418
+#: lib/lemmings_os_web/components/instance_components.ex:419
 #, elixir-autogen, elixir-format
 msgid "Update existing Artifact from workspace file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:417
+#: lib/lemmings_os_web/components/instance_components.ex:418
 #, elixir-autogen, elixir-format
 msgid "Updating..."
 msgstr ""
@@ -1971,7 +1971,22 @@ msgstr ""
 msgid "Workspace file path is invalid for Artifact promotion."
 msgstr ""
 
-#: lib/lemmings_os_web/components/instance_components.ex:182
+#: lib/lemmings_os_web/components/instance_components.ex:183
 #, elixir-autogen, elixir-format
 msgid "View/Edit memory"
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1200
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation failed."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1197
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation is still running."
+msgstr ""
+
+#: lib/lemmings_os_web/components/instance_components.ex:1203
+#, elixir-autogen, elixir-format
+msgid "Gmail draft creation recorded."
 msgstr ""

--- a/priv/gettext/world.pot
+++ b/priv/gettext/world.pot
@@ -34,12 +34,12 @@ msgstr ""
 
 #: lib/lemmings_os/helpers.ex:130
 #: lib/lemmings_os/helpers.ex:155
-#: lib/lemmings_os_web/components/world_components.ex:1346
-#: lib/lemmings_os_web/components/world_components.ex:1376
-#: lib/lemmings_os_web/components/world_components.ex:1393
-#: lib/lemmings_os_web/components/world_components.ex:1410
-#: lib/lemmings_os_web/components/world_components.ex:1414
-#: lib/lemmings_os_web/components/world_components.ex:1435
+#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1422
+#: lib/lemmings_os_web/components/world_components.ex:1426
+#: lib/lemmings_os_web/components/world_components.ex:1447
 #: lib/lemmings_os_web/live/instance_live.ex:470
 #: lib/lemmings_os_web/live/instance_raw_live.ex:204
 #, elixir-autogen, elixir-format
@@ -71,40 +71,40 @@ msgstr ""
 msgid ".aria_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:789
+#: lib/lemmings_os_web/components/world_components.ex:799
 #: lib/lemmings_os_web/live/import_lemming_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid ".button_all_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:266
-#: lib/lemmings_os_web/components/world_components.ex:557
+#: lib/lemmings_os_web/components/world_components.ex:272
+#: lib/lemmings_os_web/components/world_components.ex:565
 #, elixir-autogen, elixir-format
 msgid ".button_import_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:736
+#: lib/lemmings_os_web/components/world_components.ex:744
 #, elixir-autogen, elixir-format
 msgid ".button_open_dept"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:105
-#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:111
+#: lib/lemmings_os_web/components/world_components.ex:562
 #, elixir-autogen, elixir-format
 msgid ".button_refresh_world"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:448
+#: lib/lemmings_os_web/components/world_components.ex:454
 #, elixir-autogen, elixir-format
 msgid ".copy_world_cities_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:461
+#: lib/lemmings_os_web/components/world_components.ex:467
 #, elixir-autogen, elixir-format
 msgid ".copy_world_tools_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:128
+#: lib/lemmings_os_web/live/departments_live.html.heex:130
 #, elixir-autogen, elixir-format
 msgid ".count_departments"
 msgstr ""
@@ -114,178 +114,178 @@ msgstr ""
 msgid ".count_running_of_total"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:677
-#: lib/lemmings_os_web/live/departments_live.html.heex:56
-#: lib/lemmings_os_web/live/departments_live.html.heex:135
+#: lib/lemmings_os_web/components/world_components.ex:685
+#: lib/lemmings_os_web/live/departments_live.html.heex:58
+#: lib/lemmings_os_web/live/departments_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:678
-#: lib/lemmings_os_web/live/departments_live.html.heex:57
-#: lib/lemmings_os_web/live/departments_live.html.heex:136
+#: lib/lemmings_os_web/components/world_components.ex:686
+#: lib/lemmings_os_web/live/departments_live.html.heex:59
+#: lib/lemmings_os_web/live/departments_live.html.heex:138
 #, elixir-autogen, elixir-format
 msgid ".empty_no_departments_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:562
+#: lib/lemmings_os_web/components/world_components.ex:570
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:563
+#: lib/lemmings_os_web/components/world_components.ex:571
 #, elixir-autogen, elixir-format
 msgid ".empty_world_snapshot_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:350
+#: lib/lemmings_os_web/components/world_components.ex:356
 #: lib/lemmings_os_web/live/settings_live.html.heex:153
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_path"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:345
+#: lib/lemmings_os_web/components/world_components.ex:351
 #, elixir-autogen, elixir-format
 msgid ".label_bootstrap_source"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:422
-#: lib/lemmings_os_web/components/world_components.ex:651
+#: lib/lemmings_os_web/components/world_components.ex:428
+#: lib/lemmings_os_web/components/world_components.ex:659
 #, elixir-autogen, elixir-format
 msgid ".label_budgets"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1369
+#: lib/lemmings_os_web/components/world_components.ex:1381
 #, elixir-autogen, elixir-format
 msgid ".label_cross_city_communication"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1365
+#: lib/lemmings_os_web/components/world_components.ex:1377
 #, elixir-autogen, elixir-format
 msgid ".label_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1374
+#: lib/lemmings_os_web/components/world_components.ex:1386
 #, elixir-autogen, elixir-format
 msgid ".label_declared"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1358
+#: lib/lemmings_os_web/components/world_components.ex:1370
 #, elixir-autogen, elixir-format
 msgid ".label_departments_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:751
+#: lib/lemmings_os_web/components/world_components.ex:759
 #, elixir-autogen, elixir-format
 msgid ".label_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:126
-#: lib/lemmings_os_web/components/world_components.ex:276
+#: lib/lemmings_os_web/components/world_components.ex:132
+#: lib/lemmings_os_web/components/world_components.ex:282
 #, elixir-autogen, elixir-format
 msgid ".label_immediate_import"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:300
+#: lib/lemmings_os_web/components/world_components.ex:306
 #, elixir-autogen, elixir-format
 msgid ".label_last_bootstrap_hash"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:296
+#: lib/lemmings_os_web/components/world_components.ex:302
 #: lib/lemmings_os_web/live/settings_live.html.heex:159
 #, elixir-autogen, elixir-format
 msgid ".label_last_imported_at"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:144
-#: lib/lemmings_os_web/components/world_components.ex:288
+#: lib/lemmings_os_web/components/world_components.ex:150
+#: lib/lemmings_os_web/components/world_components.ex:294
 #: lib/lemmings_os_web/live/settings_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid ".label_last_sync"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1359
+#: lib/lemmings_os_web/components/world_components.ex:1371
 #, elixir-autogen, elixir-format
 msgid ".label_lemmings_short"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:417
-#: lib/lemmings_os_web/components/world_components.ex:635
+#: lib/lemmings_os_web/components/world_components.ex:423
+#: lib/lemmings_os_web/components/world_components.ex:643
 #, elixir-autogen, elixir-format
 msgid ".label_limits"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1348
+#: lib/lemmings_os_web/components/world_components.ex:1360
 #, elixir-autogen, elixir-format
 msgid ".label_no_fallbacks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:314
+#: lib/lemmings_os_web/components/world_components.ex:320
 #, elixir-autogen, elixir-format
 msgid ".label_no_world_issues"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:445
-#: lib/lemmings_os_web/components/world_components.ex:458
+#: lib/lemmings_os_web/components/world_components.ex:451
+#: lib/lemmings_os_web/components/world_components.ex:464
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_only"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:432
+#: lib/lemmings_os_web/components/world_components.ex:438
 #, elixir-autogen, elixir-format
 msgid ".label_placeholder_sections"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:394
-#: lib/lemmings_os_web/components/world_components.ex:657
+#: lib/lemmings_os_web/components/world_components.ex:400
+#: lib/lemmings_os_web/components/world_components.ex:665
 #, elixir-autogen, elixir-format
 msgid ".label_profiles"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1421
+#: lib/lemmings_os_web/components/world_components.ex:1433
 #, elixir-autogen, elixir-format
 msgid ".label_provider_credentials_ready"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1345
+#: lib/lemmings_os_web/components/world_components.ex:1357
 #, elixir-autogen, elixir-format
 msgid ".label_provider_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1344
+#: lib/lemmings_os_web/components/world_components.ex:1356
 #, elixir-autogen, elixir-format
 msgid ".label_provider_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:369
+#: lib/lemmings_os_web/components/world_components.ex:375
 #, elixir-autogen, elixir-format
 msgid ".label_providers"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:750
+#: lib/lemmings_os_web/components/world_components.ex:758
 #, elixir-autogen, elixir-format
 msgid ".label_queue"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:427
-#: lib/lemmings_os_web/components/world_components.ex:643
+#: lib/lemmings_os_web/components/world_components.ex:433
+#: lib/lemmings_os_web/components/world_components.ex:651
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_defaults"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1430
-#: lib/lemmings_os_web/components/world_components.ex:1431
+#: lib/lemmings_os_web/components/world_components.ex:1442
+#: lib/lemmings_os_web/components/world_components.ex:1443
 #, elixir-autogen, elixir-format
 msgid ".label_runtime_deferred"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1387
+#: lib/lemmings_os_web/components/world_components.ex:1399
 #, elixir-autogen, elixir-format
 msgid ".label_world_id"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:885
-#: lib/lemmings_os_web/components/world_components.ex:1388
+#: lib/lemmings_os_web/components/world_components.ex:895
+#: lib/lemmings_os_web/components/world_components.ex:1400
 #: lib/lemmings_os_web/live/settings_live.html.heex:61
 #, elixir-autogen, elixir-format
 msgid ".label_world_slug"
@@ -325,22 +325,22 @@ msgstr ""
 msgid ".metric_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1396
+#: lib/lemmings_os_web/components/world_components.ex:1408
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_bootstrap_file"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1399
+#: lib/lemmings_os_web/components/world_components.ex:1411
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_postgres_connection"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1402
+#: lib/lemmings_os_web/components/world_components.ex:1414
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_credentials"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1405
+#: lib/lemmings_os_web/components/world_components.ex:1417
 #, elixir-autogen, elixir-format
 msgid ".runtime_check_provider_reachability"
 msgstr ""
@@ -371,23 +371,23 @@ msgstr ""
 msgid ".subtitle_all_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:210
+#: lib/lemmings_os_web/components/world_components.ex:216
 #, elixir-autogen, elixir-format
 msgid ".tab_bootstrap"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:201
+#: lib/lemmings_os_web/components/world_components.ex:207
 #, elixir-autogen, elixir-format
 msgid ".tab_import"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:192
+#: lib/lemmings_os_web/components/world_components.ex:198
 #: lib/lemmings_os_web/live/cities_live.html.heex:227
 #, elixir-autogen, elixir-format
 msgid ".tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:219
+#: lib/lemmings_os_web/components/world_components.ex:225
 #, elixir-autogen, elixir-format
 msgid ".tab_runtime"
 msgstr ""
@@ -397,45 +397,45 @@ msgstr ""
 msgid ".title_all_cities"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:158
-#: lib/lemmings_os_web/components/world_components.ex:339
+#: lib/lemmings_os_web/components/world_components.ex:164
+#: lib/lemmings_os_web/components/world_components.ex:345
 #: lib/lemmings_os_web/live/settings_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid ".title_bootstrap_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:671
-#: lib/lemmings_os_web/live/departments_live.html.heex:124
+#: lib/lemmings_os_web/components/world_components.ex:679
+#: lib/lemmings_os_web/live/departments_live.html.heex:126
 #, elixir-autogen, elixir-format
 msgid ".title_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:129
-#: lib/lemmings_os_web/components/world_components.ex:258
+#: lib/lemmings_os_web/components/world_components.ex:135
+#: lib/lemmings_os_web/components/world_components.ex:264
 #, elixir-autogen, elixir-format
 msgid ".title_import_state"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:172
-#: lib/lemmings_os_web/components/world_components.ex:469
+#: lib/lemmings_os_web/components/world_components.ex:178
+#: lib/lemmings_os_web/components/world_components.ex:475
 #, elixir-autogen, elixir-format
 msgid ".title_runtime_checks"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:441
+#: lib/lemmings_os_web/components/world_components.ex:447
 #, elixir-autogen, elixir-format
 msgid ".title_world_cities_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:114
-#: lib/lemmings_os_web/components/world_components.ex:361
-#: lib/lemmings_os_web/components/world_components.ex:546
-#: lib/lemmings_os_web/components/world_components.ex:880
+#: lib/lemmings_os_web/components/world_components.ex:120
+#: lib/lemmings_os_web/components/world_components.ex:367
+#: lib/lemmings_os_web/components/world_components.ex:554
+#: lib/lemmings_os_web/components/world_components.ex:890
 #, elixir-autogen, elixir-format
 msgid ".title_world_identity"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:309
+#: lib/lemmings_os_web/components/world_components.ex:315
 #, elixir-autogen, elixir-format
 msgid ".title_world_issues"
 msgstr ""
@@ -445,12 +445,12 @@ msgstr ""
 msgid ".title_world_map"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:97
+#: lib/lemmings_os_web/components/world_components.ex:103
 #, elixir-autogen, elixir-format
 msgid ".title_world_status"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:454
+#: lib/lemmings_os_web/components/world_components.ex:460
 #, elixir-autogen, elixir-format
 msgid ".title_world_tools_placeholder"
 msgstr ""
@@ -465,13 +465,13 @@ msgstr ""
 msgid ".tooltip_running"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:630
+#: lib/lemmings_os_web/components/world_components.ex:638
 #, elixir-autogen
 msgid ".copy_city_effective_config"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:875
-#: lib/lemmings_os_web/live/departments_live.html.heex:51
+#: lib/lemmings_os_web/components/world_components.ex:885
+#: lib/lemmings_os_web/live/departments_live.html.heex:53
 #, elixir-autogen
 msgid ".title_world_cities"
 msgstr ""
@@ -530,7 +530,7 @@ msgstr ""
 msgid ".label_city_slug"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:629
+#: lib/lemmings_os_web/components/world_components.ex:637
 #, elixir-autogen
 msgid ".title_city_effective_config"
 msgstr ""
@@ -600,7 +600,7 @@ msgstr ""
 msgid ".city_form_node_name_placeholder"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:870
+#: lib/lemmings_os_web/components/world_components.ex:880
 #: lib/lemmings_os_web/live/cities_live.html.heex:78
 #, elixir-autogen
 msgid ".city_form_status_label"
@@ -641,268 +641,268 @@ msgstr ""
 msgid ".city_form_submit_update"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:508
+#: lib/lemmings_os_web/live/cities_live.ex:533
 #, elixir-autogen
 msgid ".flash_city_created"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:533
+#: lib/lemmings_os_web/live/cities_live.ex:558
 #, elixir-autogen
 msgid ".flash_city_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:146
+#: lib/lemmings_os_web/live/cities_live.ex:148
 #, elixir-autogen
 msgid ".flash_city_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:102
-#: lib/lemmings_os_web/live/cities_live.ex:155
+#: lib/lemmings_os_web/live/cities_live.ex:104
+#: lib/lemmings_os_web/live/cities_live.ex:157
 #, elixir-autogen
 msgid ".flash_city_not_found"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:518
 #: lib/lemmings_os_web/live/cities_live.ex:543
+#: lib/lemmings_os_web/live/cities_live.ex:568
 #, elixir-autogen
 msgid ".flash_city_save_error"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:152
+#: lib/lemmings_os_web/live/cities_live.ex:154
 #, elixir-autogen
 msgid ".flash_city_delete_error"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:717
+#: lib/lemmings_os_web/components/world_components.ex:725
 #, elixir-autogen, elixir-format
 msgid ".button_open_city_departments"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:684
+#: lib/lemmings_os_web/components/world_components.ex:692
 #, elixir-autogen, elixir-format
 msgid ".city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:672
+#: lib/lemmings_os_web/components/world_components.ex:680
 #, elixir-autogen, elixir-format
 msgid ".copy_city_departments_summary"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:99
+#: lib/lemmings_os_web/live/departments_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid ".copy_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.html.heex:98
-#: lib/lemmings_os_web/live/departments_live.html.heex:117
+#: lib/lemmings_os_web/live/departments_live.html.heex:100
+#: lib/lemmings_os_web/live/departments_live.html.heex:119
 #, elixir-autogen, elixir-format
 msgid ".title_selected_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:965
+#: lib/lemmings_os_web/components/world_components.ex:975
 #, elixir-autogen, elixir-format
 msgid ".button_department_activate"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:993
+#: lib/lemmings_os_web/components/world_components.ex:1003
 #, elixir-autogen, elixir-format
 msgid ".button_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:983
+#: lib/lemmings_os_web/components/world_components.ex:993
 #, elixir-autogen, elixir-format
 msgid ".button_department_disable"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:974
+#: lib/lemmings_os_web/components/world_components.ex:984
 #, elixir-autogen, elixir-format
 msgid ".button_department_drain"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1217
+#: lib/lemmings_os_web/components/world_components.ex:1227
 #, elixir-autogen, elixir-format
 msgid ".button_department_save_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:990
+#: lib/lemmings_os_web/components/world_components.ex:1000
 #, elixir-autogen, elixir-format
 msgid ".confirm_department_delete"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:937
+#: lib/lemmings_os_web/components/world_components.ex:947
 #, elixir-autogen, elixir-format
 msgid ".department_field_name"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:947
+#: lib/lemmings_os_web/components/world_components.ex:957
 #, elixir-autogen, elixir-format
 msgid ".department_field_notes"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:942
+#: lib/lemmings_os_web/components/world_components.ex:952
 #, elixir-autogen, elixir-format
 msgid ".department_field_tags"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1027
+#: lib/lemmings_os_web/components/world_components.ex:1037
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1028
+#: lib/lemmings_os_web/components/world_components.ex:1038
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_empty_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1003
+#: lib/lemmings_os_web/components/world_components.ex:1013
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:954
+#: lib/lemmings_os_web/components/world_components.ex:964
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:955
+#: lib/lemmings_os_web/components/world_components.ex:965
 #, elixir-autogen, elixir-format
 msgid ".department_section_lifecycle_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:933
+#: lib/lemmings_os_web/components/world_components.ex:943
 #, elixir-autogen, elixir-format
 msgid ".department_section_metadata"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1112
-#: lib/lemmings_os_web/components/world_components.ex:1145
-#: lib/lemmings_os_web/components/world_components.ex:1194
+#: lib/lemmings_os_web/components/world_components.ex:1122
+#: lib/lemmings_os_web/components/world_components.ex:1155
+#: lib/lemmings_os_web/components/world_components.ex:1204
 #, elixir-autogen, elixir-format
 msgid ".department_setting_cross_city"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1117
-#: lib/lemmings_os_web/components/world_components.ex:1154
-#: lib/lemmings_os_web/components/world_components.ex:1209
+#: lib/lemmings_os_web/components/world_components.ex:1127
+#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1219
 #, elixir-autogen, elixir-format
 msgid ".department_setting_daily_tokens"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1198
+#: lib/lemmings_os_web/components/world_components.ex:1208
 #, elixir-autogen, elixir-format
 msgid ".department_setting_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1197
+#: lib/lemmings_os_web/components/world_components.ex:1207
 #, elixir-autogen, elixir-format
 msgid ".department_setting_enabled"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1107
-#: lib/lemmings_os_web/components/world_components.ex:1138
-#: lib/lemmings_os_web/components/world_components.ex:1188
+#: lib/lemmings_os_web/components/world_components.ex:1117
+#: lib/lemmings_os_web/components/world_components.ex:1148
+#: lib/lemmings_os_web/components/world_components.ex:1198
 #, elixir-autogen, elixir-format
 msgid ".department_setting_idle_ttl"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1196
+#: lib/lemmings_os_web/components/world_components.ex:1206
 #, elixir-autogen, elixir-format
 msgid ".department_setting_inherit"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1102
-#: lib/lemmings_os_web/components/world_components.ex:1129
-#: lib/lemmings_os_web/components/world_components.ex:1179
+#: lib/lemmings_os_web/components/world_components.ex:1112
+#: lib/lemmings_os_web/components/world_components.ex:1139
+#: lib/lemmings_os_web/components/world_components.ex:1189
 #, elixir-autogen, elixir-format
 msgid ".department_setting_max_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1098
+#: lib/lemmings_os_web/components/world_components.ex:1108
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1097
+#: lib/lemmings_os_web/components/world_components.ex:1107
 #, elixir-autogen, elixir-format
 msgid ".department_settings_effective_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1125
+#: lib/lemmings_os_web/components/world_components.ex:1135
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1124
+#: lib/lemmings_os_web/components/world_components.ex:1134
 #, elixir-autogen, elixir-format
 msgid ".department_settings_local_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1165
+#: lib/lemmings_os_web/components/world_components.ex:1175
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_copy"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1164
+#: lib/lemmings_os_web/components/world_components.ex:1174
 #, elixir-autogen, elixir-format
 msgid ".department_settings_v1_title"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:812
+#: lib/lemmings_os_web/components/world_components.ex:822
 #, elixir-autogen, elixir-format
 msgid ".department_tab_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:802
+#: lib/lemmings_os_web/components/world_components.ex:812
 #, elixir-autogen, elixir-format
 msgid ".department_tab_overview"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:822
+#: lib/lemmings_os_web/components/world_components.ex:832
 #, elixir-autogen, elixir-format
 msgid ".department_tab_settings"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:670
+#: lib/lemmings_os_web/live/departments_live.ex:703
 #, elixir-autogen, elixir-format
 msgid ".flash_department_activated"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:118
+#: lib/lemmings_os_web/live/departments_live.ex:120
 #, elixir-autogen, elixir-format
 msgid ".flash_department_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:672
+#: lib/lemmings_os_web/live/departments_live.ex:705
 #, elixir-autogen, elixir-format
 msgid ".flash_department_disabled"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:671
+#: lib/lemmings_os_web/live/departments_live.ex:704
 #, elixir-autogen, elixir-format
 msgid ".flash_department_draining"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:132
+#: lib/lemmings_os_web/live/departments_live.ex:134
 #, elixir-autogen, elixir-format
 msgid ".flash_department_lifecycle_failed"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:102
+#: lib/lemmings_os_web/live/departments_live.ex:104
 #, elixir-autogen, elixir-format
 msgid ".flash_department_settings_saved"
 msgstr ""
 
-#: lib/lemmings_os_web/live/departments_live.ex:673
+#: lib/lemmings_os_web/live/departments_live.ex:706
 #, elixir-autogen, elixir-format
 msgid ".flash_department_updated"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1012
+#: lib/lemmings_os_web/components/world_components.ex:1022
 #, elixir-autogen, elixir-format
 msgid ".button_import_lemmings"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1004
+#: lib/lemmings_os_web/components/world_components.ex:1014
 #, elixir-autogen, elixir-format
 msgid ".department_lemmings_copy"
 msgstr ""
@@ -988,15 +988,15 @@ msgstr ""
 msgid ".secret_delete_label"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:206
-#: lib/lemmings_os_web/live/departments_live.ex:191
+#: lib/lemmings_os_web/live/cities_live.ex:208
+#: lib/lemmings_os_web/live/departments_live.ex:193
 #: lib/lemmings_os_web/live/lemmings_live.ex:188
-#: lib/lemmings_os_web/live/world_live.ex:103
+#: lib/lemmings_os_web/live/world_live.ex:105
 #, elixir-autogen, elixir-format
 msgid ".secret_deleted"
 msgstr ""
 
-#: lib/lemmings_os_web/components/world_components.ex:1234
+#: lib/lemmings_os_web/components/world_components.ex:1244
 #, elixir-autogen, elixir-format
 msgid ".secret_department_subtitle"
 msgstr ""
@@ -1106,10 +1106,10 @@ msgstr ""
 msgid ".secret_save_pending"
 msgstr ""
 
-#: lib/lemmings_os_web/live/cities_live.ex:166
-#: lib/lemmings_os_web/live/departments_live.ex:148
+#: lib/lemmings_os_web/live/cities_live.ex:168
+#: lib/lemmings_os_web/live/departments_live.ex:150
 #: lib/lemmings_os_web/live/lemmings_live.ex:148
-#: lib/lemmings_os_web/live/world_live.ex:65
+#: lib/lemmings_os_web/live/world_live.ex:67
 #, elixir-autogen, elixir-format
 msgid ".secret_saved"
 msgstr ""
@@ -1127,8 +1127,8 @@ msgstr ""
 #: lib/lemmings_os_web/components/lemming_components.ex:383
 #: lib/lemmings_os_web/components/lemming_components.ex:1098
 #: lib/lemmings_os_web/components/secret_bank_components.ex:24
-#: lib/lemmings_os_web/components/world_components.ex:228
-#: lib/lemmings_os_web/components/world_components.ex:832
+#: lib/lemmings_os_web/components/world_components.ex:234
+#: lib/lemmings_os_web/components/world_components.ex:842
 #: lib/lemmings_os_web/live/cities_live.html.heex:236
 #, elixir-autogen, elixir-format
 msgid ".tab_secrets"

--- a/test/lemmings_os/connections/connection_test.exs
+++ b/test/lemmings_os/connections/connection_test.exs
@@ -32,6 +32,25 @@ defmodule LemmingsOs.Connections.ConnectionTest do
       assert changeset.valid?
     end
 
+    test "accepts registered gmail type with secret refs" do
+      changeset =
+        Connection.changeset(%Connection{}, %{
+          world_id: Ecto.UUID.generate(),
+          type: "gmail",
+          status: "enabled",
+          config: %{
+            "provider" => "gmail",
+            "account_email" => "ops@example.test",
+            "scopes" => ["https://www.googleapis.com/auth/gmail.compose"],
+            "client_id" => "$GMAIL_CLIENT_ID",
+            "client_secret" => "$GMAIL_CLIENT_SECRET",
+            "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+          }
+        })
+
+      assert changeset.valid?
+    end
+
     test "rejects unknown status values" do
       changeset =
         Connection.changeset(%Connection{}, %{
@@ -83,6 +102,46 @@ defmodule LemmingsOs.Connections.ConnectionTest do
 
       refute changeset.valid?
       assert ".invalid_choice" in errors_on(changeset).type
+    end
+
+    test "rejects gmail config with raw token values" do
+      changeset =
+        Connection.changeset(%Connection{}, %{
+          world_id: Ecto.UUID.generate(),
+          type: "gmail",
+          status: "enabled",
+          config: %{
+            "provider" => "gmail",
+            "scopes" => ["https://www.googleapis.com/auth/gmail.compose"],
+            "client_id" => "$GMAIL_CLIENT_ID",
+            "client_secret" => "raw-client-secret",
+            "refresh_token" => "raw-refresh-token"
+          }
+        })
+
+      refute changeset.valid?
+      assert ".invalid_value" in errors_on(changeset).config
+    end
+
+    test "rejects gmail config with raw access token and authorization header fields" do
+      changeset =
+        Connection.changeset(%Connection{}, %{
+          world_id: Ecto.UUID.generate(),
+          type: "gmail",
+          status: "enabled",
+          config: %{
+            "provider" => "gmail",
+            "scopes" => ["https://www.googleapis.com/auth/gmail.compose"],
+            "client_id" => "$GMAIL_CLIENT_ID",
+            "client_secret" => "$GMAIL_CLIENT_SECRET",
+            "refresh_token" => "$GMAIL_REFRESH_TOKEN",
+            "access_token" => "raw-access-token",
+            "authorization" => "Bearer raw-header-token"
+          }
+        })
+
+      refute changeset.valid?
+      assert ".invalid_value" in errors_on(changeset).config
     end
 
     test "exposes canonical statuses helper" do

--- a/test/lemmings_os/connections/gmail_oauth/client_test.exs
+++ b/test/lemmings_os/connections/gmail_oauth/client_test.exs
@@ -1,0 +1,5 @@
+defmodule LemmingsOs.Connections.GmailOAuth.ClientTest do
+  use ExUnit.Case, async: true
+
+  doctest LemmingsOs.Connections.GmailOAuth.Client
+end

--- a/test/lemmings_os/connections/gmail_oauth_test.exs
+++ b/test/lemmings_os/connections/gmail_oauth_test.exs
@@ -1,0 +1,7 @@
+defmodule LemmingsOs.Connections.GmailOAuthTest do
+  use LemmingsOs.DataCase, async: true
+
+  alias LemmingsOs.Connections.GmailOAuth
+
+  doctest GmailOAuth
+end

--- a/test/lemmings_os/connections/gmail_oauth_test.exs
+++ b/test/lemmings_os/connections/gmail_oauth_test.exs
@@ -1,7 +1,42 @@
 defmodule LemmingsOs.Connections.GmailOAuthTest do
   use LemmingsOs.DataCase, async: true
 
+  import LemmingsOs.Factory
+
   alias LemmingsOs.Connections.GmailOAuth
+  alias LemmingsOs.SecretBank
 
   doctest GmailOAuth
+
+  defmodule ExplodingOAuthClient do
+    def exchange_code(_client_id, _client_secret, _code, _redirect_uri) do
+      raise "OAuth exchange should not run for invalid state"
+    end
+  end
+
+  test "complete/4 rejects a session state bound to a different scope before token exchange" do
+    world = insert(:world)
+    other_world = insert(:world)
+
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
+
+    assert {:ok, %{session_state: session_state}} =
+             GmailOAuth.start(
+               world,
+               %{
+                 "client_id" => "$GMAIL_CLIENT_ID",
+                 "client_secret" => "$GMAIL_CLIENT_SECRET"
+               },
+               redirect_uri: "https://example.test/oauth/callback"
+             )
+
+    assert {:error, :invalid_state} =
+             GmailOAuth.complete(
+               other_world,
+               %{"code" => "valid-code", "state" => session_state["state"]},
+               session_state,
+               redirect_uri: "https://example.test/oauth/callback",
+               oauth_client: ExplodingOAuthClient
+             )
+  end
 end

--- a/test/lemmings_os/connections/providers/gmail_caller_test.exs
+++ b/test/lemmings_os/connections/providers/gmail_caller_test.exs
@@ -1,0 +1,70 @@
+defmodule LemmingsOs.Connections.Providers.GmailCallerTest do
+  use LemmingsOs.DataCase, async: true
+
+  alias LemmingsOs.Connections.Providers.GmailCaller
+
+  doctest GmailCaller
+
+  describe "validate_config/1" do
+    test "accepts only safe gmail metadata with secret refs" do
+      assert :ok =
+               GmailCaller.validate_config(%{
+                 "provider" => "gmail",
+                 "account_email" => "ops@example.test",
+                 "scopes" => [GmailCaller.compose_scope()],
+                 "client_id" => "$GMAIL_CLIENT_ID",
+                 "client_secret" => "$GMAIL_CLIENT_SECRET",
+                 "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+               })
+    end
+
+    test "rejects raw credential values" do
+      assert {:error, :invalid_config} =
+               GmailCaller.validate_config(%{
+                 "provider" => "gmail",
+                 "scopes" => [GmailCaller.compose_scope()],
+                 "client_id" => "raw-client-id",
+                 "client_secret" => "raw-client-secret",
+                 "refresh_token" => "raw-refresh-token"
+               })
+    end
+
+    test "rejects extra credential-like keys such as access_token and authorization header" do
+      assert {:error, :invalid_config} =
+               GmailCaller.validate_config(%{
+                 "provider" => "gmail",
+                 "scopes" => [GmailCaller.compose_scope()],
+                 "client_id" => "$GMAIL_CLIENT_ID",
+                 "client_secret" => "$GMAIL_CLIENT_SECRET",
+                 "refresh_token" => "$GMAIL_REFRESH_TOKEN",
+                 "access_token" => "raw-access-token",
+                 "authorization" => "Bearer raw-header-value"
+               })
+    end
+
+    test "rejects password-like secrets even when keys are expected" do
+      assert {:error, :invalid_config} =
+               GmailCaller.validate_config(%{
+                 "provider" => "gmail",
+                 "scopes" => [GmailCaller.compose_scope()],
+                 "client_id" => "$GMAIL_CLIENT_ID",
+                 "client_secret" => "password123!",
+                 "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+               })
+    end
+
+    test "rejects non-compose or multi-scope lists" do
+      assert {:error, :invalid_config} =
+               GmailCaller.validate_config(%{
+                 "provider" => "gmail",
+                 "scopes" => [
+                   GmailCaller.compose_scope(),
+                   "https://www.googleapis.com/auth/gmail.readonly"
+                 ],
+                 "client_id" => "$GMAIL_CLIENT_ID",
+                 "client_secret" => "$GMAIL_CLIENT_SECRET",
+                 "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+               })
+    end
+  end
+end

--- a/test/lemmings_os/connections/type_registry_test.exs
+++ b/test/lemmings_os/connections/type_registry_test.exs
@@ -2,4 +2,15 @@ defmodule LemmingsOs.Connections.TypeRegistryTest do
   use LemmingsOs.DataCase, async: true
 
   doctest LemmingsOs.Connections.TypeRegistry
+
+  alias LemmingsOs.Connections.TypeRegistry
+
+  test "registers gmail type and keeps mock" do
+    types = TypeRegistry.list_types()
+    type_ids = Enum.map(types, & &1.id)
+
+    assert "mock" in type_ids
+    assert "gmail" in type_ids
+    assert TypeRegistry.module_for_type("gmail") == LemmingsOs.Connections.Providers.GmailCaller
+  end
 end

--- a/test/lemmings_os/lemming_tools_test.exs
+++ b/test/lemmings_os/lemming_tools_test.exs
@@ -153,6 +153,78 @@ defmodule LemmingsOs.LemmingToolsTest do
     end
   end
 
+  describe "email.create_draft privacy projection" do
+    test "sanitizes persisted args and result for email drafts" do
+      %{world: world, instance: instance} = spawn_instance_fixture()
+
+      assert {:ok, tool_execution} =
+               LemmingTools.create_tool_execution(world, instance, %{
+                 tool_name: "email.create_draft",
+                 status: "running",
+                 args: %{
+                   "connection_ref" => "gmail",
+                   "to" => ["customer@example.com", "ops@example.com"],
+                   "cc" => "sales@example.com, finance@example.com",
+                   "bcc" => ["private@example.com"],
+                   "subject" => "Sensitive renewal quote for ACME",
+                   "body" => "full body should not be persisted",
+                   "body_format" => "text/plain",
+                   "artifact_ids" => ["artifact-1"]
+                 }
+               })
+
+      assert tool_execution.args == %{
+               "connection_ref" => "gmail",
+               "to_count" => 2,
+               "cc_count" => 2,
+               "bcc_count" => 1,
+               "subject_preview" => "Sensitive renewal quote for ACME",
+               "body_bytes" => 33,
+               "body_format" => "text/plain",
+               "artifact_count" => 1,
+               "artifact_ids" => ["artifact-1"]
+             }
+
+      assert {:ok, updated_execution} =
+               LemmingTools.update_tool_execution(world, instance, tool_execution, %{
+                 status: "ok",
+                 result: %{
+                   "status" => "draft_created",
+                   "provider" => "gmail",
+                   "connection_ref" => "gmail",
+                   "draft_id" => "draft-123",
+                   "message_id" => "message-123",
+                   "to" => ["customer@example.com"],
+                   "cc" => [],
+                   "bcc" => ["private@example.com"],
+                   "subject" => "Sensitive renewal quote for ACME",
+                   "artifact_ids" => ["artifact-1"],
+                   "raw_provider_payload" => %{"private" => true}
+                 }
+               })
+
+      assert updated_execution.result == %{
+               "status" => "draft_created",
+               "provider" => "gmail",
+               "connection_ref" => "gmail",
+               "draft_id" => "draft-123",
+               "message_id" => "message-123",
+               "to_count" => 1,
+               "cc_count" => 0,
+               "bcc_count" => 1,
+               "subject_preview" => "Sensitive renewal quote for ACME",
+               "artifact_count" => 1,
+               "artifact_ids" => ["artifact-1"]
+             }
+
+      persisted = inspect(%{args: updated_execution.args, result: updated_execution.result})
+      refute persisted =~ "customer@example.com"
+      refute persisted =~ "private@example.com"
+      refute persisted =~ "full body should not be persisted"
+      refute persisted =~ "raw_provider_payload"
+    end
+  end
+
   defp spawn_instance_fixture do
     world = insert(:world)
     city = insert(:city, world: world)

--- a/test/lemmings_os/model_runtime_test.exs
+++ b/test/lemmings_os/model_runtime_test.exs
@@ -469,6 +469,28 @@ defmodule LemmingsOs.ModelRuntimeTest do
     assert List.last(request.messages) == %{role: "user", content: "Write notes/output.md"}
   end
 
+  test "S08a: debug_request/3 exposes email draft argument contract" do
+    config_snapshot = %{
+      name: "Customer Follow-up",
+      description: "Prepares customer updates after support triage completes.",
+      provider_module: FakeProvider,
+      model: "test-model",
+      tools_config: %{allowed_tools: ["email.create_draft"]}
+    }
+
+    assert {:ok, %{request: request}} =
+             ModelRuntime.debug_request(config_snapshot, [], %{content: "Draft a follow-up"})
+
+    assert %{role: "system", content: system_prompt} = Enum.at(request.messages, 0)
+
+    assert String.contains?(system_prompt, "- email.create_draft:")
+    assert String.contains?(system_prompt, "args: required `connection_ref`")
+    assert String.contains?(system_prompt, "`to` (recipient email string")
+    assert String.contains?(system_prompt, "optional `cc`/`bcc`")
+    assert String.contains?(system_prompt, "optional `body_format` (`text/plain` default")
+    assert String.contains?(system_prompt, "Creates a Gmail draft only; never sends email.")
+  end
+
   test "S09: debug_request/3 keeps one user message when current request already exists in history" do
     config_snapshot = %{
       name: "Budget Brief",

--- a/test/lemmings_os/tools/adapters/email/gmail_client_test.exs
+++ b/test/lemmings_os/tools/adapters/email/gmail_client_test.exs
@@ -5,6 +5,15 @@ defmodule LemmingsOs.Tools.Adapters.Email.GmailClientTest do
 
   doctest GmailClient
 
+  test "does not expose public Gmail send, read, list, sync, or delete functions" do
+    refute function_exported?(GmailClient, :send_message, 3)
+    refute function_exported?(GmailClient, :send_email, 3)
+    refute function_exported?(GmailClient, :read_message, 2)
+    refute function_exported?(GmailClient, :list_messages, 2)
+    refute function_exported?(GmailClient, :sync_messages, 2)
+    refute function_exported?(GmailClient, :delete_message, 2)
+  end
+
   test "exchange_refresh_token/4 returns access token on success" do
     bypass = Bypass.open()
 

--- a/test/lemmings_os/tools/adapters/email/gmail_client_test.exs
+++ b/test/lemmings_os/tools/adapters/email/gmail_client_test.exs
@@ -1,0 +1,76 @@
+defmodule LemmingsOs.Tools.Adapters.Email.GmailClientTest do
+  use ExUnit.Case, async: true
+
+  alias LemmingsOs.Tools.Adapters.Email.GmailClient
+
+  doctest GmailClient
+
+  test "exchange_refresh_token/4 returns access token on success" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "POST", "/token", fn conn ->
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+      Plug.Conn.resp(conn, 200, ~s({"access_token":"token-123","token_type":"Bearer"}))
+    end)
+
+    assert {:ok, "token-123"} =
+             GmailClient.exchange_refresh_token(
+               "client-id",
+               "client-secret",
+               "refresh-token",
+               token_url: "http://localhost:#{bypass.port}/token"
+             )
+  end
+
+  test "exchange_refresh_token/4 returns auth_failed on non-success status" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "POST", "/token", fn conn ->
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+      Plug.Conn.resp(conn, 400, ~s({"error":"invalid_grant"}))
+    end)
+
+    assert {:error, :auth_failed} =
+             GmailClient.exchange_refresh_token(
+               "client-id",
+               "client-secret",
+               "refresh-token",
+               token_url: "http://localhost:#{bypass.port}/token"
+             )
+  end
+
+  test "create_draft/3 returns draft descriptor on success" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "POST", "/drafts", fn conn ->
+      assert ["Bearer access-token-123"] == Plug.Conn.get_req_header(conn, "authorization")
+      {:ok, body, conn} = Plug.Conn.read_body(conn)
+      assert %{"message" => %{"raw" => "raw-message"}} = Jason.decode!(body)
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+      Plug.Conn.resp(conn, 200, ~s({"id":"draft-42","message":{"id":"message-42"}}))
+    end)
+
+    assert {:ok, %{draft_id: "draft-42", message_id: "message-42"}} =
+             GmailClient.create_draft(
+               "access-token-123",
+               "raw-message",
+               drafts_url: "http://localhost:#{bypass.port}/drafts"
+             )
+  end
+
+  test "create_draft/3 returns draft_failed when response body is invalid" do
+    bypass = Bypass.open()
+
+    Bypass.expect_once(bypass, "POST", "/drafts", fn conn ->
+      conn = Plug.Conn.put_resp_content_type(conn, "application/json")
+      Plug.Conn.resp(conn, 200, ~s({"message":{"id":"message-only"}}))
+    end)
+
+    assert {:error, :draft_failed} =
+             GmailClient.create_draft(
+               "access-token-123",
+               "raw-message",
+               drafts_url: "http://localhost:#{bypass.port}/drafts"
+             )
+  end
+end

--- a/test/lemmings_os/tools/adapters/email_test.exs
+++ b/test/lemmings_os/tools/adapters/email_test.exs
@@ -89,6 +89,66 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
     assert mime =~ "Subject: Plain text draft"
   end
 
+  test "normalizes string recipients, blank optional recipients, and default body format",
+       context do
+    put_gmail_runtime_config!(context)
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => "first@example.com, second@example.com",
+                 "cc" => "",
+                 "bcc" => nil,
+                 "subject" => "Default format draft",
+                 "body" => "Hello from LemmingsOS"
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert result.result["to"] == ["first@example.com", "second@example.com"]
+    assert result.result["cc"] == []
+    assert result.result["bcc"] == []
+
+    assert_receive {:email_draft_create_called, "access-token", raw_message}
+    assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+    assert mime =~ "Content-Type: text/plain; charset=\"UTF-8\""
+    assert mime =~ "To: first@example.com, second@example.com"
+    refute mime =~ "\r\nCc:"
+    refute mime =~ "\r\nBcc:"
+  end
+
+  test "normalizes comma-separated cc and bcc recipient strings", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["customer@example.com"],
+                 "cc" => "ops@example.com, sales@example.com",
+                 "bcc" => "audit@example.com",
+                 "subject" => "Recipient draft",
+                 "body" => "Hello",
+                 "body_format" => ""
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert result.result["cc"] == ["ops@example.com", "sales@example.com"]
+    assert result.result["bcc"] == ["audit@example.com"]
+
+    assert_receive {:email_draft_create_called, "access-token", raw_message}
+    assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+    assert mime =~ "Cc: ops@example.com, sales@example.com"
+    assert mime =~ "Bcc: audit@example.com"
+    assert mime =~ "Content-Type: text/plain; charset=\"UTF-8\""
+  end
+
   test "creates a Gmail draft with text/html body and one attachment", context do
     put_gmail_runtime_config!(context)
     artifact = insert_ready_artifact!(context, "quote.pdf", "application/pdf", "%PDF-1.4 body")
@@ -297,6 +357,63 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
              )
 
     assert "attachment_paths" in fields
+  end
+
+  test "invalid arguments emit safe draft_failed event without raw input values", context do
+    put_gmail_runtime_config!(context)
+
+    raw_body = "sentinel body should not be observed"
+    raw_subject = "sentinel subject should not be observed"
+    raw_recipient = "raw-recipient@example.com"
+    raw_path = "/tmp/sentinel-secret.pdf"
+    raw_token = "sentinel-access-token"
+
+    assert {:error, %{code: "tool.validation.invalid_args"} = error} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => [raw_recipient],
+                 "subject" => raw_subject,
+                 "body" => raw_body,
+                 "body_format" => "text/plain",
+                 "attachment_paths" => [raw_path],
+                 "access_token" => raw_token
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert error.details.unsupported_fields == ["access_token", "attachment_paths"]
+
+    [event] =
+      Events.list_recent_events(
+        %{
+          world_id: context.world.id,
+          city_id: context.city.id,
+          department_id: context.department.id,
+          lemming_id: context.lemming.id
+        },
+        event_types: ["email.draft_failed"],
+        limit: 1
+      )
+
+    assert event.payload["world_id"] == context.world.id
+    assert event.payload["city_id"] == context.city.id
+    assert event.payload["department_id"] == context.department.id
+    assert event.payload["lemming_instance_id"] == context.instance.id
+    assert event.payload["tool_name"] == "email.create_draft"
+    assert event.payload["status"] == "failed"
+    assert event.payload["error_code"] == "invalid_args"
+
+    inspected_payload = inspect(event.payload)
+    refute inspected_payload =~ raw_body
+    refute inspected_payload =~ raw_subject
+    refute inspected_payload =~ raw_recipient
+    refute inspected_payload =~ raw_path
+    refute inspected_payload =~ raw_token
+    refute inspected_payload =~ "attachment_paths"
+    refute inspected_payload =~ "access_token"
   end
 
   test "returns safe artifact errors for missing, non-ready, not-allowed, and broken storage",

--- a/test/lemmings_os/tools/adapters/email_test.exs
+++ b/test/lemmings_os/tools/adapters/email_test.exs
@@ -13,6 +13,7 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
 
   setup do
     old_storage = Application.get_env(:lemmings_os, :artifact_storage)
+    old_email_draft = Application.get_env(:lemmings_os, :email_draft)
 
     storage_root =
       Path.join(
@@ -41,6 +42,12 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
         Application.put_env(:lemmings_os, :artifact_storage, old_storage)
       else
         Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+
+      if old_email_draft do
+        Application.put_env(:lemmings_os, :email_draft, old_email_draft)
+      else
+        Application.delete_env(:lemmings_os, :email_draft)
       end
 
       File.rm_rf(storage_root)
@@ -72,15 +79,21 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
                success_config(self())
              )
 
-    assert result.summary == "Created Gmail draft for customer@example.com with 0 attachments"
+    assert result.summary == "Created Gmail draft for 1 recipient(s) with 0 attachments"
     assert result.preview == "Subject: Plain text draft"
     assert result.result["status"] == "draft_created"
     assert result.result["provider"] == "gmail"
     assert result.result["connection_ref"] == "gmail"
     assert result.result["draft_id"] == "draft-abc"
     assert result.result["message_id"] == "message-abc"
-    assert result.result["to"] == ["customer@example.com"]
+    assert result.result["to_count"] == 1
+    assert result.result["cc_count"] == 0
+    assert result.result["bcc_count"] == 0
+    assert result.result["subject_preview"] == "Plain text draft"
+    assert result.result["artifact_count"] == 0
     assert result.result["artifact_ids"] == []
+    refute Map.has_key?(result.result, "to")
+    refute Map.has_key?(result.result, "subject")
 
     assert_receive {:email_draft_create_called, "access-token", raw_message}
     assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
@@ -108,9 +121,9 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
                success_config(self())
              )
 
-    assert result.result["to"] == ["first@example.com", "second@example.com"]
-    assert result.result["cc"] == []
-    assert result.result["bcc"] == []
+    assert result.result["to_count"] == 2
+    assert result.result["cc_count"] == 0
+    assert result.result["bcc_count"] == 0
 
     assert_receive {:email_draft_create_called, "access-token", raw_message}
     assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
@@ -139,8 +152,8 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
                success_config(self())
              )
 
-    assert result.result["cc"] == ["ops@example.com", "sales@example.com"]
-    assert result.result["bcc"] == ["audit@example.com"]
+    assert result.result["cc_count"] == 2
+    assert result.result["bcc_count"] == 1
 
     assert_receive {:email_draft_create_called, "access-token", raw_message}
     assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
@@ -170,7 +183,8 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
              )
 
     assert result.result["artifact_ids"] == [artifact.id]
-    assert result.result["cc"] == ["team@example.com"]
+    assert result.result["cc_count"] == 1
+    assert result.result["artifact_count"] == 1
 
     assert_receive {:email_draft_create_called, "access-token", raw_message}
     assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
@@ -478,6 +492,95 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
              )
   end
 
+  test "rejects an individual attachment larger than configured megabyte limit", context do
+    put_gmail_runtime_config!(context)
+    put_email_draft_config!(max_attachment_megabytes: 0.000001)
+
+    artifact =
+      insert_metadata_only_artifact!(context,
+        filename: "large-secret-name.pdf",
+        storage_ref: "local://private/storage/ref.pdf",
+        size_bytes: 2
+      )
+
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [artifact.id]),
+               %{},
+               success_config(self())
+             )
+
+    assert error == %{
+             code: "tool.email.attachment_too_large",
+             message: "Attachment exceeds configured draft limit",
+             details: %{artifact_id: artifact.id}
+           }
+
+    refute_receive {:email_draft_exchange_called, _access_token}
+    refute_receive {:email_draft_create_called, _access_token, _raw_message}
+
+    [event] = recent_email_failed_events(context)
+    assert event.payload["error_code"] == "tool.email.attachment_too_large"
+    assert event.payload["artifact_ids"] == [artifact.id]
+
+    inspected_payload = inspect(event.payload)
+    refute inspected_payload =~ "large-secret-name.pdf"
+    refute inspected_payload =~ "local://private/storage/ref.pdf"
+  end
+
+  test "rejects attachments whose total size exceeds configured megabyte limit", context do
+    put_gmail_runtime_config!(context)
+
+    put_email_draft_config!(
+      max_attachment_megabytes: 1,
+      max_total_attachment_megabytes: 0.000003
+    )
+
+    first = insert_metadata_only_artifact!(context, size_bytes: 2)
+    second = insert_metadata_only_artifact!(context, size_bytes: 2)
+
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [first.id, second.id]),
+               %{},
+               success_config(self())
+             )
+
+    assert error.code == "tool.email.attachment_too_large"
+    assert error.message == "Attachment exceeds configured draft limit"
+    assert error.details == %{artifact_id: second.id}
+
+    refute_receive {:email_draft_exchange_called, _access_token}
+    refute_receive {:email_draft_create_called, _access_token, _raw_message}
+  end
+
+  test "rejects too many attachments before calling Gmail client", context do
+    put_gmail_runtime_config!(context)
+    put_email_draft_config!(max_attachment_count: 1)
+
+    first_id = Ecto.UUID.generate()
+    second_id = Ecto.UUID.generate()
+
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [first_id, second_id]),
+               %{},
+               success_config(self())
+             )
+
+    assert error == %{
+             code: "tool.email.attachment_too_large",
+             message: "Attachment exceeds configured draft limit",
+             details: %{}
+           }
+
+    refute_receive {:email_draft_exchange_called, _access_token}
+    refute_receive {:email_draft_create_called, _access_token, _raw_message}
+  end
+
   test "events are emitted and payload/result do not leak secrets or provider tokens", context do
     raw_client_secret = "sentinel-client-secret"
     raw_refresh_token = "sentinel-refresh-token"
@@ -558,6 +661,21 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
         "access_token" => Keyword.get(opts, :access_token, "access-token")
       }
     }
+  end
+
+  defp put_email_draft_config!(overrides) do
+    config =
+      Keyword.merge(
+        [
+          max_attachment_count: 5,
+          max_attachment_megabytes: 10,
+          max_total_attachment_megabytes: 20,
+          max_body_megabytes: 0.2
+        ],
+        overrides
+      )
+
+    Application.put_env(:lemmings_os, :email_draft, config)
   end
 
   defp put_gmail_runtime_config!(context, opts \\ []) do
@@ -646,6 +764,45 @@ defmodule LemmingsOs.Tools.Adapters.EmailTest do
       checksum: String.duplicate("a", 64),
       status: "ready",
       metadata: %{"source" => "manual_promotion"}
+    )
+  end
+
+  defp insert_metadata_only_artifact!(context, opts) do
+    artifact_id = Ecto.UUID.generate()
+
+    insert(:artifact,
+      id: artifact_id,
+      world: context.world,
+      city: context.city,
+      department: context.department,
+      lemming: context.lemming,
+      lemming_instance: nil,
+      type: "other",
+      filename: Keyword.get(opts, :filename, "attachment.bin"),
+      content_type: Keyword.get(opts, :content_type, "application/octet-stream"),
+      storage_ref:
+        Keyword.get(
+          opts,
+          :storage_ref,
+          "local://artifacts/#{context.world.id}/#{artifact_id}/attachment.bin"
+        ),
+      size_bytes: Keyword.get(opts, :size_bytes, 1),
+      checksum: String.duplicate("c", 64),
+      status: "ready",
+      metadata: %{"source" => "manual_promotion"}
+    )
+  end
+
+  defp recent_email_failed_events(context) do
+    Events.list_recent_events(
+      %{
+        world_id: context.world.id,
+        city_id: context.city.id,
+        department_id: context.department.id,
+        lemming_id: context.lemming.id
+      },
+      event_types: ["email.draft_failed"],
+      limit: 1
     )
   end
 end

--- a/test/lemmings_os/tools/adapters/email_test.exs
+++ b/test/lemmings_os/tools/adapters/email_test.exs
@@ -1,0 +1,534 @@
+defmodule LemmingsOs.Tools.Adapters.EmailTest do
+  use LemmingsOs.DataCase, async: false
+
+  import ExUnit.CaptureLog
+
+  alias LemmingsOs.Artifacts.LocalStorage
+  alias LemmingsOs.Connections.Providers.GmailCaller
+  alias LemmingsOs.Events
+  alias LemmingsOs.SecretBank
+  alias LemmingsOs.Tools.Adapters.Email
+
+  doctest Email
+
+  setup do
+    old_storage = Application.get_env(:lemmings_os, :artifact_storage)
+
+    storage_root =
+      Path.join(
+        System.tmp_dir!(),
+        "lemmings_email_adapter_test_#{System.unique_integer([:positive])}"
+      )
+
+    Application.put_env(:lemmings_os, :artifact_storage, backend: :local, root_path: storage_root)
+    File.mkdir_p!(storage_root)
+
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+    lemming = insert(:lemming, world: world, city: city, department: department)
+
+    instance =
+      insert(:lemming_instance,
+        world: world,
+        city: city,
+        department: department,
+        lemming: lemming
+      )
+
+    on_exit(fn ->
+      if old_storage do
+        Application.put_env(:lemmings_os, :artifact_storage, old_storage)
+      else
+        Application.delete_env(:lemmings_os, :artifact_storage)
+      end
+
+      File.rm_rf(storage_root)
+    end)
+
+    {:ok,
+     world: world,
+     city: city,
+     department: department,
+     lemming: lemming,
+     instance: instance,
+     storage_root: storage_root}
+  end
+
+  test "creates a Gmail draft with text/plain body and no attachments", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["customer@example.com"],
+                 "subject" => "Plain text draft",
+                 "body" => "Hello from LemmingsOS",
+                 "body_format" => "text/plain"
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert result.summary == "Created Gmail draft for customer@example.com with 0 attachments"
+    assert result.preview == "Subject: Plain text draft"
+    assert result.result["status"] == "draft_created"
+    assert result.result["provider"] == "gmail"
+    assert result.result["connection_ref"] == "gmail"
+    assert result.result["draft_id"] == "draft-abc"
+    assert result.result["message_id"] == "message-abc"
+    assert result.result["to"] == ["customer@example.com"]
+    assert result.result["artifact_ids"] == []
+
+    assert_receive {:email_draft_create_called, "access-token", raw_message}
+    assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+    assert mime =~ "Content-Type: text/plain; charset=\"UTF-8\""
+    assert mime =~ "To: customer@example.com"
+    assert mime =~ "Subject: Plain text draft"
+  end
+
+  test "creates a Gmail draft with text/html body and one attachment", context do
+    put_gmail_runtime_config!(context)
+    artifact = insert_ready_artifact!(context, "quote.pdf", "application/pdf", "%PDF-1.4 body")
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["sales@example.com"],
+                 "cc" => ["team@example.com"],
+                 "subject" => "Quote draft",
+                 "body" => "<p>Quote attached</p>",
+                 "body_format" => "text/html",
+                 "artifact_ids" => [artifact.id]
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert result.result["artifact_ids"] == [artifact.id]
+    assert result.result["cc"] == ["team@example.com"]
+
+    assert_receive {:email_draft_create_called, "access-token", raw_message}
+    assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+    assert mime =~ "Content-Type: multipart/mixed"
+    assert mime =~ "Content-Type: text/html; charset=\"UTF-8\""
+    assert mime =~ "Content-Type: application/pdf; name=\"quote.pdf\""
+    assert mime =~ "Content-Disposition: attachment; filename=\"quote.pdf\""
+  end
+
+  test "creates a Gmail draft with multiple attachments", context do
+    put_gmail_runtime_config!(context)
+    first = insert_ready_artifact!(context, "a.txt", "text/plain", "A content")
+    second = insert_ready_artifact!(context, "b.txt", "text/plain", "B content")
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["ops@example.com"],
+                 "subject" => "Multi attachment draft",
+                 "body" => "See files",
+                 "body_format" => "text/plain",
+                 "artifact_ids" => [first.id, second.id]
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert result.result["artifact_ids"] == [first.id, second.id]
+    assert_receive {:email_draft_create_called, "access-token", raw_message}
+    assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+    assert mime =~ "filename=\"a.txt\""
+    assert mime =~ "filename=\"b.txt\""
+  end
+
+  test "returns connection_not_found when Gmail connection is missing", context do
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["ops@example.com"],
+                 "subject" => "Missing connection",
+                 "body" => "Body",
+                 "body_format" => "text/plain"
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert error.code == "tool.email.connection_not_found"
+  end
+
+  test "returns connection_not_allowed for disabled or invalid Gmail connection", context do
+    put_gmail_runtime_config!(context)
+    connection = LemmingsOs.Connections.get_connection_by_type(context.world, "gmail")
+
+    assert {:ok, _} =
+             LemmingsOs.Connections.update_connection(context.world, connection, %{
+               status: "disabled"
+             })
+
+    assert {:error, %{code: "tool.email.connection_not_allowed"}} =
+             Email.create_draft(
+               context.instance,
+               valid_args(),
+               %{},
+               success_config(self())
+             )
+
+    assert {:ok, _} =
+             LemmingsOs.Connections.update_connection(context.world, connection, %{
+               status: "invalid"
+             })
+
+    assert {:error, %{code: "tool.email.connection_not_allowed"}} =
+             Email.create_draft(
+               context.instance,
+               valid_args(),
+               %{},
+               success_config(self())
+             )
+  end
+
+  test "returns connection_auth_failed when refresh token exchange fails", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               valid_args(),
+               %{},
+               %{
+                 "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientAuthFailure
+               }
+             )
+
+    assert error.code == "tool.email.connection_auth_failed"
+  end
+
+  test "returns draft_create_failed when provider draft call fails", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:error, error} =
+             Email.create_draft(
+               context.instance,
+               valid_args(),
+               %{},
+               %{
+                 "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientDraftFailure
+               }
+             )
+
+    assert error.code == "tool.email.draft_create_failed"
+  end
+
+  test "falls back to default Gmail client when trusted gmail_client is nil", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:ok, result} =
+             Email.create_draft(
+               context.instance,
+               valid_args(),
+               %{},
+               %{
+                 "gmail_client" => nil,
+                 "gmail_client_opts" => %{
+                   "req" => LemmingsOs.TestSupport.EmailDraftReqSuccess
+                 }
+               }
+             )
+
+    assert result.result["status"] == "draft_created"
+    assert result.result["draft_id"] == "draft-123"
+    assert result.result["message_id"] == "message-123"
+  end
+
+  test "validates recipients, body format, and rejects raw path fields", context do
+    put_gmail_runtime_config!(context)
+
+    assert {:error, %{code: "tool.email.invalid_recipient", details: %{field: "to"}}} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["not-an-email"],
+                 "subject" => "Invalid",
+                 "body" => "Body",
+                 "body_format" => "text/plain"
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert {:error, %{code: "tool.email.invalid_body_format"}} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["valid@example.com"],
+                 "subject" => "Invalid format",
+                 "body" => "Body",
+                 "body_format" => "text/markdown"
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert {:error,
+            %{code: "tool.validation.invalid_args", details: %{unsupported_fields: fields}}} =
+             Email.create_draft(
+               context.instance,
+               %{
+                 "connection_ref" => "gmail",
+                 "to" => ["valid@example.com"],
+                 "subject" => "Invalid field",
+                 "body" => "Body",
+                 "body_format" => "text/plain",
+                 "attachment_paths" => ["/tmp/secret.pdf"]
+               },
+               %{},
+               success_config(self())
+             )
+
+    assert "attachment_paths" in fields
+  end
+
+  test "returns safe artifact errors for missing, non-ready, not-allowed, and broken storage",
+       context do
+    put_gmail_runtime_config!(context)
+
+    missing_id = Ecto.UUID.generate()
+
+    assert {:error, %{code: "tool.email.artifact_not_found"}} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [missing_id]),
+               %{},
+               success_config(self())
+             )
+
+    non_ready =
+      insert_ready_artifact!(context, "archived.txt", "text/plain", "archived",
+        status: "archived"
+      )
+
+    assert {:error, %{code: "tool.email.artifact_not_found"}} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [non_ready.id]),
+               %{},
+               success_config(self())
+             )
+
+    other_lemming =
+      insert(:lemming,
+        world: context.world,
+        city: context.city,
+        department: context.department
+      )
+
+    not_allowed =
+      insert_ready_artifact!(
+        context,
+        "other-owner.txt",
+        "text/plain",
+        "content",
+        lemming: other_lemming
+      )
+
+    assert {:error, %{code: "tool.email.artifact_not_allowed"}} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [not_allowed.id]),
+               %{},
+               success_config(self())
+             )
+
+    broken = insert_broken_ready_artifact!(context, "broken.txt", "text/plain")
+
+    assert {:error, %{code: "tool.email.artifact_not_found"}} =
+             Email.create_draft(
+               context.instance,
+               Map.put(valid_args(), "artifact_ids", [broken.id]),
+               %{},
+               success_config(self())
+             )
+  end
+
+  test "events are emitted and payload/result do not leak secrets or provider tokens", context do
+    raw_client_secret = "sentinel-client-secret"
+    raw_refresh_token = "sentinel-refresh-token"
+    raw_access_token = "sentinel-access-token"
+    raw_auth_code = "sentinel-auth-code"
+
+    put_gmail_runtime_config!(context,
+      client_secret_value: raw_client_secret,
+      refresh_token_value: raw_refresh_token
+    )
+
+    log =
+      capture_log(fn ->
+        assert {:ok, result} =
+                 Email.create_draft(
+                   context.instance,
+                   valid_args(),
+                   %{},
+                   success_config(self(), access_token: raw_access_token)
+                 )
+
+        assert inspect(result) =~ "draft_created"
+        refute inspect(result) =~ raw_client_secret
+        refute inspect(result) =~ raw_refresh_token
+        refute inspect(result) =~ raw_access_token
+        refute inspect(result) =~ raw_auth_code
+      end)
+
+    refute log =~ raw_client_secret
+    refute log =~ raw_refresh_token
+    refute log =~ raw_access_token
+    refute log =~ raw_auth_code
+
+    events =
+      Events.list_recent_events(
+        %{
+          world_id: context.world.id,
+          city_id: context.city.id,
+          department_id: context.department.id,
+          lemming_id: context.lemming.id
+        },
+        event_types: ["email.draft_requested", "email.draft_created"],
+        limit: 10
+      )
+
+    assert Enum.any?(events, &(&1.event_type == "email.draft_requested"))
+    assert Enum.any?(events, &(&1.event_type == "email.draft_created"))
+
+    inspected_payloads = Enum.map_join(events, "\n", &inspect(&1.payload))
+    refute inspected_payloads =~ raw_client_secret
+    refute inspected_payloads =~ raw_refresh_token
+    refute inspected_payloads =~ raw_access_token
+    refute inspected_payloads =~ raw_auth_code
+
+    connection = LemmingsOs.Connections.get_connection_by_type(context.world, "gmail")
+    assert connection.config["client_id"] == "$GMAIL_CLIENT_ID"
+    assert connection.config["client_secret"] == "$GMAIL_CLIENT_SECRET"
+    assert connection.config["refresh_token"] == "$GMAIL_REFRESH_TOKEN"
+    refute inspect(connection.config) =~ raw_client_secret
+    refute inspect(connection.config) =~ raw_refresh_token
+  end
+
+  defp valid_args do
+    %{
+      "connection_ref" => "gmail",
+      "to" => ["ops@example.com"],
+      "subject" => "Test draft",
+      "body" => "Hello",
+      "body_format" => "text/plain"
+    }
+  end
+
+  defp success_config(pid, opts \\ []) do
+    %{
+      "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientSuccess,
+      "gmail_client_opts" => %{
+        "test_pid" => pid,
+        "access_token" => Keyword.get(opts, :access_token, "access-token")
+      }
+    }
+  end
+
+  defp put_gmail_runtime_config!(context, opts \\ []) do
+    client_id_value = Keyword.get(opts, :client_id_value, "client-id-value")
+    client_secret_value = Keyword.get(opts, :client_secret_value, "client-secret-value")
+    refresh_token_value = Keyword.get(opts, :refresh_token_value, "refresh-token-value")
+
+    assert {:ok, _} = SecretBank.upsert_secret(context.world, "GMAIL_CLIENT_ID", client_id_value)
+
+    assert {:ok, _} =
+             SecretBank.upsert_secret(context.world, "GMAIL_CLIENT_SECRET", client_secret_value)
+
+    assert {:ok, _} =
+             SecretBank.upsert_secret(context.world, "GMAIL_REFRESH_TOKEN", refresh_token_value)
+
+    config = %{
+      "provider" => "gmail",
+      "account_email" => "ops@example.com",
+      "scopes" => [GmailCaller.compose_scope()],
+      "client_id" => "$GMAIL_CLIENT_ID",
+      "client_secret" => "$GMAIL_CLIENT_SECRET",
+      "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+    }
+
+    case LemmingsOs.Connections.get_connection_by_type(context.world, "gmail") do
+      nil ->
+        insert(:world_connection,
+          world: context.world,
+          type: "gmail",
+          status: "enabled",
+          config: config
+        )
+
+      connection ->
+        assert {:ok, _} =
+                 LemmingsOs.Connections.update_connection(context.world, connection, %{
+                   status: "enabled",
+                   config: config
+                 })
+    end
+  end
+
+  defp insert_ready_artifact!(context, filename, content_type, content, opts \\ []) do
+    artifact_id = Ecto.UUID.generate()
+    source_path = Path.join(context.storage_root, "source_#{artifact_id}")
+    lemming = Keyword.get(opts, :lemming, context.lemming)
+    status = Keyword.get(opts, :status, "ready")
+    File.write!(source_path, content)
+
+    {:ok, stored} = LocalStorage.store_copy(context.world.id, artifact_id, source_path, filename)
+
+    insert(:artifact,
+      id: artifact_id,
+      world: context.world,
+      city: context.city,
+      department: context.department,
+      lemming: lemming,
+      lemming_instance: nil,
+      type: "other",
+      filename: filename,
+      content_type: content_type,
+      storage_ref: stored.storage_ref,
+      size_bytes: stored.size_bytes,
+      checksum: stored.checksum,
+      status: status,
+      metadata: %{"source" => "manual_promotion"}
+    )
+  end
+
+  defp insert_broken_ready_artifact!(context, filename, content_type) do
+    artifact_id = Ecto.UUID.generate()
+    {:ok, storage_ref} = LocalStorage.build_storage_ref(context.world.id, artifact_id, filename)
+
+    insert(:artifact,
+      id: artifact_id,
+      world: context.world,
+      city: context.city,
+      department: context.department,
+      lemming: context.lemming,
+      lemming_instance: nil,
+      type: "other",
+      filename: filename,
+      content_type: content_type,
+      storage_ref: storage_ref,
+      size_bytes: 100,
+      checksum: String.duplicate("a", 64),
+      status: "ready",
+      metadata: %{"source" => "manual_promotion"}
+    )
+  end
+end

--- a/test/lemmings_os/tools/catalog_test.exs
+++ b/test/lemmings_os/tools/catalog_test.exs
@@ -19,6 +19,25 @@ defmodule LemmingsOs.Tools.CatalogTest do
                %{id: "email.create_draft"}
              ] = Catalog.list_tools()
     end
+
+    test "exposes only draft creation for Gmail/email behavior" do
+      tool_ids = Catalog.list_tools() |> Enum.map(& &1.id)
+
+      assert "email.create_draft" in tool_ids
+
+      gmail_or_email_tool_ids =
+        Enum.filter(tool_ids, fn tool_id ->
+          String.starts_with?(tool_id, ["email.", "gmail."])
+        end)
+
+      refute Enum.any?(gmail_or_email_tool_ids, fn tool_id ->
+               String.contains?(tool_id, ["send", "read", "sync", "list", "delete"])
+             end)
+
+      for unsupported <- unsupported_gmail_tools() do
+        refute unsupported in tool_ids
+      end
+    end
   end
 
   describe "supported_tool?/1" do
@@ -35,6 +54,12 @@ defmodule LemmingsOs.Tools.CatalogTest do
       assert Catalog.supported_tool?("email.create_draft")
       refute Catalog.supported_tool?("exec.run")
     end
+
+    test "does not support Gmail send, read, list, sync, or delete tools" do
+      for unsupported <- unsupported_gmail_tools() do
+        refute Catalog.supported_tool?(unsupported)
+      end
+    end
   end
 
   describe "DefaultRuntimeFetcher.fetch/0" do
@@ -42,5 +67,24 @@ defmodule LemmingsOs.Tools.CatalogTest do
       assert {:ok, runtime_tools} = DefaultRuntimeFetcher.fetch()
       assert runtime_tools == Catalog.list_tools()
     end
+  end
+
+  defp unsupported_gmail_tools do
+    ~w(
+      email.send
+      email.send_approved
+      email.read
+      email.list
+      email.sync
+      email.delete
+      gmail.send
+      gmail.read
+      gmail.list
+      gmail.sync
+      gmail.delete
+      gmail.messages.list
+      gmail.messages.read
+      gmail.messages.send
+    )
   end
 end

--- a/test/lemmings_os/tools/catalog_test.exs
+++ b/test/lemmings_os/tools/catalog_test.exs
@@ -15,7 +15,8 @@ defmodule LemmingsOs.Tools.CatalogTest do
                %{id: "knowledge.read"},
                %{id: "knowledge.store"},
                %{id: "documents.markdown_to_html"},
-               %{id: "documents.print_to_pdf"}
+               %{id: "documents.print_to_pdf"},
+               %{id: "email.create_draft"}
              ] = Catalog.list_tools()
     end
   end
@@ -31,6 +32,7 @@ defmodule LemmingsOs.Tools.CatalogTest do
       assert Catalog.supported_tool?("knowledge.store")
       assert Catalog.supported_tool?("documents.markdown_to_html")
       assert Catalog.supported_tool?("documents.print_to_pdf")
+      assert Catalog.supported_tool?("email.create_draft")
       refute Catalog.supported_tool?("exec.run")
     end
   end

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -12,6 +12,7 @@ defmodule LemmingsOs.Tools.RuntimeTest do
   alias LemmingsOs.Knowledge.SourceFile
   alias LemmingsOs.LemmingInstances.LemmingInstance
   alias LemmingsOs.Repo
+  alias LemmingsOs.SecretBank
   alias LemmingsOs.Tools.Runtime
   alias LemmingsOs.Tools.WorkArea
   alias LemmingsOs.Worlds.World
@@ -104,6 +105,66 @@ defmodule LemmingsOs.Tools.RuntimeTest do
 
       assert {:error, %{code: "tool.validation.invalid_path"}} =
                Runtime.execute(world, instance, "fs.read_text_file", %{"path" => "../secret.txt"})
+    end
+  end
+
+  describe "execute/5 with email.create_draft" do
+    test "normalizes adapter success with standard runtime envelope", %{
+      world: world,
+      instance: instance
+    } do
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "client-id")
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET", "client-secret")
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_REFRESH_TOKEN", "refresh-token")
+
+      insert(:world_connection,
+        world: world,
+        type: "gmail",
+        status: "enabled",
+        config: %{
+          "provider" => "gmail",
+          "account_email" => "ops@example.com",
+          "scopes" => ["https://www.googleapis.com/auth/gmail.compose"],
+          "client_id" => "$GMAIL_CLIENT_ID",
+          "client_secret" => "$GMAIL_CLIENT_SECRET",
+          "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+        }
+      )
+
+      args = %{
+        "connection_ref" => "gmail",
+        "to" => ["customer@example.com"],
+        "subject" => "Runtime envelope draft",
+        "body" => "Hello from runtime",
+        "body_format" => "text/plain"
+      }
+
+      runtime_meta = %{
+        trusted_tool_config: %{
+          "email.create_draft" => %{
+            "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientSuccess,
+            "gmail_client_opts" => %{
+              "test_pid" => self(),
+              "access_token" => "runtime-access-token"
+            }
+          }
+        }
+      }
+
+      assert {:ok, result} =
+               Runtime.execute(world, instance, "email.create_draft", args, runtime_meta)
+
+      assert result.tool_name == "email.create_draft"
+      assert result.args == args
+      assert result.summary == "Created Gmail draft for customer@example.com with 0 attachments"
+      assert result.preview == "Subject: Runtime envelope draft"
+      assert result.result["status"] == "draft_created"
+      assert result.result["provider"] == "gmail"
+      assert result.result["connection_ref"] == "gmail"
+      assert result.result["to"] == ["customer@example.com"]
+      assert result.result["subject"] == "Runtime envelope draft"
+
+      assert_receive {:email_draft_create_called, "runtime-access-token", _raw_message}
     end
   end
 

--- a/test/lemmings_os/tools/runtime_test.exs
+++ b/test/lemmings_os/tools/runtime_test.exs
@@ -166,6 +166,74 @@ defmodule LemmingsOs.Tools.RuntimeTest do
 
       assert_receive {:email_draft_create_called, "runtime-access-token", _raw_message}
     end
+
+    test "accepts common LLM recipient shapes and body_format default", %{
+      world: world,
+      instance: instance
+    } do
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "client-id")
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET", "client-secret")
+      assert {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_REFRESH_TOKEN", "refresh-token")
+
+      insert(:world_connection,
+        world: world,
+        type: "gmail",
+        status: "enabled",
+        config: %{
+          "provider" => "gmail",
+          "account_email" => "ops@example.com",
+          "scopes" => ["https://www.googleapis.com/auth/gmail.compose"],
+          "client_id" => "$GMAIL_CLIENT_ID",
+          "client_secret" => "$GMAIL_CLIENT_SECRET",
+          "refresh_token" => "$GMAIL_REFRESH_TOKEN"
+        }
+      )
+
+      args = %{
+        "connection_ref" => "gmail",
+        "to" => "jordan.lee@example.com",
+        "cc" => "",
+        "bcc" => nil,
+        "subject" => "Follow-up on SSO login issue",
+        "body" => "Hello Jordan"
+      }
+
+      runtime_meta = %{
+        trusted_tool_config: %{
+          "email.create_draft" => %{
+            "gmail_client" => LemmingsOs.TestSupport.EmailDraftGmailClientSuccess,
+            "gmail_client_opts" => %{"test_pid" => self()}
+          }
+        }
+      }
+
+      assert {:ok, result} =
+               Runtime.execute(world, instance, "email.create_draft", args, runtime_meta)
+
+      assert result.result["to"] == ["jordan.lee@example.com"]
+      assert result.result["cc"] == []
+      assert result.result["bcc"] == []
+      assert result.summary == "Created Gmail draft for jordan.lee@example.com with 0 attachments"
+
+      assert_receive {:email_draft_create_called, "access-token", raw_message}
+      assert {:ok, mime} = Base.url_decode64(raw_message, padding: false)
+      assert mime =~ "Content-Type: text/plain; charset=\"UTF-8\""
+    end
+
+    test "Gmail send, read, list, sync, and delete tool calls fail safely", %{
+      world: world,
+      instance: instance
+    } do
+      for unsupported <- unsupported_gmail_tools() do
+        assert {:error,
+                %{
+                  tool_name: ^unsupported,
+                  code: "tool.unsupported",
+                  message: "Tool is not supported",
+                  details: %{tool_name: ^unsupported}
+                }} = Runtime.execute(world, instance, unsupported, %{})
+      end
+    end
   end
 
   describe "execute/4 with knowledge tools" do
@@ -1128,6 +1196,25 @@ defmodule LemmingsOs.Tools.RuntimeTest do
 
   defp restore_system_env(key, nil), do: System.delete_env(key)
   defp restore_system_env(key, value), do: System.put_env(key, value)
+
+  defp unsupported_gmail_tools do
+    ~w(
+      email.send
+      email.send_approved
+      email.read
+      email.list
+      email.sync
+      email.delete
+      gmail.send
+      gmail.read
+      gmail.list
+      gmail.sync
+      gmail.delete
+      gmail.messages.list
+      gmail.messages.read
+      gmail.messages.send
+    )
+  end
 
   defp create_ready_source_file_chunk!(
          world,

--- a/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
+++ b/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
@@ -109,6 +109,28 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     refute String.contains?(query_params["scope"], " ")
   end
 
+  test "start stores only exact supported return_to paths", %{conn: conn} do
+    world = insert(:world)
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
+
+    for unsafe_return_to <- [
+          "/worldevil?tab=connections",
+          "/cities-malformed?city=123",
+          "/departments_anything",
+          "https://example.test/world"
+        ] do
+      response =
+        get(conn, ~p"/connections/gmail/oauth/start", %{
+          "world_id" => world.id,
+          "client_id" => "$GMAIL_CLIENT_ID",
+          "client_secret" => "$GMAIL_CLIENT_SECRET",
+          "return_to" => unsafe_return_to
+        })
+
+      assert get_session(response, @session_key)["return_to"] == "/world?tab=connections"
+    end
+  end
+
   test "callback success redirects to city connections tab for city-scoped onboarding", %{
     conn: conn
   } do
@@ -252,6 +274,12 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
 
     original = Connections.get_connection_by_type(world, "gmail")
     assert original
+    original_refresh_ref = original.config["refresh_token"]
+
+    assert {:ok, original_refresh} =
+             SecretBank.resolve_runtime_secret(world, original_refresh_ref)
+
+    assert original_refresh.value == "oauth_secret_value_1"
 
     restarted = oauth_start(conn, world)
     state_two = get_session(restarted, @session_key)
@@ -268,11 +296,15 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     updated = Connections.get_connection_by_type(world, "gmail")
     assert updated.id == original.id
     assert updated.config["account_email"] == "owner@example.test"
+    assert updated.config["refresh_token"] != original_refresh_ref
 
     assert {:ok, resolved_refresh} =
              SecretBank.resolve_runtime_secret(world, updated.config["refresh_token"])
 
     assert resolved_refresh.value == "oauth_secret_value_2"
+
+    assert {:error, :missing_secret} =
+             SecretBank.resolve_runtime_secret(world, original_refresh_ref)
 
     [profile_failure_event] =
       Events.list_recent_events(world,
@@ -281,6 +313,53 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       )
 
     assert profile_failure_event.payload["reason"] == "profile_lookup_failed"
+  end
+
+  test "failed callback leaves existing gmail refresh token unchanged", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    _callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    original = Connections.get_connection_by_type(world, "gmail")
+    original_refresh_ref = original.config["refresh_token"]
+
+    assert {:ok, original_refresh} =
+             SecretBank.resolve_runtime_secret(world, original_refresh_ref)
+
+    failed_start = oauth_start(conn, world)
+    failed_state = get_session(failed_start, @session_key)
+
+    failed_callback_conn =
+      failed_start
+      |> recycle()
+      |> init_test_session(%{@session_key => failed_state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "invalid_code",
+        "state" => failed_state["state"]
+      })
+
+    assert redirected_to(failed_callback_conn) == "/world?tab=connections"
+    assert Phoenix.Flash.get(failed_callback_conn.assigns.flash, :error) =~ "Gmail OAuth failed"
+
+    unchanged = Connections.get_connection_by_type(world, "gmail")
+    assert unchanged.id == original.id
+    assert unchanged.config["refresh_token"] == original_refresh_ref
+
+    assert {:ok, unchanged_refresh} =
+             SecretBank.resolve_runtime_secret(world, original_refresh_ref)
+
+    assert unchanged_refresh.value == original_refresh.value
   end
 
   test "callback preserves custom client credential refs from existing scoped connection", %{

--- a/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
+++ b/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
@@ -55,6 +55,21 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     :ok
   end
 
+  test "router exposes only Gmail OAuth start and callback routes" do
+    gmail_routes =
+      LemmingsOsWeb.Router.__routes__()
+      |> Enum.filter(fn route ->
+        String.contains?(route.path, "/gmail") or String.contains?(inspect(route.plug), "Gmail")
+      end)
+      |> Enum.map(&{&1.verb, &1.path, &1.plug_opts})
+      |> Enum.sort()
+
+    assert gmail_routes == [
+             {:get, "/connections/gmail/oauth/callback", :callback},
+             {:get, "/connections/gmail/oauth/start", :start}
+           ]
+  end
+
   test "start stores session state and redirects with compose scope", %{conn: conn} do
     world = insert(:world)
     {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
@@ -79,6 +94,12 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     assert session_state["config"]["connection_id"] == "existing-connection-id"
     assert session_state["return_to"] == "/world?tab=connections"
     refute inspect(session_state) =~ "dev_only_client_id"
+
+    session_cookie = Enum.join(get_resp_header(response, "set-cookie"), "\n")
+    refute session_cookie =~ "$GMAIL_CLIENT_ID"
+    refute session_cookie =~ "$GMAIL_CLIENT_SECRET"
+    refute session_cookie =~ "existing-connection-id"
+    refute session_cookie =~ world.id
 
     %URI{query: query} = URI.parse(redirect_url)
     query_params = URI.decode_query(query || "")

--- a/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
+++ b/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
@@ -15,16 +15,16 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     def exchange_code(_client_id, _client_secret, "valid_code", _redirect_uri) do
       {:ok,
        %{
-         "refresh_token" => "dev_only_refresh_token_1",
-         "access_token" => "dev_only_access_token_1"
+         "refresh_token" => "oauth_secret_value_1",
+         "access_token" => "profile_lookup_value_1"
        }}
     end
 
     def exchange_code(_client_id, _client_secret, "valid_code_2", _redirect_uri) do
       {:ok,
        %{
-         "refresh_token" => "dev_only_refresh_token_2",
-         "access_token" => "dev_only_access_token_profile_failure"
+         "refresh_token" => "oauth_secret_value_2",
+         "access_token" => "profile_lookup_value_failure"
        }}
     end
 
@@ -32,9 +32,9 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       {:error, :oauth_exchange_failed}
     end
 
-    def fetch_profile("dev_only_access_token_1"), do: {:ok, "owner@example.test"}
+    def fetch_profile("profile_lookup_value_1"), do: {:ok, "owner@example.test"}
 
-    def fetch_profile("dev_only_access_token_profile_failure"),
+    def fetch_profile("profile_lookup_value_failure"),
       do: {:error, :profile_lookup_failed}
 
     def fetch_profile(_access_token), do: {:error, :profile_lookup_failed}
@@ -62,8 +62,10 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     response =
       get(conn, ~p"/connections/gmail/oauth/start", %{
         "world_id" => world.id,
+        "connection_id" => "existing-connection-id",
         "client_id" => "$GMAIL_CLIENT_ID",
-        "client_secret" => "$GMAIL_CLIENT_SECRET"
+        "client_secret" => "$GMAIL_CLIENT_SECRET",
+        "return_to" => "/world?tab=connections"
       })
 
     redirect_url = redirected_to(response, 302)
@@ -74,6 +76,8 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     assert is_integer(session_state["expires_at_unix"])
     assert session_state["config"]["client_id"] == "$GMAIL_CLIENT_ID"
     assert session_state["config"]["client_secret"] == "$GMAIL_CLIENT_SECRET"
+    assert session_state["config"]["connection_id"] == "existing-connection-id"
+    assert session_state["return_to"] == "/world?tab=connections"
     refute inspect(session_state) =~ "dev_only_client_id"
 
     %URI{query: query} = URI.parse(redirect_url)
@@ -82,6 +86,82 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     assert query_params["scope"] == @compose_scope
     assert query_params["scope"] == String.trim(query_params["scope"])
     refute String.contains?(query_params["scope"], " ")
+  end
+
+  test "callback success redirects to city connections tab for city-scoped onboarding", %{
+    conn: conn
+  } do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    seed_google_client_secrets(world)
+
+    started =
+      get(conn, ~p"/connections/gmail/oauth/start", %{
+        "world_id" => world.id,
+        "city_id" => city.id,
+        "client_id" => "$GMAIL_CLIENT_ID",
+        "client_secret" => "$GMAIL_CLIENT_SECRET"
+      })
+
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    redirect_path = redirected_to(callback_conn)
+    assert String.starts_with?(redirect_path, "/cities?")
+
+    assert URI.parse(redirect_path).query |> URI.decode_query() == %{
+             "city" => city.id,
+             "tab" => "connections"
+           }
+
+    assert Connections.get_connection_by_type(city, "gmail")
+  end
+
+  test "callback success redirects to department connections tab for department-scoped onboarding",
+       %{conn: conn} do
+    world = insert(:world)
+    city = insert(:city, world: world)
+    department = insert(:department, world: world, city: city)
+    seed_google_client_secrets(world)
+
+    started =
+      get(conn, ~p"/connections/gmail/oauth/start", %{
+        "world_id" => world.id,
+        "city_id" => city.id,
+        "department_id" => department.id,
+        "client_id" => "$GMAIL_CLIENT_ID",
+        "client_secret" => "$GMAIL_CLIENT_SECRET"
+      })
+
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    redirect_path = redirected_to(callback_conn)
+    assert String.starts_with?(redirect_path, "/departments?")
+
+    assert URI.parse(redirect_path).query |> URI.decode_query() == %{
+             "city" => city.id,
+             "dept" => department.id,
+             "tab" => "connections"
+           }
+
+    assert Connections.get_connection_by_type(department, "gmail")
   end
 
   test "callback success stores refresh token ref only and creates gmail connection", %{
@@ -102,7 +182,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
         "state" => state["state"]
       })
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
 
     connection = Connections.get_connection_by_type(world, "gmail")
     assert connection.type == "gmail"
@@ -116,9 +196,9 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     assert {:ok, resolved_refresh} =
              SecretBank.resolve_runtime_secret(world, connection.config["refresh_token"])
 
-    assert resolved_refresh.value == "dev_only_refresh_token_1"
-    refute inspect(connection.config) =~ "dev_only_refresh_token_1"
-    refute inspect(connection.config) =~ "dev_only_access_token_not_for_storage"
+    assert resolved_refresh.value == "oauth_secret_value_1"
+    refute inspect(connection.config) =~ "oauth_secret_value_1"
+    refute inspect(connection.config) =~ "profile_lookup_value_not_for_storage"
 
     [event] =
       Events.list_recent_events(world,
@@ -127,8 +207,8 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       )
 
     assert event.payload["connection_id"] == connection.id
-    refute inspect(event.payload) =~ "dev_only_refresh_token_1"
-    refute inspect(event.payload) =~ "dev_only_access_token_1"
+    refute inspect(event.payload) =~ "oauth_secret_value_1"
+    refute inspect(event.payload) =~ "profile_lookup_value_1"
     refute inspect(event.payload) =~ "valid_code"
     refute inspect(event.payload) =~ "dev_only_client_secret"
   end
@@ -171,7 +251,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
     assert {:ok, resolved_refresh} =
              SecretBank.resolve_runtime_secret(world, updated.config["refresh_token"])
 
-    assert resolved_refresh.value == "dev_only_refresh_token_2"
+    assert resolved_refresh.value == "oauth_secret_value_2"
 
     [profile_failure_event] =
       Events.list_recent_events(world,
@@ -180,6 +260,54 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       )
 
     assert profile_failure_event.payload["reason"] == "profile_lookup_failed"
+  end
+
+  test "callback preserves custom client credential refs from existing scoped connection", %{
+    conn: conn
+  } do
+    world = insert(:world)
+    seed_custom_google_client_secrets(world)
+
+    {:ok, existing} =
+      Connections.create_connection(world, %{
+        type: "gmail",
+        status: "enabled",
+        config: %{
+          "provider" => "gmail",
+          "scopes" => [@compose_scope],
+          "client_id" => "$GMAIL_CLIENT_ID2",
+          "client_secret" => "$GMAIL_CLIENT_SECRET2",
+          "account_email" => ""
+        }
+      })
+
+    started =
+      get(conn, ~p"/connections/gmail/oauth/start", %{
+        "world_id" => world.id,
+        "connection_id" => existing.id,
+        "client_id" => "$GMAIL_CLIENT_ID2",
+        "client_secret" => "$GMAIL_CLIENT_SECRET2"
+      })
+
+    state = get_session(started, @session_key)
+
+    _callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    updated = Connections.get_connection_by_type(world, "gmail")
+    assert updated.id == existing.id
+    assert updated.config["client_id"] == "$GMAIL_CLIENT_ID2"
+    assert updated.config["client_secret"] == "$GMAIL_CLIENT_SECRET2"
+    assert updated.config["provider"] == "gmail"
+    assert updated.config["scopes"] == [@compose_scope]
+    assert updated.config["account_email"] == "owner@example.test"
+    assert String.starts_with?(updated.config["refresh_token"], "$GMAIL_REFRESH_TOKEN_WORLD_")
   end
 
   test "profile lookup failure does not fail oauth and leaves account email blank when no prior value",
@@ -199,7 +327,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
         "state" => state["state"]
       })
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
 
     connection = Connections.get_connection_by_type(world, "gmail")
     assert connection.config["account_email"] == ""
@@ -211,7 +339,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       )
 
     assert profile_failure_event.payload["reason"] == "profile_lookup_failed"
-    refute inspect(profile_failure_event.payload) =~ "dev_only_access_token_profile_failure"
+    refute inspect(profile_failure_event.payload) =~ "profile_lookup_value_failure"
   end
 
   test "callback rejects missing session state", %{conn: conn} do
@@ -248,7 +376,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
         "state" => "tampered"
       })
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
     assert Phoenix.Flash.get(callback_conn.assigns.flash, :error) == "Gmail OAuth failed."
 
     [event] =
@@ -274,7 +402,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       |> init_test_session(%{@session_key => state})
       |> get(~p"/connections/gmail/oauth/callback", %{"code" => "valid_code"})
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
 
     [event] =
       Events.list_recent_events(world,
@@ -302,7 +430,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
         "state" => state["state"]
       })
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
 
     [event] =
       Events.list_recent_events(world,
@@ -331,7 +459,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
         "world_id" => other_world.id
       })
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
     assert Connections.get_connection_by_type(world, "gmail")
     assert is_nil(Connections.get_connection_by_type(other_world, "gmail"))
   end
@@ -350,7 +478,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
           |> recycle()
           |> init_test_session(%{@session_key => state})
           |> get(~p"/connections/gmail/oauth/callback", %{
-            "code" => "provider_failure_code_dev_only_refresh_token_1",
+            "code" => "provider_failure_code_oauth_secret_value_1",
             "state" => state["state"]
           })
 
@@ -359,7 +487,7 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
 
     assert_receive {:callback_conn, callback_conn}
 
-    assert redirected_to(callback_conn) == "/settings"
+    assert redirected_to(callback_conn) == "/world?tab=connections"
     assert Phoenix.Flash.get(callback_conn.assigns.flash, :error) == "Gmail OAuth failed."
 
     [event] =
@@ -369,11 +497,11 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
       )
 
     assert event.payload["reason"] == "oauth_exchange_failed"
-    refute inspect(event.payload) =~ "dev_only_refresh_token_1"
-    refute inspect(event.payload) =~ "provider_failure_code_dev_only_refresh_token_1"
+    refute inspect(event.payload) =~ "oauth_secret_value_1"
+    refute inspect(event.payload) =~ "provider_failure_code_oauth_secret_value_1"
     refute inspect(event.payload) =~ "dev_only_client_secret"
-    refute log =~ "dev_only_refresh_token_1"
-    refute log =~ "provider_failure_code_dev_only_refresh_token_1"
+    refute log =~ "oauth_secret_value_1"
+    refute log =~ "provider_failure_code_oauth_secret_value_1"
     refute log =~ "dev_only_client_secret"
     refute log =~ "valid_code"
   end
@@ -389,5 +517,10 @@ defmodule LemmingsOsWeb.GmailOAuthControllerTest do
   defp seed_google_client_secrets(world) do
     {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
     {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET", "dev_only_client_secret")
+  end
+
+  defp seed_custom_google_client_secrets(world) do
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID2", "dev_only_client_id_2")
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET2", "dev_only_client_secret_2")
   end
 end

--- a/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
+++ b/test/lemmings_os_web/controllers/gmail_oauth_controller_test.exs
@@ -1,0 +1,393 @@
+defmodule LemmingsOsWeb.GmailOAuthControllerTest do
+  use LemmingsOsWeb.ConnCase, async: false
+
+  import ExUnit.CaptureLog
+  import LemmingsOs.Factory
+
+  alias LemmingsOs.Connections
+  alias LemmingsOs.Events
+  alias LemmingsOs.SecretBank
+
+  @compose_scope "https://www.googleapis.com/auth/gmail.compose"
+  @session_key "gmail_oauth_state"
+
+  defmodule FakeOAuthClient do
+    def exchange_code(_client_id, _client_secret, "valid_code", _redirect_uri) do
+      {:ok,
+       %{
+         "refresh_token" => "dev_only_refresh_token_1",
+         "access_token" => "dev_only_access_token_1"
+       }}
+    end
+
+    def exchange_code(_client_id, _client_secret, "valid_code_2", _redirect_uri) do
+      {:ok,
+       %{
+         "refresh_token" => "dev_only_refresh_token_2",
+         "access_token" => "dev_only_access_token_profile_failure"
+       }}
+    end
+
+    def exchange_code(_client_id, _client_secret, _code, _redirect_uri) do
+      {:error, :oauth_exchange_failed}
+    end
+
+    def fetch_profile("dev_only_access_token_1"), do: {:ok, "owner@example.test"}
+
+    def fetch_profile("dev_only_access_token_profile_failure"),
+      do: {:error, :profile_lookup_failed}
+
+    def fetch_profile(_access_token), do: {:error, :profile_lookup_failed}
+  end
+
+  setup do
+    previous = Application.get_env(:lemmings_os, :gmail_oauth_client)
+    Application.put_env(:lemmings_os, :gmail_oauth_client, FakeOAuthClient)
+
+    on_exit(fn ->
+      if previous do
+        Application.put_env(:lemmings_os, :gmail_oauth_client, previous)
+      else
+        Application.delete_env(:lemmings_os, :gmail_oauth_client)
+      end
+    end)
+
+    :ok
+  end
+
+  test "start stores session state and redirects with compose scope", %{conn: conn} do
+    world = insert(:world)
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
+
+    response =
+      get(conn, ~p"/connections/gmail/oauth/start", %{
+        "world_id" => world.id,
+        "client_id" => "$GMAIL_CLIENT_ID",
+        "client_secret" => "$GMAIL_CLIENT_SECRET"
+      })
+
+    redirect_url = redirected_to(response, 302)
+    assert redirect_url =~ "https://accounts.google.com/o/oauth2/v2/auth?"
+    session_state = get_session(response, @session_key)
+    assert session_state
+    assert is_binary(session_state["state"])
+    assert is_integer(session_state["expires_at_unix"])
+    assert session_state["config"]["client_id"] == "$GMAIL_CLIENT_ID"
+    assert session_state["config"]["client_secret"] == "$GMAIL_CLIENT_SECRET"
+    refute inspect(session_state) =~ "dev_only_client_id"
+
+    %URI{query: query} = URI.parse(redirect_url)
+    query_params = URI.decode_query(query || "")
+
+    assert query_params["scope"] == @compose_scope
+    assert query_params["scope"] == String.trim(query_params["scope"])
+    refute String.contains?(query_params["scope"], " ")
+  end
+
+  test "callback success stores refresh token ref only and creates gmail connection", %{
+    conn: conn
+  } do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    assert redirected_to(callback_conn) == "/settings"
+
+    connection = Connections.get_connection_by_type(world, "gmail")
+    assert connection.type == "gmail"
+    assert connection.config["provider"] == "gmail"
+    assert connection.config["scopes"] == [@compose_scope]
+    assert connection.config["client_id"] == "$GMAIL_CLIENT_ID"
+    assert connection.config["client_secret"] == "$GMAIL_CLIENT_SECRET"
+    assert connection.config["account_email"] == "owner@example.test"
+    assert String.starts_with?(connection.config["refresh_token"], "$GMAIL_REFRESH_TOKEN_WORLD_")
+
+    assert {:ok, resolved_refresh} =
+             SecretBank.resolve_runtime_secret(world, connection.config["refresh_token"])
+
+    assert resolved_refresh.value == "dev_only_refresh_token_1"
+    refute inspect(connection.config) =~ "dev_only_refresh_token_1"
+    refute inspect(connection.config) =~ "dev_only_access_token_not_for_storage"
+
+    [event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_succeeded"],
+        limit: 1
+      )
+
+    assert event.payload["connection_id"] == connection.id
+    refute inspect(event.payload) =~ "dev_only_refresh_token_1"
+    refute inspect(event.payload) =~ "dev_only_access_token_1"
+    refute inspect(event.payload) =~ "valid_code"
+    refute inspect(event.payload) =~ "dev_only_client_secret"
+  end
+
+  test "callback updates existing gmail connection at selected scope", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    _first_callback =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    original = Connections.get_connection_by_type(world, "gmail")
+    assert original
+
+    restarted = oauth_start(conn, world)
+    state_two = get_session(restarted, @session_key)
+
+    _second_callback =
+      restarted
+      |> recycle()
+      |> init_test_session(%{@session_key => state_two})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code_2",
+        "state" => state_two["state"]
+      })
+
+    updated = Connections.get_connection_by_type(world, "gmail")
+    assert updated.id == original.id
+    assert updated.config["account_email"] == "owner@example.test"
+
+    assert {:ok, resolved_refresh} =
+             SecretBank.resolve_runtime_secret(world, updated.config["refresh_token"])
+
+    assert resolved_refresh.value == "dev_only_refresh_token_2"
+
+    [profile_failure_event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_profile_lookup_failed"],
+        limit: 1
+      )
+
+    assert profile_failure_event.payload["reason"] == "profile_lookup_failed"
+  end
+
+  test "profile lookup failure does not fail oauth and leaves account email blank when no prior value",
+       %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code_2",
+        "state" => state["state"]
+      })
+
+    assert redirected_to(callback_conn) == "/settings"
+
+    connection = Connections.get_connection_by_type(world, "gmail")
+    assert connection.config["account_email"] == ""
+
+    [profile_failure_event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_profile_lookup_failed"],
+        limit: 1
+      )
+
+    assert profile_failure_event.payload["reason"] == "profile_lookup_failed"
+    refute inspect(profile_failure_event.payload) =~ "dev_only_access_token_profile_failure"
+  end
+
+  test "callback rejects missing session state", %{conn: conn} do
+    world = insert(:world)
+
+    callback_conn =
+      conn
+      |> init_test_session(%{})
+      |> get(~p"/connections/gmail/oauth/callback", %{"code" => "valid_code", "state" => "nonce"})
+
+    assert redirected_to(callback_conn) == "/settings"
+    assert Phoenix.Flash.get(callback_conn.assigns.flash, :error) == "Gmail OAuth failed."
+
+    assert [] ==
+             Events.list_recent_events(world,
+               event_types: ["connection.gmail.oauth_failed"],
+               limit: 1
+             )
+  end
+
+  test "callback rejects invalid state", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => "tampered"
+      })
+
+    assert redirected_to(callback_conn) == "/settings"
+    assert Phoenix.Flash.get(callback_conn.assigns.flash, :error) == "Gmail OAuth failed."
+
+    [event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_failed"],
+        limit: 1
+      )
+
+    assert event.payload["reason"] == "invalid_state"
+    refute inspect(event.payload) =~ "tampered"
+  end
+
+  test "callback rejects missing state param", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{"code" => "valid_code"})
+
+    assert redirected_to(callback_conn) == "/settings"
+
+    [event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_failed"],
+        limit: 1
+      )
+
+    assert event.payload["reason"] == "invalid_state"
+  end
+
+  test "callback rejects expired state", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+    expired_state = Map.put(state, "expires_at_unix", DateTime.to_unix(DateTime.utc_now()) - 1)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => expired_state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"]
+      })
+
+    assert redirected_to(callback_conn) == "/settings"
+
+    [event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_failed"],
+        limit: 1
+      )
+
+    assert event.payload["reason"] == "invalid_state"
+  end
+
+  test "callback ignores tampered callback scope params and keeps session scope", %{conn: conn} do
+    world = insert(:world)
+    other_world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    callback_conn =
+      started
+      |> recycle()
+      |> init_test_session(%{@session_key => state})
+      |> get(~p"/connections/gmail/oauth/callback", %{
+        "code" => "valid_code",
+        "state" => state["state"],
+        "world_id" => other_world.id
+      })
+
+    assert redirected_to(callback_conn) == "/settings"
+    assert Connections.get_connection_by_type(world, "gmail")
+    assert is_nil(Connections.get_connection_by_type(other_world, "gmail"))
+  end
+
+  test "callback failure does not leak token-like values", %{conn: conn} do
+    world = insert(:world)
+    seed_google_client_secrets(world)
+
+    started = oauth_start(conn, world)
+    state = get_session(started, @session_key)
+
+    log =
+      capture_log(fn ->
+        callback_conn =
+          started
+          |> recycle()
+          |> init_test_session(%{@session_key => state})
+          |> get(~p"/connections/gmail/oauth/callback", %{
+            "code" => "provider_failure_code_dev_only_refresh_token_1",
+            "state" => state["state"]
+          })
+
+        send(self(), {:callback_conn, callback_conn})
+      end)
+
+    assert_receive {:callback_conn, callback_conn}
+
+    assert redirected_to(callback_conn) == "/settings"
+    assert Phoenix.Flash.get(callback_conn.assigns.flash, :error) == "Gmail OAuth failed."
+
+    [event] =
+      Events.list_recent_events(world,
+        event_types: ["connection.gmail.oauth_failed"],
+        limit: 1
+      )
+
+    assert event.payload["reason"] == "oauth_exchange_failed"
+    refute inspect(event.payload) =~ "dev_only_refresh_token_1"
+    refute inspect(event.payload) =~ "provider_failure_code_dev_only_refresh_token_1"
+    refute inspect(event.payload) =~ "dev_only_client_secret"
+    refute log =~ "dev_only_refresh_token_1"
+    refute log =~ "provider_failure_code_dev_only_refresh_token_1"
+    refute log =~ "dev_only_client_secret"
+    refute log =~ "valid_code"
+  end
+
+  defp oauth_start(conn, world) do
+    get(conn, ~p"/connections/gmail/oauth/start", %{
+      "world_id" => world.id,
+      "client_id" => "$GMAIL_CLIENT_ID",
+      "client_secret" => "$GMAIL_CLIENT_SECRET"
+    })
+  end
+
+  defp seed_google_client_secrets(world) do
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
+    {:ok, _} = SecretBank.upsert_secret(world, "GMAIL_CLIENT_SECRET", "dev_only_client_secret")
+  end
+end

--- a/test/lemmings_os_web/live/cities_live_test.exs
+++ b/test/lemmings_os_web/live/cities_live_test.exs
@@ -326,6 +326,37 @@ defmodule LemmingsOsWeb.CitiesLiveTest do
 
       refute Connections.get_connection(city, created.id)
     end
+
+    test "city detail rejects Gmail upsert when connection id belongs to another type", %{
+      conn: conn
+    } do
+      world = insert(:world)
+      city = insert(:city, world: world, name: "Ops City", slug: "ops-city", status: "active")
+      mock_connection = insert(:city_connection, world: world, city: city, type: "mock")
+
+      {:ok, view, _html} = live(conn, ~p"/cities?city=#{city.id}&tab=connections")
+
+      view |> element("#city-connections-open-create") |> render_click()
+
+      view
+      |> element("#city-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+      view
+      |> element("#city-connections-create-form")
+      |> render_submit(%{
+        "connection_create" => %{
+          "type" => "gmail",
+          "status" => "enabled",
+          "connection_id" => mock_connection.id,
+          "client_id" => "$GMAIL_CLIENT_ID",
+          "client_secret" => "$GMAIL_CLIENT_SECRET"
+        }
+      })
+
+      assert has_element?(view, "#flash-error", "Invalid connection payload")
+      refute Connections.get_connection_by_type(city, "gmail")
+    end
   end
 
   describe "artifacts tab" do

--- a/test/lemmings_os_web/live/cities_live_test.exs
+++ b/test/lemmings_os_web/live/cities_live_test.exs
@@ -274,8 +274,23 @@ defmodule LemmingsOsWeb.CitiesLiveTest do
 
       assert has_element?(view, "#city-connections-panel")
       assert has_element?(view, "#city-connections-open-create")
+      refute has_element?(view, "#city-gmail-connect-panel")
       view |> element("#city-connections-open-create") |> render_click()
       assert render(view) =~ "$MOCK_API_KEY"
+
+      view
+      |> element("#city-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+      assert has_element?(view, "#city-connections-create-gmail-panel")
+      assert has_element?(view, "#city-connections-create-gmail-client-id")
+      refute has_element?(view, "#city-connections-create-config")
+
+      view
+      |> element("#city-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "mock"}})
+
+      assert has_element?(view, "#city-connections-create-config")
 
       world_row = Connections.resolve_visible_connection(city, "mock")
       assert has_element?(view, "#city-connections-source-#{world_row.connection.id}", "World")
@@ -302,16 +317,6 @@ defmodule LemmingsOsWeb.CitiesLiveTest do
       view
       |> element("#city-connections-edit-#{created.id}")
       |> render_click()
-
-      view
-      |> element("#city-connections-edit-form-#{created.id}")
-      |> render_change(%{
-        "connection_edit" => %{
-          "connection_id" => created.id,
-          "type" => "mock",
-          "status" => "enabled"
-        }
-      })
 
       assert has_element?(view, "#city-connections-edit-form-#{created.id}")
 

--- a/test/lemmings_os_web/live/departments_live_test.exs
+++ b/test/lemmings_os_web/live/departments_live_test.exs
@@ -549,6 +549,46 @@ defmodule LemmingsOsWeb.DepartmentsLiveTest do
       refute Connections.get_connection(department, created.id)
     end
 
+    test "connections tab rejects Gmail upsert when connection id belongs to another type", %{
+      conn: conn
+    } do
+      world = insert(:world)
+      city = insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")
+      department = insert(:department, world: world, city: city, name: "Support", slug: "support")
+
+      mock_connection =
+        insert(:department_connection,
+          world: world,
+          city: city,
+          department: department,
+          type: "mock"
+        )
+
+      {:ok, view, _html} =
+        live(conn, ~p"/departments?#{%{city: city.id, dept: department.id, tab: "connections"}}")
+
+      view |> element("#department-connections-open-create") |> render_click()
+
+      view
+      |> element("#department-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+      view
+      |> element("#department-connections-create-form")
+      |> render_submit(%{
+        "connection_create" => %{
+          "type" => "gmail",
+          "status" => "enabled",
+          "connection_id" => mock_connection.id,
+          "client_id" => "$GMAIL_CLIENT_ID",
+          "client_secret" => "$GMAIL_CLIENT_SECRET"
+        }
+      })
+
+      assert has_element?(view, "#flash-error", "Invalid connection payload")
+      refute Connections.get_connection_by_type(department, "gmail")
+    end
+
     test "S16: artifacts tab lists artifacts filtered by department", %{conn: conn} do
       world = insert(:world)
       city = insert(:city, world: world, name: "Alpha City", slug: "alpha-city", status: "active")

--- a/test/lemmings_os_web/live/departments_live_test.exs
+++ b/test/lemmings_os_web/live/departments_live_test.exs
@@ -503,8 +503,23 @@ defmodule LemmingsOsWeb.DepartmentsLiveTest do
 
       assert has_element?(view, "#department-connections-panel")
       assert has_element?(view, "#department-connections-open-create")
+      refute has_element?(view, "#department-gmail-connect-panel")
       view |> element("#department-connections-open-create") |> render_click()
       assert render(view) =~ "$MOCK_API_KEY"
+
+      view
+      |> element("#department-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+      assert has_element?(view, "#department-connections-create-gmail-panel")
+      assert has_element?(view, "#department-connections-create-gmail-client-id")
+      refute has_element?(view, "#department-connections-create-config")
+
+      view
+      |> element("#department-connections-create-type")
+      |> render_change(%{"connection_create" => %{"type" => "mock"}})
+
+      assert has_element?(view, "#department-connections-create-config")
 
       view
       |> element("#department-connections-create-form")
@@ -524,16 +539,6 @@ defmodule LemmingsOsWeb.DepartmentsLiveTest do
       view
       |> element("#department-connections-edit-#{created.id}")
       |> render_click()
-
-      view
-      |> element("#department-connections-edit-form-#{created.id}")
-      |> render_change(%{
-        "connection_edit" => %{
-          "connection_id" => created.id,
-          "type" => "mock",
-          "status" => "enabled"
-        }
-      })
 
       assert has_element?(view, "#department-connections-edit-form-#{created.id}")
 

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -753,10 +753,11 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
           "connection_ref" => "gmail",
           "draft_id" => "draft-123",
           "message_id" => "message-123",
-          "to" => ["customer@example.com"],
-          "cc" => [],
-          "bcc" => [],
-          "subject" => "Renewal quote",
+          "to_count" => 1,
+          "cc_count" => 0,
+          "bcc_count" => 0,
+          "subject_preview" => "Renewal quote",
+          "artifact_count" => 1,
           "artifact_ids" => ["artifact-1"],
           "access_token" => "redacted_provider_credential_123",
           "raw_provider_payload" => %{"sensitive" => true},
@@ -773,7 +774,7 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
     assert has_element?(
              view,
              "#tool-execution-summary-#{tool_execution.id}",
-             "Created Gmail draft for customer@example.com with 1 attachment"
+             "Created Gmail draft for 1 recipient(s) with 1 attachment"
            )
 
     assert has_element?(
@@ -790,6 +791,18 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
 
     assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"artifact_ids\"")
     assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "artifact-1")
+    assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"to_count\": 1")
+    assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"bcc_count\": 0")
+
+    assert has_element?(
+             view,
+             "#tool-execution-result-#{tool_execution.id}",
+             "\"subject_preview\""
+           )
+
+    refute has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"to\"")
+    refute has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"bcc\"")
+    refute has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"subject\":")
 
     refute has_element?(
              view,

--- a/test/lemmings_os_web/live/instance_live_test.exs
+++ b/test/lemmings_os_web/live/instance_live_test.exs
@@ -729,6 +729,93 @@ defmodule LemmingsOsWeb.InstanceLiveTest do
              text_position(html, "Follow-up question")
   end
 
+  test "S08c1: email.create_draft tool card renders safe summary, preview, and allowlisted result keys",
+       %{conn: conn} do
+    %{world: world, instance: instance} = spawn_runtime_session()
+
+    {:ok, tool_execution} =
+      LemmingTools.create_tool_execution(world, instance, %{
+        tool_name: "email.create_draft",
+        status: "ok",
+        args: %{
+          "connection_ref" => "gmail",
+          "to" => ["customer@example.com"],
+          "subject" => "Renewal quote",
+          "body" => "Prepared body",
+          "body_format" => "text/plain",
+          "artifact_ids" => ["artifact-1"]
+        },
+        summary: "redacted_provider_credential_123 should never render",
+        preview: "redacted-local-path",
+        result: %{
+          "status" => "draft_created",
+          "provider" => "gmail",
+          "connection_ref" => "gmail",
+          "draft_id" => "draft-123",
+          "message_id" => "message-123",
+          "to" => ["customer@example.com"],
+          "cc" => [],
+          "bcc" => [],
+          "subject" => "Renewal quote",
+          "artifact_ids" => ["artifact-1"],
+          "access_token" => "redacted_provider_credential_123",
+          "raw_provider_payload" => %{"sensitive" => true},
+          "storage_ref" => "redacted-storage-ref",
+          "local_path" => "redacted-local-path"
+        }
+      })
+
+    {:ok, view, _html} =
+      live(conn, ~p"/lemmings/instances/#{instance.id}?#{%{world: world.id}}")
+
+    assert has_element?(view, "#card-tool-execution-#{tool_execution.id}")
+
+    assert has_element?(
+             view,
+             "#tool-execution-summary-#{tool_execution.id}",
+             "Created Gmail draft for customer@example.com with 1 attachment"
+           )
+
+    assert has_element?(
+             view,
+             "#tool-execution-preview-#{tool_execution.id}",
+             "Subject: Renewal quote"
+           )
+
+    assert has_element?(
+             view,
+             "#tool-execution-result-#{tool_execution.id}",
+             "\"draft_id\": \"draft-123\""
+           )
+
+    assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "\"artifact_ids\"")
+    assert has_element?(view, "#tool-execution-result-#{tool_execution.id}", "artifact-1")
+
+    refute has_element?(
+             view,
+             "#card-tool-execution-#{tool_execution.id}",
+             "redacted_provider_credential_123"
+           )
+
+    refute has_element?(
+             view,
+             "#tool-execution-result-#{tool_execution.id}",
+             "raw_provider_payload"
+           )
+
+    refute has_element?(
+             view,
+             "#tool-execution-result-#{tool_execution.id}",
+             "redacted-storage-ref"
+           )
+
+    refute has_element?(
+             view,
+             "#tool-execution-result-#{tool_execution.id}",
+             "redacted-local-path"
+           )
+  end
+
   test "S08d: tool execution artifact link opens workspace file content", %{conn: conn} do
     %{world: world, instance: instance} = spawn_runtime_session()
 

--- a/test/lemmings_os_web/live/world_live_test.exs
+++ b/test/lemmings_os_web/live/world_live_test.exs
@@ -464,6 +464,47 @@ defmodule LemmingsOsWeb.WorldLiveTest do
     assert Connections.list_connections(world, type: "gmail") |> length() == 1
   end
 
+  test "connections tab rejects Gmail upsert when connection id belongs to another type", %{
+    conn: conn
+  } do
+    path =
+      WorldBootstrapTestHelpers.write_temp_file!(WorldBootstrapTestHelpers.valid_bootstrap_yaml())
+
+    world =
+      insert(:world,
+        slug: "local",
+        name: "Local World",
+        bootstrap_path: path,
+        bootstrap_source: "direct",
+        last_import_status: "ok"
+      )
+
+    mock_connection = insert(:world_connection, world: world, type: "mock")
+
+    {:ok, view, _html} = live(conn, ~p"/world?#{%{tab: "connections"}}")
+
+    view |> element("#world-connections-open-create") |> render_click()
+
+    view
+    |> element("#world-connections-create-type")
+    |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+    view
+    |> element("#world-connections-create-form")
+    |> render_submit(%{
+      "connection_create" => %{
+        "type" => "gmail",
+        "status" => "enabled",
+        "connection_id" => mock_connection.id,
+        "client_id" => "$GMAIL_CLIENT_ID",
+        "client_secret" => "$GMAIL_CLIENT_SECRET"
+      }
+    })
+
+    assert has_element?(view, "#flash-error", "Invalid connection payload")
+    refute Connections.get_connection_by_type(world, "gmail")
+  end
+
   test "artifacts tab lists artifacts filtered by world", %{conn: conn} do
     path =
       WorldBootstrapTestHelpers.write_temp_file!(WorldBootstrapTestHelpers.valid_bootstrap_yaml())

--- a/test/lemmings_os_web/live/world_live_test.exs
+++ b/test/lemmings_os_web/live/world_live_test.exs
@@ -298,11 +298,31 @@ defmodule LemmingsOsWeb.WorldLiveTest do
 
     assert has_element?(view, "#world-connections-panel")
     assert has_element?(view, "#world-connections-open-create")
+    refute has_element?(view, "#world-gmail-connect-panel")
 
     view |> element("#world-connections-open-create") |> render_click()
 
     assert has_element?(view, "#world-connections-create-type")
+    assert has_element?(view, "#world-connections-create-config")
     assert render(view) =~ "$MOCK_API_KEY"
+
+    view
+    |> element("#world-connections-create-type")
+    |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+    assert has_element?(view, "#world-connections-create-gmail-panel")
+    assert has_element?(view, "#world-connections-create-gmail-client-id")
+    assert has_element?(view, "#world-connections-create-gmail-client-secret")
+    assert has_element?(view, "#world-connections-create-gmail-connected-status", "Not connected")
+    assert has_element?(view, "#world-connections-create-gmail-account", "Not available")
+    assert has_element?(view, "#world-connections-create-gmail-compose-scope")
+    refute has_element?(view, "#world-connections-create-config")
+
+    view
+    |> element("#world-connections-create-type")
+    |> render_change(%{"connection_create" => %{"type" => "mock"}})
+
+    assert has_element?(view, "#world-connections-create-config")
 
     view
     |> element("#world-connections-create-form")
@@ -322,16 +342,6 @@ defmodule LemmingsOsWeb.WorldLiveTest do
     view
     |> element("#world-connections-edit-#{created.id}")
     |> render_click()
-
-    view
-    |> element("#world-connections-edit-form-#{created.id}")
-    |> render_change(%{
-      "connection_edit" => %{
-        "connection_id" => created.id,
-        "type" => "mock",
-        "status" => "enabled"
-      }
-    })
 
     assert has_element?(view, "#world-connections-edit-form-#{created.id}")
 
@@ -368,6 +378,90 @@ defmodule LemmingsOsWeb.WorldLiveTest do
     |> render_click()
 
     refute Connections.get_connection(world, created.id)
+  end
+
+  test "connections tab saves Gmail config and redirects connect through scoped OAuth", %{
+    conn: conn
+  } do
+    path =
+      WorldBootstrapTestHelpers.write_temp_file!(WorldBootstrapTestHelpers.valid_bootstrap_yaml())
+
+    world =
+      insert(:world,
+        slug: "local",
+        name: "Local World",
+        bootstrap_path: path,
+        bootstrap_source: "direct",
+        last_import_status: "ok"
+      )
+
+    assert {:ok, _metadata} =
+             LemmingsOs.SecretBank.upsert_secret(world, "GMAIL_CLIENT_ID", "dev_only_client_id")
+
+    assert {:ok, _metadata} =
+             LemmingsOs.SecretBank.upsert_secret(
+               world,
+               "GMAIL_CLIENT_SECRET",
+               "dev_only_client_secret"
+             )
+
+    {:ok, view, _html} = live(conn, ~p"/world?#{%{tab: "connections"}}")
+
+    view |> element("#world-connections-open-create") |> render_click()
+
+    view
+    |> element("#world-connections-create-type")
+    |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+    view
+    |> element("#world-connections-create-form")
+    |> render_submit(%{
+      "connection_create" => %{
+        "type" => "gmail",
+        "status" => "enabled",
+        "client_id" => "$GMAIL_CLIENT_ID2",
+        "client_secret" => "$GMAIL_CLIENT_SECRET2"
+      }
+    })
+
+    gmail_connection = Connections.get_connection_by_type(world, "gmail")
+    assert gmail_connection.config["client_id"] == "$GMAIL_CLIENT_ID2"
+    assert gmail_connection.config["client_secret"] == "$GMAIL_CLIENT_SECRET2"
+    refute Map.has_key?(gmail_connection.config, "refresh_token")
+
+    view |> element("#world-connections-open-create") |> render_click()
+
+    view
+    |> element("#world-connections-create-type")
+    |> render_change(%{"connection_create" => %{"type" => "gmail"}})
+
+    assert has_element?(
+             view,
+             "#world-connections-create-gmail-client-id[value='$GMAIL_CLIENT_ID2']"
+           )
+
+    {:error, {:redirect, %{to: redirect_path}}} =
+      view
+      |> element("#world-connections-create-form")
+      |> render_submit(%{
+        "connection_create" => %{
+          "type" => "gmail",
+          "status" => "enabled",
+          "connection_id" => gmail_connection.id,
+          "client_id" => "$GMAIL_CLIENT_ID2",
+          "client_secret" => "$GMAIL_CLIENT_SECRET2",
+          "action" => "connect_gmail"
+        }
+      })
+
+    assert redirect_path =~ "/connections/gmail/oauth/start"
+    assert redirect_path =~ "world_id=#{world.id}"
+    assert redirect_path =~ "connection_id=#{gmail_connection.id}"
+    assert redirect_path =~ "client_id=%24GMAIL_CLIENT_ID2"
+    assert redirect_path =~ "client_secret=%24GMAIL_CLIENT_SECRET2"
+    assert redirect_path =~ "return_to=%2Fworld%3Ftab%3Dconnections"
+
+    assert Connections.list_connections(world, type: "gmail") |> length() == 1
   end
 
   test "artifacts tab lists artifacts filtered by world", %{conn: conn} do

--- a/test/support/email_draft_req_fakes.ex
+++ b/test/support/email_draft_req_fakes.ex
@@ -1,0 +1,86 @@
+defmodule LemmingsOs.TestSupport.EmailDraftReqSuccess do
+  @moduledoc false
+
+  def post(url, _opts) when is_binary(url) do
+    cond do
+      String.ends_with?(url, "/token") ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{
+             "access_token" => "test-access-token",
+             "token_type" => "Bearer"
+           }
+         }}
+
+      String.ends_with?(url, "/drafts") ->
+        {:ok,
+         %Req.Response{
+           status: 200,
+           body: %{
+             "id" => "draft-123",
+             "message" => %{"id" => "message-123"}
+           }
+         }}
+
+      true ->
+        {:ok, %Req.Response{status: 404, body: %{}}}
+    end
+  end
+end
+
+defmodule LemmingsOs.TestSupport.EmailDraftReqFailure do
+  @moduledoc false
+
+  def post(_url, _opts) do
+    {:ok, %Req.Response{status: 401, body: %{"error" => "unauthorized"}}}
+  end
+end
+
+defmodule LemmingsOs.TestSupport.EmailDraftGmailClientSuccess do
+  @moduledoc false
+
+  def exchange_refresh_token(_client_id, _client_secret, _refresh_token, opts) do
+    if pid = Keyword.get(opts, :test_pid) do
+      send(pid, {:email_draft_exchange_called, Keyword.get(opts, :access_token, "access-token")})
+    end
+
+    {:ok, Keyword.get(opts, :access_token, "access-token")}
+  end
+
+  def create_draft(access_token, raw_message, opts) do
+    if pid = Keyword.get(opts, :test_pid) do
+      send(pid, {:email_draft_create_called, access_token, raw_message})
+    end
+
+    {:ok,
+     %{
+       draft_id: "draft-abc",
+       message_id: "message-abc"
+     }}
+  end
+end
+
+defmodule LemmingsOs.TestSupport.EmailDraftGmailClientAuthFailure do
+  @moduledoc false
+
+  def exchange_refresh_token(_client_id, _client_secret, _refresh_token, _opts) do
+    {:error, :auth_failed}
+  end
+
+  def create_draft(_access_token, _raw_message, _opts) do
+    {:ok, %{draft_id: "not-used"}}
+  end
+end
+
+defmodule LemmingsOs.TestSupport.EmailDraftGmailClientDraftFailure do
+  @moduledoc false
+
+  def exchange_refresh_token(_client_id, _client_secret, _refresh_token, opts) do
+    {:ok, Keyword.get(opts, :access_token, "access-token")}
+  end
+
+  def create_draft(_access_token, _raw_message, _opts) do
+    {:error, :draft_failed}
+  end
+end

--- a/test/support/gmail_oauth_req_fakes.ex
+++ b/test/support/gmail_oauth_req_fakes.ex
@@ -1,0 +1,31 @@
+defmodule LemmingsOs.TestSupport.GmailOAuthReqSuccess do
+  @moduledoc false
+
+  def post(_url, _opts) do
+    {:ok,
+     %Req.Response{
+       status: 200,
+       body: %{
+         "access_token" => "test-access-token",
+         "refresh_token" => "test-refresh-token",
+         "token_type" => "Bearer"
+       }
+     }}
+  end
+
+  def get(_url, _opts) do
+    {:ok, %Req.Response{status: 200, body: %{"emailAddress" => "owner@example.test"}}}
+  end
+end
+
+defmodule LemmingsOs.TestSupport.GmailOAuthReqFailure do
+  @moduledoc false
+
+  def post(_url, _opts) do
+    {:ok, %Req.Response{status: 400, body: %{"error" => "invalid_grant"}}}
+  end
+
+  def get(_url, _opts) do
+    {:ok, %Req.Response{status: 401, body: %{"error" => %{"message" => "unauthorized"}}}}
+  end
+end


### PR DESCRIPTION
  ## Summary

  Adds Gmail connection onboarding and a first-party `email.create_draft` runtime tool. Operators can connect a scoped Gmail account through OAuth, store
  the refresh token through Secret Bank, and let a Lemming create reviewable Gmail drafts with optional Artifact attachments. This is draft-only: it does
  not add Gmail send, read, sync, or mailbox ingestion behavior.

  ## Scope

  - [ ] Bug fix
  - [x] Feature
  - [ ] Refactor
  - [x] Docs
  - [ ] Chore

  ## Linked Issues

  Closes #
  Related #

  ## Technical Notes

  - Key implementation details:
    - Adds scoped `gmail` Connection type support, Gmail OAuth start/callback routes, OAuth state validation, and safe event recording.
    - Adds `email.create_draft` to the tool catalog/runtime/model contract.
    - Adds Gmail draft adapter/client behavior with bounded, normalized results instead of raw Gmail API payloads.
    - Adds UI integration for Gmail connection controls across World, City, and Department connection surfaces, plus safe Instance timeline draft
  rendering.
  - Data model / migration impact:
    - No database migration. Gmail uses the existing Connection model with `type = gmail` and safe provider metadata in config.
  - Config/env var changes:
    - Adds Secret Bank allowlist support for Gmail OAuth credential refs such as `$GMAIL_CLIENT_ID`, `$GMAIL_CLIENT_SECRET`, and documented aliases.
    - Google Cloud still needs Gmail API enabled, OAuth consent configured, and the callback URI registered.
  - Security/privacy considerations:
    - Refresh tokens are stored through Secret Bank; Connection config stores refs and safe metadata only.
    - OAuth state is session-bound and validated before token exchange.
    - Draft tool results/events avoid raw OAuth codes, refresh/access tokens, auth headers, raw provider responses, Artifact storage refs, and local
  filesystem paths.
    - Residual risk: current control plane is local-admin mode without per-user RBAC.

  ## Validation

  - [x] `mix format`
  - [x] `mix test`
  - [x] `mix precommit`
  - [ ] Manual validation completed

  ### Manual validation notes

  Automated validation recorded in `llms/tasks/0016_gmail_draft_creation/06_gmail_final_pr_audit.md`:

  - Targeted backend tests passed: connections, tools, artifacts, and model runtime.
  - Targeted UI/controller tests passed: World, City, Department, Instance timeline, and Gmail OAuth controller.
  - `mix precommit` passed with Credo and Dialyzer clean.

  Manual gaps remaining: browser-based Google OAuth flow, screen-reader pass through the external redirect, mobile viewport review, and production
  reverse-proxy callback URL verification.

  ## Screenshots / Recordings (if UI changes)

  
<img width="2569" height="1893" alt="image" src="https://github.com/user-attachments/assets/31d19729-8b2c-4c7f-a5c8-be3a54521c34" />
<img width="965" height="569" alt="image" src="https://github.com/user-attachments/assets/bfc270a6-c472-444e-b1ed-46aad0d48f6b" />
<img width="1992" height="1783" alt="image" src="https://github.com/user-attachments/assets/834a3f24-0ee6-43b9-a5f7-f0c3736f8f2a" />


  ## Rollout / Rollback

  - Rollout notes:
    - Configure Google Cloud OAuth client with Gmail API and the authorized callback URI.
    - Provide Gmail OAuth client credentials through the documented Secret Bank/env ref policy.
    - Connect Gmail from the scoped Connections UI before using `email.create_draft`.
  - Rollback notes:
    - Revert this PR to remove the Gmail OAuth routes, connection UI, and `email.create_draft` tool registration.
    - Existing Gmail Connection rows become unused if the tool/routes are removed; no schema rollback is required.

  ## Checklist

  - [x] Tests added/updated for changed behavior
  - [x] Docs updated (README/docs/ADR/runbook) when needed
  - [x] No secrets or sensitive data committed
  - [x] Backward compatibility considered
